### PR TITLE
feat(draug-eval): pre-committed refactor-flow eval harness (5 frozen tasks)

### DIFF
--- a/tools/draug-eval-runner/Cargo.toml
+++ b/tools/draug-eval-runner/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "draug-eval-runner"
+version = "0.1.0"
+edition = "2021"
+description = "Pre-committed eval harness for Draug's refactor flow. Loads tasks.toml, queries CodeGraph CSR, and verifies caller counts + file sets match the frozen ground truth."
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+folkering-codegraph = { path = "../folkering-codegraph" }
+toml = "0.8"
+serde = { version = "1", features = ["derive"] }
+
+[[bin]]
+name = "draug-eval"
+path = "src/main.rs"

--- a/tools/draug-eval-runner/README.md
+++ b/tools/draug-eval-runner/README.md
@@ -1,0 +1,101 @@
+# Draug Refactor-Flow Eval Runner
+
+Pre-committed evaluation harness for Draug's autonomous refactor pipeline.
+
+## Why this exists
+
+Step 3 of the post-CodeGraph plan is teaching Draug to use the call-graph
+when refactoring existing functions: query callers → fold blast-radius
+into the prompt → patch → verify callers still compile. Before we measure
+whether that integration improves Draug's outputs, we lock in the test
+set. Adding tasks **after** measurement starts is cherry-picking and
+makes the result unfalsifiable.
+
+This crate is that lock-in.
+
+## What it does today (Phase 1)
+
+Loads `tasks.toml`, builds a CodeGraph CSR over the monorepo, and verifies
+every task's frozen caller count + caller-file set still matches reality.
+
+If the CSR drifts away from the locked-in expectations, the runner fails
+and you decide:
+- The fixture is stale because the codebase legitimately changed → refresh it
+- The graph regressed → fix CodeGraph
+
+This is also a regression test for `folkering-codegraph` itself: the same
+five functions yield the same caller answer commit after commit.
+
+## What it will do tomorrow (Phase 2, lands with step 3)
+
+Each task additionally gets fed to Draug. The resulting patch is applied
+to a sandbox copy of the monorepo, `cargo check` runs on the target file
++ every caller file, and the score is reported. **Compile + caller-compat
+is the headline metric** — that's what CodeGraph integration is supposed
+to enable, so that's what gets measured.
+
+## Running
+
+```sh
+cargo run -p draug-eval-runner --release
+# or
+tools/draug-eval-runner/target/release/draug-eval
+```
+
+```
+[draug-eval] 5 task(s) loaded from tools/draug-eval-runner/tasks.toml
+[draug-eval] building CSR from . ...
+[draug-eval] CSR ready (4835 vertices, 95902 edges, 402952 bytes) in 762 ms
+
+[PASS] 01_pop_i32_slot (29 callers across 8 files)
+[PASS] 02_maybe_bounds_check (10 callers across 2 files)
+[PASS] 03_alloc_pages (4 callers across 1 files)
+[PASS] 04_compile_module (5 callers across 4 files)
+[PASS] 05_push_dec (12 callers across 1 files)
+
+[draug-eval] summary: 5 passed, 0 failed
+```
+
+Exit code: `0` on full pass, `1` on any task fail, `2` on infrastructure
+error (bad fixture, can't build CSR, etc).
+
+## The five tasks
+
+| ID | Function | Callers | Files | What it stresses |
+|---|---|---:|---:|---|
+| `01_pop_i32_slot` | JIT stack pop | 29 | 8 | Wide blast radius |
+| `02_maybe_bounds_check` | bounds-check elision | 10 | 2 | Mid blast, semantic refactor |
+| `03_alloc_pages` | kernel buddy allocator | 4 | 1 | Precision (no `new` collisions) |
+| `04_compile_module` | host JIT entry point | 5 | 4 | Cross-crate-ish (examples + lib) |
+| `05_push_dec` | TCP shell formatting | 12 | 1 | Tight cluster, single file |
+
+Each one is a defensible refactor target — not contrived. See the
+`description` field in `tasks.toml` for the actual change a refactor flow
+would propose.
+
+## Adding a task
+
+1. Pick a real fn currently in the tree. Aim for caller counts in the 4-15
+   range — too few and there's nothing to measure, too many and the task is
+   really five tasks in a trenchcoat.
+2. Build a fresh CSR and capture the ground truth:
+   ```sh
+   tools/folkering-codegraph/target/release/dump-graph.exe . /tmp/g.fcg1
+   tools/folkering-codegraph/target/release/query-callers.exe \
+       --load /tmp/g.fcg1 <fn-name>
+   ```
+3. Append a `[[task]]` block to `tasks.toml` with the captured count + file
+   set.
+4. Re-run the runner. New task should pass.
+5. Document why in the task's `description` — what's the refactor we'd want
+   Draug to attempt? This is the brief that step 3's prompt builder will
+   consume.
+
+## Don't do this
+
+- Don't add tasks after Draug has been wired to use CodeGraph. Lock-in is
+  the point.
+- Don't tweak `expected_caller_*` to make a task pass after a CodeGraph
+  change — investigate whether the change is correct first.
+- Don't pick easy tasks (4 callers all in the same file, fn is a one-liner).
+  We learn nothing.

--- a/tools/draug-eval-runner/src/main.rs
+++ b/tools/draug-eval-runner/src/main.rs
@@ -1,0 +1,218 @@
+//! Draug refactor-flow eval runner.
+//!
+//! Loads `tasks.toml`, builds a CodeGraph CSR over the monorepo, and verifies
+//! that each task's frozen caller count + file set still matches reality.
+//!
+//! Phase 1 (now): regression check on CodeGraph — if the CSR drifts away
+//! from the locked-in expectations, the runner fails and the user decides
+//! whether the fixture or the graph is wrong.
+//!
+//! Phase 2 (lands with Draug refactor flow in step 3): each task additionally
+//! gets fed to Draug, the resulting patch is applied to a sandbox copy of
+//! the monorepo, `cargo check` is run on the target file + every caller
+//! file, and the score is reported. Compile + caller-compat is the headline
+//! metric — that's what CodeGraph integration is supposed to enable.
+//!
+//! Usage:
+//!     draug-eval                   # build CSR, verify all tasks
+//!     draug-eval --tasks PATH      # use a different tasks.toml
+//!     draug-eval --root PATH       # build CSR from PATH instead of CWD
+
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Instant;
+
+#[derive(Debug, Deserialize)]
+struct TasksFile {
+    task: Vec<Task>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // `description` + `target_file` aren't checked yet but
+                    // are surfaced when step 3's refactor flow lands.
+struct Task {
+    id: String,
+    description: String,
+    target_fn: String,
+    target_file: String,
+    expected_caller_count: u32,
+    expected_caller_files: Vec<String>,
+}
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let mut tasks_path = PathBuf::from("tools/draug-eval-runner/tasks.toml");
+    let mut root_path = PathBuf::from(".");
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--tasks" => tasks_path = args.next().expect("--tasks needs a path").into(),
+            "--root"  => root_path  = args.next().expect("--root needs a path").into(),
+            "-h" | "--help" => {
+                println!("draug-eval — verify CodeGraph against frozen task fixtures");
+                println!();
+                println!("Usage: draug-eval [--tasks tasks.toml] [--root .]");
+                return ExitCode::SUCCESS;
+            }
+            other => {
+                eprintln!("unknown arg: {other}");
+                return ExitCode::from(2);
+            }
+        }
+    }
+
+    let raw = match std::fs::read_to_string(&tasks_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: read {}: {}", tasks_path.display(), e);
+            return ExitCode::from(2);
+        }
+    };
+    let tasks: TasksFile = match toml::from_str(&raw) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: parse {}: {}", tasks_path.display(), e);
+            return ExitCode::from(2);
+        }
+    };
+
+    println!("[draug-eval] {} task(s) loaded from {}", tasks.task.len(), tasks_path.display());
+    println!("[draug-eval] building CSR from {} ...", root_path.display());
+
+    let t0 = Instant::now();
+    let graph = match folkering_codegraph::build_from_dir(&root_path) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("error: build_from_dir: {e:?}");
+            return ExitCode::from(2);
+        }
+    };
+    let build_ms = t0.elapsed().as_millis();
+    println!(
+        "[draug-eval] CSR ready ({} vertices, {} edges, {} bytes) in {} ms\n",
+        graph.names.len(),
+        graph.col_indices.len(),
+        graph.csr_bytes(),
+        build_ms,
+    );
+
+    let mut passed = 0;
+    let mut failed = 0;
+
+    for task in &tasks.task {
+        match check_task(task, &graph) {
+            Ok(()) => {
+                println!("[PASS] {} ({} callers across {} files)",
+                    task.id, task.expected_caller_count,
+                    task.expected_caller_files.len());
+                passed += 1;
+            }
+            Err(reason) => {
+                println!("[FAIL] {}", task.id);
+                for line in reason.lines() {
+                    println!("       {line}");
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    println!("\n[draug-eval] summary: {passed} passed, {failed} failed");
+    if failed > 0 { ExitCode::from(1) } else { ExitCode::SUCCESS }
+}
+
+fn check_task(task: &Task, graph: &folkering_codegraph::CallGraph) -> Result<(), String> {
+    let target_idx = graph
+        .lookup(&task.target_fn)
+        .ok_or_else(|| format!("target_fn '{}' not in graph (from {})",
+            task.target_fn, task.target_file))?;
+
+    let caller_indices = graph.callers_of(target_idx);
+    let actual_count = caller_indices.len() as u32;
+
+    if actual_count != task.expected_caller_count {
+        return Err(format!(
+            "caller count drift: expected {}, got {}",
+            task.expected_caller_count, actual_count,
+        ));
+    }
+
+    let actual_files: BTreeSet<String> = caller_indices.iter()
+        .filter_map(|i| graph.names.get(*i as usize))
+        .map(|qualified| qualified_to_file(qualified))
+        .collect();
+
+    let expected_files: BTreeSet<String> = task.expected_caller_files.iter()
+        .map(|s| normalize_path(s))
+        .collect();
+
+    if actual_files != expected_files {
+        let missing: Vec<&str> = expected_files.difference(&actual_files)
+            .map(|s| s.as_str()).collect();
+        let extra: Vec<&str> = actual_files.difference(&expected_files)
+            .map(|s| s.as_str()).collect();
+        let mut msg = String::from("caller-file set drift\n");
+        if !missing.is_empty() {
+            msg.push_str(&format!("  missing (expected, not found):\n"));
+            for f in &missing { msg.push_str(&format!("    - {f}\n")); }
+        }
+        if !extra.is_empty() {
+            msg.push_str("  extra (found, not expected):\n");
+            for f in &extra { msg.push_str(&format!("    + {f}\n")); }
+        }
+        return Err(msg);
+    }
+
+    Ok(())
+}
+
+/// Pull the file path out of a qualified vertex name like
+/// `.\tools\a64-encoder\src\wasm_lower\call.rs::Lowerer::lower_call`
+/// → `tools/a64-encoder/src/wasm_lower/call.rs`.
+fn qualified_to_file(qualified: &str) -> String {
+    let path = qualified.split("::").next().unwrap_or(qualified);
+    normalize_path(&path.to_string())
+}
+
+fn normalize_path(p: &str) -> String {
+    let mut s = p.to_string();
+    s = s.replace('\\', "/");
+    if let Some(stripped) = s.strip_prefix("./") { s = stripped.to_string(); }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_leading_dot_and_swaps_separators() {
+        assert_eq!(normalize_path(r".\tools\a64-encoder\src\wasm_lower\call.rs"),
+            "tools/a64-encoder/src/wasm_lower/call.rs");
+        assert_eq!(normalize_path("tools/foo.rs"), "tools/foo.rs");
+    }
+
+    #[test]
+    fn qualified_to_file_extracts_file_part() {
+        assert_eq!(
+            qualified_to_file(r".\tools\a64-encoder\src\wasm_lower\call.rs::Lowerer::lower_call"),
+            "tools/a64-encoder/src/wasm_lower/call.rs",
+        );
+    }
+
+    /// Real fixture parses cleanly. Catches `tasks.toml` schema regressions.
+    #[test]
+    fn fixture_parses() {
+        let path = Path::new("tasks.toml");
+        if !path.exists() { return; } // skip when not run from crate dir
+        let raw = std::fs::read_to_string(path).unwrap();
+        let parsed: TasksFile = toml::from_str(&raw).unwrap();
+        assert!(!parsed.task.is_empty(), "tasks.toml must have at least one task");
+        for t in &parsed.task {
+            assert!(!t.id.is_empty());
+            assert!(!t.target_fn.is_empty());
+            assert_eq!(t.expected_caller_files.iter().filter(|s| s.is_empty()).count(), 0);
+        }
+    }
+}

--- a/tools/draug-eval-runner/tasks.toml
+++ b/tools/draug-eval-runner/tasks.toml
@@ -1,0 +1,105 @@
+# Draug refactor-flow evaluation set.
+#
+# These five tasks are pre-committed BEFORE we start measuring whether
+# CodeGraph integration improves Draug's refactor outputs. Adding tasks
+# AFTER measurement begins is cherry-picking — DO NOT.
+#
+# Frozen: 2026-04-27 against main @ 2bce9a0 (post-PR #38 kind-aware edges).
+# CSR: 4826 vertices, 92,717 edges, 392 KB.
+#
+# Each task captures:
+#   - a real fn currently in the tree that's a defensible refactor target
+#   - the expected CodeGraph caller answer at lock-in time
+# The runner verifies the CSR query still matches; if it drifts the user
+# decides whether the fixture is wrong (refresh) or the graph is wrong
+# (regression). Step 3 (refactor flow) will additionally score generated
+# patches against compile + caller-compat tests.
+
+[[task]]
+id = "01_pop_i32_slot"
+description = """
+Refactor `pop_i32_slot` to return `Result<Reg, LowerError>` instead of
+panicking on stack underflow. High-impact change: 29 call sites across
+8 files in the wasm_lower module, all of which need to handle the new
+Result. Tests CodeGraph's blast-radius signal.
+"""
+target_fn = "pop_i32_slot"
+target_file = "tools/a64-encoder/src/wasm_lower/stack.rs"
+expected_caller_count = 29
+expected_caller_files = [
+    "tools/a64-encoder/src/wasm_lower/call.rs",
+    "tools/a64-encoder/src/wasm_lower/control.rs",
+    "tools/a64-encoder/src/wasm_lower/convert.rs",
+    "tools/a64-encoder/src/wasm_lower/globals.rs",
+    "tools/a64-encoder/src/wasm_lower/memory.rs",
+    "tools/a64-encoder/src/wasm_lower/mod.rs",
+    "tools/a64-encoder/src/wasm_lower/scalar.rs",
+    "tools/a64-encoder/src/wasm_lower/simd.rs",
+]
+
+[[task]]
+id = "02_maybe_bounds_check"
+description = """
+`maybe_bounds_check` chooses between elided and emitted bounds checks
+based on symbolic analysis. Refactor: extract the elision-decision
+logic into a separate `BoundsCheckDecision` enum + helper, so the call
+sites can match on intent rather than chase a boolean. 10 call sites
+in 2 files (memory.rs, simd.rs) — moderate blast radius.
+"""
+target_fn = "maybe_bounds_check"
+target_file = "tools/a64-encoder/src/wasm_lower/bounds.rs"
+expected_caller_count = 10
+expected_caller_files = [
+    "tools/a64-encoder/src/wasm_lower/memory.rs",
+    "tools/a64-encoder/src/wasm_lower/simd.rs",
+]
+
+[[task]]
+id = "03_alloc_pages"
+description = """
+Kernel buddy allocator's `alloc_pages` accepts an `order` (log2 page
+count). Add a `Layout`-style API alongside that takes raw byte size
++ alignment and computes order internally. Small blast radius — 4
+call sites all in physical.rs — tests precision (CodeGraph should NOT
+inflate this with cross-file `new` collisions).
+"""
+target_fn = "alloc_pages"
+target_file = "kernel/src/memory/physical.rs"
+expected_caller_count = 4
+expected_caller_files = [
+    "kernel/src/memory/physical.rs",
+]
+
+[[task]]
+id = "04_compile_module"
+description = """
+`compile_module` is the host-side WASM-to-AArch64 entry point. Refactor:
+add explicit `CompileOptions` struct (currently positional args). 5 call
+sites spread across jit_cache + 3 example bins — cross-crate-ish blast
+radius. Examples are intentionally included; refactor must keep them
+working.
+"""
+target_fn = "compile_module"
+target_file = "tools/a64-encoder/src/wasm_lower/mod.rs"
+expected_caller_count = 5
+expected_caller_files = [
+    "tools/a64-encoder/examples/bench_mlp_ablation.rs",
+    "tools/a64-encoder/examples/run_real_wasm_bigmlp.rs",
+    "tools/a64-encoder/examples/run_real_wasm_multifn.rs",
+    "tools/a64-encoder/src/jit_cache.rs",
+]
+
+[[task]]
+id = "05_push_dec"
+description = """
+`push_dec` formats a u32 into a String for the kernel TCP shell. Refactor
+to use the kernel's existing `core::fmt::Write` machinery instead of
+manual digit pushing. 12 call sites all in tcp_shell.rs — tightly
+clustered, single-file refactor, but every cmd_* handler depends on it.
+"""
+target_fn = "push_dec"
+target_file = "kernel/src/net/tcp_shell.rs"
+expected_caller_count = 12
+expected_caller_files = [
+    "kernel/src/net/tcp_shell.rs",
+]


### PR DESCRIPTION
## Summary

Phase 1 of the post-CodeGraph step-3 plan: **lock in the test set BEFORE** we start measuring whether wiring Draug to use CodeGraph improves her refactor outputs. Adding tasks after measurement starts is cherry-picking — so the harness lands first.

## What this is

\`tools/draug-eval-runner/\` — a host-side binary + fixture set:
- \`tasks.toml\` — five real refactor candidates with their expected CodeGraph caller answers, frozen against main @ 2bce9a0
- \`src/main.rs\` — runner that builds a CSR and verifies every task still matches
- \`README.md\` — schema, how to add a task, what's measured now vs later

## The five tasks

| ID | Function | Callers | Files | Stresses |
|---|---|---:|---:|---|
| \`01_pop_i32_slot\` | JIT stack pop | 29 | 8 | Wide blast radius |
| \`02_maybe_bounds_check\` | bounds-check elision | 10 | 2 | Mid blast, semantic refactor |
| \`03_alloc_pages\` | kernel buddy allocator | 4 | 1 | Precision (no \`new\` collisions) |
| \`04_compile_module\` | host JIT entry | 5 | 4 | Cross-crate-ish (examples + lib) |
| \`05_push_dec\` | TCP shell formatting | 12 | 1 | Tight cluster, single file |

Spread across kernel + a64-encoder + cross-crate; caller counts 4-29 to cover multiple blast-radius profiles. Not contrived — every task has a defensible refactor brief in its \`description\` field.

## What the runner does today (Phase 1)

- Loads \`tasks.toml\`
- Builds a fresh CSR over the monorepo (~770 ms)
- Verifies every task's frozen caller count + caller-file set still matches
- Doubles as a regression test for \`folkering-codegraph\` itself

If the CSR drifts, the runner fails loud and the user decides whether the fixture or the graph is wrong.

## What it will do tomorrow (Phase 2, with step 3)

Each task additionally gets fed to Draug. Patch is applied to a sandbox copy, \`cargo check\` runs on target + every caller file, score reported. **Compile + caller-compat is the headline metric** — that's what CodeGraph integration is supposed to enable.

## Test plan

- [x] \`cargo build --release\`: clean
- [x] \`cargo test --release\`: 3/3 unit tests + fixture parses
- [x] \`target/release/draug-eval\`: 5/5 PASS

## Don't do this after merge

Don't add new tasks once step 3 starts wiring Draug + CodeGraph. The lock-in is the point. README spells this out.