### PR TITLE
feat(draug-eval): refactor flow Phase 2A — prompt builder + LLM client

### DIFF
--- a/tools/draug-eval-runner/.gitignore
+++ b/tools/draug-eval-runner/.gitignore
@@ -1,0 +1,3 @@
+# LLM responses + assembled prompts. Per-run output that varies with
+# the model, sampling, and the current state of the tree — not source.
+output/

--- a/tools/draug-eval-runner/Cargo.toml
+++ b/tools/draug-eval-runner/Cargo.toml
@@ -10,6 +10,11 @@ publish = false
 folkering-codegraph = { path = "../folkering-codegraph" }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+# syn parses target Rust files to validate fn existence + locate the
+# byte range of the fn item before we slice the source for the prompt.
+# Already a transitive dep via folkering-codegraph; declared explicitly
+# here so we don't rely on the transitive guarantee.
+syn = { version = "2", features = ["full", "visit"] }
 
 [[bin]]
 name = "draug-eval"

--- a/tools/draug-eval-runner/README.md
+++ b/tools/draug-eval-runner/README.md
@@ -26,38 +26,66 @@ and you decide:
 This is also a regression test for `folkering-codegraph` itself: the same
 five functions yield the same caller answer commit after commit.
 
-## What it will do tomorrow (Phase 2, lands with step 3)
+## Phase 2A: refactor flow infrastructure (live now)
 
-Each task additionally gets fed to Draug. The resulting patch is applied
-to a sandbox copy of the monorepo, `cargo check` runs on the target file
-+ every caller file, and the score is reported. **Compile + caller-compat
-is the headline metric** — that's what CodeGraph integration is supposed
-to enable, so that's what gets measured.
+Two new subcommands let you actually drive a refactor end-to-end:
+
+* `prompt <task-id>` — assemble the LLM-facing refactor prompt and
+  write it to `output/<id>/prompt.md`. No LLM call. Useful for
+  inspecting the prompt before paying for tokens.
+
+* `refactor <task-id>` — assemble the prompt, ship it to the host-side
+  `folkering-proxy` LLM endpoint (default `127.0.0.1:14711`,
+  `qwen2.5-coder:7b`), save the response, and pull the first `​```rust​`
+  fenced block out as a `refactor.md`.
+
+The prompt folds together three things:
+  1. The original source extracted verbatim from the tree (layout
+     preserved, comments included).
+  2. The caller list from CodeGraph — Draug's blast radius.
+  3. The refactor goal + a small constraint set (preserve signature
+     unless authorized, output a single fenced block, no diff format).
+
+## Phase 2B: applying + scoring (next PR)
+
+Each task's refactor patch will be applied to a sandbox copy of the
+monorepo, `cargo check` will run on the target + every caller file,
+and the score will be reported. **Compile + caller-compat is the
+headline metric** — that's what CodeGraph integration is supposed to
+enable.
 
 ## Running
 
 ```sh
+# Verify CSR matches frozen task fixtures (default, no LLM):
 cargo run -p draug-eval-runner --release
-# or
-tools/draug-eval-runner/target/release/draug-eval
+
+# Build a prompt only:
+cargo run -p draug-eval-runner --release -- prompt 03_alloc_pages
+
+# Full refactor against the proxy (proxy must be running):
+cargo run -p draug-eval-runner --release -- refactor 03_alloc_pages
+
+# Use a different model:
+cargo run -p draug-eval-runner --release -- \
+    --model gemma4:31b-cloud refactor 01_pop_i32_slot
 ```
 
-```
-[draug-eval] 5 task(s) loaded from tools/draug-eval-runner/tasks.toml
-[draug-eval] building CSR from . ...
-[draug-eval] CSR ready (4835 vertices, 95902 edges, 402952 bytes) in 762 ms
+`verify` output:
 
+```
+[verify] 5 task(s); CSR 4887 verts / 97566 edges / 409816 bytes
 [PASS] 01_pop_i32_slot (29 callers across 8 files)
 [PASS] 02_maybe_bounds_check (10 callers across 2 files)
 [PASS] 03_alloc_pages (4 callers across 1 files)
 [PASS] 04_compile_module (5 callers across 4 files)
 [PASS] 05_push_dec (12 callers across 1 files)
 
-[draug-eval] summary: 5 passed, 0 failed
+[verify] summary: 5 passed, 0 failed
 ```
 
 Exit code: `0` on full pass, `1` on any task fail, `2` on infrastructure
-error (bad fixture, can't build CSR, etc).
+error (bad fixture, can't build CSR, can't reach proxy).
 
 ## The five tasks
 

--- a/tools/draug-eval-runner/src/main.rs
+++ b/tools/draug-eval-runner/src/main.rs
@@ -1,28 +1,34 @@
 //! Draug refactor-flow eval runner.
 //!
-//! Loads `tasks.toml`, builds a CodeGraph CSR over the monorepo, and verifies
-//! that each task's frozen caller count + file set still matches reality.
+//! Three subcommands:
 //!
-//! Phase 1 (now): regression check on CodeGraph — if the CSR drifts away
-//! from the locked-in expectations, the runner fails and the user decides
-//! whether the fixture or the graph is wrong.
+//!   * `verify`  — load `tasks.toml`, build a fresh CSR, confirm every
+//!                 task's frozen caller count + file set still matches.
+//!                 Catches CodeGraph regressions. Default subcommand.
 //!
-//! Phase 2 (lands with Draug refactor flow in step 3): each task additionally
-//! gets fed to Draug, the resulting patch is applied to a sandbox copy of
-//! the monorepo, `cargo check` is run on the target file + every caller
-//! file, and the score is reported. Compile + caller-compat is the headline
-//! metric — that's what CodeGraph integration is supposed to enable.
+//!   * `prompt <task-id>`  — assemble the LLM-facing refactor prompt for
+//!                 a single task and write it to `output/<id>/prompt.md`.
+//!                 No LLM call. Useful for inspecting / hand-editing the
+//!                 prompt before paying for tokens.
 //!
-//! Usage:
-//!     draug-eval                   # build CSR, verify all tasks
-//!     draug-eval --tasks PATH      # use a different tasks.toml
-//!     draug-eval --root PATH       # build CSR from PATH instead of CWD
+//!   * `refactor <task-id>` — assemble the prompt, ship it to the
+//!                 host-side `folkering-proxy` LLM endpoint, save the
+//!                 response. Pulls a code block out of the response if
+//!                 there is one.
+//!
+//! Verifying the actual refactor (apply patch + cargo check + caller-
+//! compat scoring) is Phase 2B, deferred to its own PR. This crate's
+//! README documents the full plan.
+
+mod prompt;
+mod proxy;
+mod source_extract;
 
 use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Deserialize)]
 struct TasksFile {
@@ -30,8 +36,6 @@ struct TasksFile {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)] // `description` + `target_file` aren't checked yet but
-                    // are surfaced when step 3's refactor flow lands.
 struct Task {
     id: String,
     description: String,
@@ -41,65 +45,129 @@ struct Task {
     expected_caller_files: Vec<String>,
 }
 
-fn main() -> ExitCode {
-    let mut args = std::env::args().skip(1);
-    let mut tasks_path = PathBuf::from("tools/draug-eval-runner/tasks.toml");
-    let mut root_path = PathBuf::from(".");
-    while let Some(arg) = args.next() {
-        match arg.as_str() {
-            "--tasks" => tasks_path = args.next().expect("--tasks needs a path").into(),
-            "--root"  => root_path  = args.next().expect("--root needs a path").into(),
-            "-h" | "--help" => {
-                println!("draug-eval — verify CodeGraph against frozen task fixtures");
-                println!();
-                println!("Usage: draug-eval [--tasks tasks.toml] [--root .]");
-                return ExitCode::SUCCESS;
-            }
-            other => {
-                eprintln!("unknown arg: {other}");
-                return ExitCode::from(2);
-            }
+#[derive(Debug)]
+struct GlobalArgs {
+    tasks_path: PathBuf,
+    root_path: PathBuf,
+    output_dir: PathBuf,
+    proxy_host: String,
+    proxy_port: u16,
+    /// LLM model used by the `refactor` subcommand. The L1 default in
+    /// Draug is qwen2.5-coder:7b, which is local + fast — keep that
+    /// here so the eval doesn't burn cloud tokens on every run.
+    llm_model: String,
+}
+
+impl GlobalArgs {
+    fn defaults() -> Self {
+        GlobalArgs {
+            tasks_path: PathBuf::from("tools/draug-eval-runner/tasks.toml"),
+            root_path: PathBuf::from("."),
+            output_dir: PathBuf::from("tools/draug-eval-runner/output"),
+            proxy_host: proxy::DEFAULT_HOST.to_string(),
+            proxy_port: proxy::DEFAULT_PORT,
+            llm_model: "qwen2.5-coder:7b".to_string(),
         }
     }
+}
 
-    let raw = match std::fs::read_to_string(&tasks_path) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("error: read {}: {}", tasks_path.display(), e);
-            return ExitCode::from(2);
+fn main() -> ExitCode {
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
+    let mut g = GlobalArgs::defaults();
+    let mut subcommand: Option<String> = None;
+    let mut subcommand_args: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < raw_args.len() {
+        let a = &raw_args[i];
+        match a.as_str() {
+            "-h" | "--help" => return print_help(),
+            "--tasks" => { g.tasks_path = next_or_die(&raw_args, &mut i, "--tasks").into(); }
+            "--root"  => { g.root_path  = next_or_die(&raw_args, &mut i, "--root").into(); }
+            "--output" => { g.output_dir = next_or_die(&raw_args, &mut i, "--output").into(); }
+            "--proxy-host" => { g.proxy_host = next_or_die(&raw_args, &mut i, "--proxy-host"); }
+            "--proxy-port" => {
+                let s = next_or_die(&raw_args, &mut i, "--proxy-port");
+                g.proxy_port = match s.parse() {
+                    Ok(p) => p,
+                    Err(_) => { eprintln!("--proxy-port: not a u16: {s}"); return ExitCode::from(2); }
+                };
+            }
+            "--model" => { g.llm_model = next_or_die(&raw_args, &mut i, "--model"); }
+            other if subcommand.is_none() => {
+                subcommand = Some(other.to_string());
+            }
+            other => {
+                subcommand_args.push(other.to_string());
+            }
         }
-    };
-    let tasks: TasksFile = match toml::from_str(&raw) {
+        i += 1;
+    }
+
+    let cmd = subcommand.as_deref().unwrap_or("verify");
+    match cmd {
+        "verify" => cmd_verify(&g),
+        "prompt"   => cmd_prompt(&g, &subcommand_args),
+        "refactor" => cmd_refactor(&g, &subcommand_args),
+        other => {
+            eprintln!("unknown subcommand: {other}");
+            print_help();
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn next_or_die(args: &[String], i: &mut usize, flag: &str) -> String {
+    *i += 1;
+    if *i >= args.len() {
+        eprintln!("flag '{flag}' needs a value");
+        std::process::exit(2);
+    }
+    args[*i].clone()
+}
+
+fn print_help() -> ExitCode {
+    println!("draug-eval — refactor-flow evaluation harness for Draug");
+    println!();
+    println!("USAGE:");
+    println!("  draug-eval [GLOBAL FLAGS] <subcommand> [ARGS]");
+    println!();
+    println!("SUBCOMMANDS:");
+    println!("  verify                  Verify CSR against frozen task fixtures (default)");
+    println!("  prompt <task-id>        Build refactor prompt → output/<id>/prompt.md");
+    println!("  refactor <task-id>      Build prompt + LLM call → output/<id>/refactor.md");
+    println!();
+    println!("GLOBAL FLAGS:");
+    println!("  --tasks PATH            tasks.toml location");
+    println!("  --root PATH             repo root for CSR build");
+    println!("  --output DIR            where prompt/refactor results land");
+    println!("  --proxy-host HOST       folkering-proxy address (default 127.0.0.1)");
+    println!("  --proxy-port PORT       (default 14711)");
+    println!("  --model NAME            LLM model name (default qwen2.5-coder:7b)");
+    ExitCode::SUCCESS
+}
+
+// ── verify ──────────────────────────────────────────────────────────
+
+fn cmd_verify(g: &GlobalArgs) -> ExitCode {
+    let tasks = match load_tasks(&g.tasks_path) {
         Ok(t) => t,
-        Err(e) => {
-            eprintln!("error: parse {}: {}", tasks_path.display(), e);
-            return ExitCode::from(2);
-        }
+        Err(code) => return code,
     };
-
-    println!("[draug-eval] {} task(s) loaded from {}", tasks.task.len(), tasks_path.display());
-    println!("[draug-eval] building CSR from {} ...", root_path.display());
-
-    let t0 = Instant::now();
-    let graph = match folkering_codegraph::build_from_dir(&root_path) {
+    let graph = match build_graph(&g.root_path) {
         Ok(g) => g,
-        Err(e) => {
-            eprintln!("error: build_from_dir: {e:?}");
-            return ExitCode::from(2);
-        }
+        Err(code) => return code,
     };
-    let build_ms = t0.elapsed().as_millis();
     println!(
-        "[draug-eval] CSR ready ({} vertices, {} edges, {} bytes) in {} ms\n",
+        "[verify] {} task(s); CSR {} verts / {} edges / {} bytes",
+        tasks.task.len(),
         graph.names.len(),
         graph.col_indices.len(),
         graph.csr_bytes(),
-        build_ms,
     );
 
     let mut passed = 0;
     let mut failed = 0;
-
     for task in &tasks.task {
         match check_task(task, &graph) {
             Ok(()) => {
@@ -117,9 +185,234 @@ fn main() -> ExitCode {
             }
         }
     }
-
-    println!("\n[draug-eval] summary: {passed} passed, {failed} failed");
+    println!("\n[verify] summary: {passed} passed, {failed} failed");
     if failed > 0 { ExitCode::from(1) } else { ExitCode::SUCCESS }
+}
+
+// ── prompt ──────────────────────────────────────────────────────────
+
+fn cmd_prompt(g: &GlobalArgs, args: &[String]) -> ExitCode {
+    let task_id = match args.first() {
+        Some(s) => s,
+        None => {
+            eprintln!("prompt: needs <task-id>");
+            return ExitCode::from(2);
+        }
+    };
+    let tasks = match load_tasks(&g.tasks_path) {
+        Ok(t) => t,
+        Err(code) => return code,
+    };
+    let task = match tasks.task.iter().find(|t| t.id == *task_id) {
+        Some(t) => t,
+        None => {
+            eprintln!("prompt: task '{task_id}' not in {}", g.tasks_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let graph = match build_graph(&g.root_path) {
+        Ok(g) => g,
+        Err(code) => return code,
+    };
+
+    let target_file = g.root_path.join(&task.target_file);
+    let input = prompt::RefactorPromptInput {
+        task_id: &task.id,
+        goal: &task.description,
+        target_fn: &task.target_fn,
+        target_file: &target_file,
+        graph: &graph,
+    };
+    let built = match prompt::build(&input) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("prompt: build failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let task_out = g.output_dir.join(&task.id);
+    if let Err(e) = std::fs::create_dir_all(&task_out) {
+        eprintln!("prompt: mkdir {}: {e}", task_out.display());
+        return ExitCode::from(2);
+    }
+    let prompt_path = task_out.join("prompt.md");
+    if let Err(e) = std::fs::write(&prompt_path, &built.markdown) {
+        eprintln!("prompt: write {}: {e}", prompt_path.display());
+        return ExitCode::from(2);
+    }
+
+    println!("[prompt] {} bytes → {}", built.markdown.len(), prompt_path.display());
+    println!("[prompt] {} caller(s) across {} file(s)",
+        built.caller_count, built.caller_files.len());
+    ExitCode::SUCCESS
+}
+
+// ── refactor ────────────────────────────────────────────────────────
+
+fn cmd_refactor(g: &GlobalArgs, args: &[String]) -> ExitCode {
+    let task_id = match args.first() {
+        Some(s) => s,
+        None => {
+            eprintln!("refactor: needs <task-id>");
+            return ExitCode::from(2);
+        }
+    };
+    let tasks = match load_tasks(&g.tasks_path) {
+        Ok(t) => t,
+        Err(code) => return code,
+    };
+    let task = match tasks.task.iter().find(|t| t.id == *task_id) {
+        Some(t) => t,
+        None => {
+            eprintln!("refactor: task '{task_id}' not in {}", g.tasks_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let graph = match build_graph(&g.root_path) {
+        Ok(g) => g,
+        Err(code) => return code,
+    };
+
+    let target_file = g.root_path.join(&task.target_file);
+    let input = prompt::RefactorPromptInput {
+        task_id: &task.id,
+        goal: &task.description,
+        target_fn: &task.target_fn,
+        target_file: &target_file,
+        graph: &graph,
+    };
+    let built = match prompt::build(&input) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("refactor: prompt build failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let task_out = g.output_dir.join(&task.id);
+    if let Err(e) = std::fs::create_dir_all(&task_out) {
+        eprintln!("refactor: mkdir {}: {e}", task_out.display());
+        return ExitCode::from(2);
+    }
+    let prompt_path = task_out.join("prompt.md");
+    let _ = std::fs::write(&prompt_path, &built.markdown);
+
+    println!("[refactor] task={} model={} prompt_bytes={}",
+        task.id, g.llm_model, built.markdown.len());
+    println!("[refactor] calling proxy {}:{} ...", g.proxy_host, g.proxy_port);
+
+    let t0 = Instant::now();
+    // 3-min timeout matches the proxy's OLLAMA_TIMEOUT_SECS for cloud-
+    // backed models. Local 7b should answer in ≤30s once warm.
+    let resp = match proxy::llm_generate(
+        (&g.proxy_host, g.proxy_port),
+        &g.llm_model,
+        &built.markdown,
+        Duration::from_secs(180),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("refactor: proxy call failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let elapsed = t0.elapsed();
+
+    println!("[refactor] status={} body_bytes={} elapsed={:.1}s",
+        resp.status, resp.body.len(), elapsed.as_secs_f32());
+
+    if resp.status != 0 {
+        eprintln!("[refactor] proxy returned non-OK status — see body for details");
+        let response_path = task_out.join("response.txt");
+        let _ = std::fs::write(&response_path, &resp.body);
+        eprintln!("[refactor] saved raw body → {}", response_path.display());
+        return ExitCode::from(1);
+    }
+
+    // Persist raw + extracted artefacts.
+    let response_path = task_out.join("response.txt");
+    if let Err(e) = std::fs::write(&response_path, &resp.body) {
+        eprintln!("refactor: write {}: {e}", response_path.display());
+        return ExitCode::from(2);
+    }
+
+    let body = match resp.body_str() {
+        Some(s) => s,
+        None => {
+            eprintln!("refactor: response not valid UTF-8 (saved to response.txt as raw bytes)");
+            return ExitCode::from(1);
+        }
+    };
+    let code = extract_rust_code_block(body);
+    let refactor_path = task_out.join("refactor.md");
+    let mut report = String::with_capacity(body.len() + 256);
+    report.push_str("# Refactor result for ");
+    report.push_str(&task.id);
+    report.push_str("\n\n");
+    report.push_str("Model: `");
+    report.push_str(&g.llm_model);
+    report.push_str("`\n");
+    report.push_str("Prompt: see `prompt.md`\n");
+    report.push_str("Raw response: see `response.txt`\n\n");
+    if let Some(rs) = &code {
+        report.push_str("## Extracted refactored function\n\n```rust\n");
+        report.push_str(rs);
+        if !rs.ends_with('\n') { report.push('\n'); }
+        report.push_str("```\n");
+    } else {
+        report.push_str("## No fenced ```rust block found\n\n");
+        report.push_str("Raw response was saved verbatim to `response.txt`. ");
+        report.push_str("Inspect manually — the model didn't follow the format constraint.\n");
+    }
+    if let Err(e) = std::fs::write(&refactor_path, &report) {
+        eprintln!("refactor: write {}: {e}", refactor_path.display());
+        return ExitCode::from(2);
+    }
+
+    println!("[refactor] saved → {}", refactor_path.display());
+    if code.is_none() {
+        println!("[refactor] WARNING: no ```rust block extracted — check response.txt");
+    }
+    ExitCode::SUCCESS
+}
+
+/// Pull the first ```rust ... ``` fenced block out of an LLM response.
+/// Falls back to ``` (no language tag) if no rust-tagged fence appears.
+fn extract_rust_code_block(body: &str) -> Option<String> {
+    for tag in ["```rust", "```"] {
+        if let Some(open) = body.find(tag) {
+            let rest = &body[open + tag.len()..];
+            // Skip optional newline/spaces after the opening fence.
+            let after_fence = rest.trim_start_matches(|c: char| c != '\n')
+                .strip_prefix('\n')
+                .unwrap_or(rest);
+            if let Some(close) = after_fence.find("\n```") {
+                return Some(after_fence[..close].to_string());
+            }
+        }
+    }
+    None
+}
+
+// ── shared plumbing ─────────────────────────────────────────────────
+
+fn load_tasks(path: &Path) -> Result<TasksFile, ExitCode> {
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        eprintln!("error: read {}: {}", path.display(), e);
+        ExitCode::from(2)
+    })?;
+    toml::from_str(&raw).map_err(|e| {
+        eprintln!("error: parse {}: {}", path.display(), e);
+        ExitCode::from(2)
+    })
+}
+
+fn build_graph(root: &Path) -> Result<folkering_codegraph::CallGraph, ExitCode> {
+    folkering_codegraph::build_from_dir(root).map_err(|e| {
+        eprintln!("error: build_from_dir({}): {e:?}", root.display());
+        ExitCode::from(2)
+    })
 }
 
 fn check_task(task: &Task, graph: &folkering_codegraph::CallGraph) -> Result<(), String> {
@@ -154,7 +447,7 @@ fn check_task(task: &Task, graph: &folkering_codegraph::CallGraph) -> Result<(),
             .map(|s| s.as_str()).collect();
         let mut msg = String::from("caller-file set drift\n");
         if !missing.is_empty() {
-            msg.push_str(&format!("  missing (expected, not found):\n"));
+            msg.push_str("  missing (expected, not found):\n");
             for f in &missing { msg.push_str(&format!("    - {f}\n")); }
         }
         if !extra.is_empty() {
@@ -167,17 +460,13 @@ fn check_task(task: &Task, graph: &folkering_codegraph::CallGraph) -> Result<(),
     Ok(())
 }
 
-/// Pull the file path out of a qualified vertex name like
-/// `.\tools\a64-encoder\src\wasm_lower\call.rs::Lowerer::lower_call`
-/// → `tools/a64-encoder/src/wasm_lower/call.rs`.
 fn qualified_to_file(qualified: &str) -> String {
     let path = qualified.split("::").next().unwrap_or(qualified);
-    normalize_path(&path.to_string())
+    normalize_path(path)
 }
 
 fn normalize_path(p: &str) -> String {
-    let mut s = p.to_string();
-    s = s.replace('\\', "/");
+    let mut s = p.replace('\\', "/");
     if let Some(stripped) = s.strip_prefix("./") { s = stripped.to_string(); }
     s
 }
@@ -201,18 +490,33 @@ mod tests {
         );
     }
 
-    /// Real fixture parses cleanly. Catches `tasks.toml` schema regressions.
     #[test]
     fn fixture_parses() {
         let path = Path::new("tasks.toml");
-        if !path.exists() { return; } // skip when not run from crate dir
+        if !path.exists() { return; }
         let raw = std::fs::read_to_string(path).unwrap();
         let parsed: TasksFile = toml::from_str(&raw).unwrap();
-        assert!(!parsed.task.is_empty(), "tasks.toml must have at least one task");
+        assert!(!parsed.task.is_empty());
         for t in &parsed.task {
             assert!(!t.id.is_empty());
             assert!(!t.target_fn.is_empty());
-            assert_eq!(t.expected_caller_files.iter().filter(|s| s.is_empty()).count(), 0);
         }
+    }
+
+    #[test]
+    fn extract_rust_code_block_pulls_first_fence() {
+        let body = "Some preamble\n```rust\nfn foo() {}\n```\nTrailing.";
+        assert_eq!(extract_rust_code_block(body).as_deref(), Some("fn foo() {}"));
+    }
+
+    #[test]
+    fn extract_rust_code_block_falls_back_to_unlabelled() {
+        let body = "```\nfn foo() {}\n```";
+        assert_eq!(extract_rust_code_block(body).as_deref(), Some("fn foo() {}"));
+    }
+
+    #[test]
+    fn extract_rust_code_block_returns_none_for_unfenced() {
+        assert_eq!(extract_rust_code_block("plain text"), None);
     }
 }

--- a/tools/draug-eval-runner/src/prompt.rs
+++ b/tools/draug-eval-runner/src/prompt.rs
@@ -1,0 +1,193 @@
+//! Refactor-prompt assembly.
+//!
+//! A refactor prompt is the LLM-facing artifact step 3 of the post-CodeGraph
+//! plan produces. It folds together three things the agent needs to do
+//! the work without hallucinating:
+//!
+//!   1. The original source for the target fn (extracted verbatim from
+//!      the tree, layout preserved).
+//!   2. The list of callers from CodeGraph — Draug's "blast radius" so
+//!      she knows whose interfaces she must not break.
+//!   3. The refactor goal + a small set of constraints (no signature
+//!      changes without listing every caller, return only one fenced
+//!      block, etc).
+//!
+//! The output is a Markdown-formatted string. Markdown because the LLM
+//! reliably parses it, and we get readable diff output when we save the
+//! prompt to a file for human inspection.
+
+use folkering_codegraph::CallGraph;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::source_extract::{self, ExtractError};
+
+/// Inputs needed to build a refactor prompt for one task.
+pub struct RefactorPromptInput<'a> {
+    pub task_id: &'a str,
+    pub goal: &'a str,
+    pub target_fn: &'a str,
+    pub target_file: &'a Path,
+    /// Loaded call-graph. The builder queries it for the caller list
+    /// instead of trusting whatever's in tasks.toml — that way the
+    /// prompt always reflects current reality, not stale fixture data.
+    pub graph: &'a CallGraph,
+}
+
+#[derive(Debug)]
+pub enum PromptError {
+    Extract(ExtractError),
+    TargetNotInGraph(String),
+}
+
+impl std::fmt::Display for PromptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PromptError::Extract(e) => write!(f, "source extract: {e}"),
+            PromptError::TargetNotInGraph(n) =>
+                write!(f, "target fn '{n}' not in CodeGraph (rebuild CSR?)"),
+        }
+    }
+}
+
+impl std::error::Error for PromptError {}
+
+pub struct BuiltPrompt {
+    pub markdown: String,
+    /// Distinct caller files (file granularity, normalised) the prompt
+    /// surfaces to the LLM. Caller of the prompt builder uses this to
+    /// decide which files to `cargo check` after applying a patch.
+    pub caller_files: Vec<String>,
+    /// Total caller fns (vertex-granularity) — included in the prompt
+    /// header so the LLM knows the blast radius scale.
+    pub caller_count: usize,
+}
+
+pub fn build(input: &RefactorPromptInput<'_>) -> Result<BuiltPrompt, PromptError> {
+    let extracted = source_extract::extract_fn(input.target_file, input.target_fn)
+        .map_err(PromptError::Extract)?;
+
+    let target_idx = input.graph.lookup(input.target_fn)
+        .ok_or_else(|| PromptError::TargetNotInGraph(input.target_fn.to_string()))?;
+    let caller_indices = input.graph.callers_of(target_idx);
+    let caller_count = caller_indices.len();
+
+    // Per-caller display: `file::QualifiedName`. Sorted + deduped so
+    // the prompt is stable across runs (helps prompt-cache hits). Path
+    // separators are normalised (CodeGraph emits `.\foo\bar.rs` on
+    // Windows; the LLM reads forward slashes more naturally).
+    let caller_lines: BTreeSet<String> = caller_indices.iter()
+        .filter_map(|idx| input.graph.names.get(*idx as usize))
+        .map(|q| {
+            if let Some((file, rest)) = q.split_once("::") {
+                format!("{}::{}", normalise(file), rest)
+            } else {
+                normalise(q)
+            }
+        })
+        .collect();
+    let caller_files: BTreeSet<String> = caller_lines.iter()
+        .map(|q| {
+            let file = q.split("::").next().unwrap_or(q);
+            normalise(file)
+        })
+        .collect();
+
+    let mut md = String::with_capacity(2048 + extracted.source.len());
+
+    md.push_str("# Refactor task: ");
+    md.push_str(input.task_id);
+    md.push_str("\n\n");
+
+    md.push_str("## Goal\n\n");
+    md.push_str(input.goal.trim());
+    md.push_str("\n\n");
+
+    md.push_str("## Target\n\n");
+    md.push_str("- Function: `");
+    md.push_str(input.target_fn);
+    md.push_str("`\n");
+    md.push_str("- File: `");
+    md.push_str(&normalise(&input.target_file.display().to_string()));
+    md.push_str("` (lines ");
+    md.push_str(&extracted.start_line.to_string());
+    md.push('–');
+    md.push_str(&extracted.end_line.to_string());
+    md.push_str(")\n\n");
+
+    md.push_str("## Blast radius — callers from the static call-graph\n\n");
+    md.push_str(&caller_count.to_string());
+    md.push_str(" caller(s) across ");
+    md.push_str(&caller_files.len().to_string());
+    md.push_str(" file(s):\n\n");
+    for c in &caller_lines {
+        md.push_str("- `");
+        md.push_str(c);
+        md.push_str("`\n");
+    }
+    md.push('\n');
+
+    md.push_str("## Constraints\n\n");
+    md.push_str(
+        "- Preserve the public signature of the target fn unless the goal \
+        explicitly authorizes changing it. If you must change it, list \
+        every caller you would need to update, file by file.\n\
+        - Don't introduce new external dependencies.\n\
+        - Match the existing surrounding style (no_std discipline, error \
+        types, lifetime patterns).\n\
+        - Output only the refactored function inside a single fenced \
+        ```rust block. No prose outside the block, no `// Before:`/`// After:` \
+        comments, no diff format.\n\n",
+    );
+
+    md.push_str("## Original source\n\n```rust\n");
+    md.push_str(&extracted.source);
+    if !extracted.source.ends_with('\n') { md.push('\n'); }
+    md.push_str("```\n");
+
+    Ok(BuiltPrompt {
+        markdown: md,
+        caller_files: caller_files.into_iter().collect(),
+        caller_count,
+    })
+}
+
+fn normalise(p: &str) -> String {
+    let mut s = p.replace('\\', "/");
+    if let Some(stripped) = s.strip_prefix("./") { s = stripped.to_string(); }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn folkering_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap().parent().unwrap().to_path_buf()
+    }
+
+    #[test]
+    fn builds_prompt_for_real_task() {
+        let root = folkering_root();
+        let graph = folkering_codegraph::build_from_dir(&root).expect("graph");
+        let target_file = root.join("kernel/src/memory/physical.rs");
+        let input = RefactorPromptInput {
+            task_id: "smoke",
+            goal: "Add a Layout-style API alongside `alloc_pages` that takes raw bytes + alignment.",
+            target_fn: "alloc_pages",
+            target_file: &target_file,
+            graph: &graph,
+        };
+        let built = build(&input).expect("build");
+        assert!(built.markdown.contains("# Refactor task: smoke"));
+        assert!(built.markdown.contains("## Goal"));
+        assert!(built.markdown.contains("## Blast radius"));
+        assert!(built.markdown.contains("## Original source"));
+        assert!(built.markdown.contains("fn alloc_pages"),
+            "prompt must include the original fn body");
+        assert!(built.caller_count >= 1, "expected ≥1 caller from real graph");
+        assert!(!built.caller_files.is_empty());
+    }
+}

--- a/tools/draug-eval-runner/src/proxy.rs
+++ b/tools/draug-eval-runner/src/proxy.rs
@@ -1,0 +1,169 @@
+//! Synchronous TCP client for `folkering-proxy` endpoints.
+//!
+//! Same wire format the kernel uses, so we can validate end-to-end
+//! against the real proxy without spinning up the OS:
+//!
+//! Reply frame (shared by LLM, PATCH, GRAPH_CALLERS):
+//! ```text
+//!   [u32 status LE][u32 output_len LE][output_len bytes payload]
+//! ```
+//!
+//! LLM request:
+//! ```text
+//!   LLM <model>\n
+//!   <prompt_byte_len decimal>\n
+//!   <prompt bytes>
+//! ```
+//!
+//! GRAPH_CALLERS request:
+//! ```text
+//!   GRAPH_CALLERS <fn_name>\n
+//! ```
+//!
+//! All status codes match the proxy crate's published constants
+//! (see `folkering-proxy/src/llm.rs`, `codegraph.rs`, `patch.rs`).
+
+use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// Default proxy endpoint. Matches the address the kernel pins to
+/// (`10.0.0.2:14711` from inside QEMU; `127.0.0.1:14711` from host).
+pub const DEFAULT_HOST: &str = "127.0.0.1";
+pub const DEFAULT_PORT: u16 = 14711;
+
+#[derive(Debug)]
+pub enum ProxyError {
+    Io(io::Error),
+    NoAddr,
+    ShortResponse { wanted: usize, got: usize },
+}
+
+impl std::fmt::Display for ProxyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProxyError::Io(e) => write!(f, "io: {e}"),
+            ProxyError::NoAddr => write!(f, "no socket address resolved"),
+            ProxyError::ShortResponse { wanted, got } =>
+                write!(f, "short response: wanted {wanted} bytes, got {got}"),
+        }
+    }
+}
+
+impl std::error::Error for ProxyError {}
+
+impl From<io::Error> for ProxyError {
+    fn from(e: io::Error) -> Self { ProxyError::Io(e) }
+}
+
+#[derive(Debug)]
+pub struct ProxyResponse {
+    pub status: u32,
+    pub body: Vec<u8>,
+}
+
+impl ProxyResponse {
+    pub fn body_str(&self) -> Option<&str> { core::str::from_utf8(&self.body).ok() }
+}
+
+/// Send `LLM <model>\n<len>\n<prompt>` and read the framed response.
+/// Timeout includes the full Ollama round-trip; cloud-backed models
+/// can take ~60s cold.
+pub fn llm_generate(
+    addr: (&str, u16),
+    model: &str,
+    prompt: &str,
+    timeout: Duration,
+) -> Result<ProxyResponse, ProxyError> {
+    let mut req = Vec::with_capacity(prompt.len() + 64);
+    req.extend_from_slice(b"LLM ");
+    req.extend_from_slice(model.as_bytes());
+    req.push(b'\n');
+    req.extend_from_slice(prompt.len().to_string().as_bytes());
+    req.push(b'\n');
+    req.extend_from_slice(prompt.as_bytes());
+    send_and_read(addr, &req, timeout)
+}
+
+/// Send `GRAPH_CALLERS <fn>\n` and read the framed response. The
+/// proxy returns `\n`-separated qualified names in the body on status=0.
+pub fn graph_callers(
+    addr: (&str, u16),
+    fn_name: &str,
+    timeout: Duration,
+) -> Result<ProxyResponse, ProxyError> {
+    let mut req = Vec::with_capacity(fn_name.len() + 16);
+    req.extend_from_slice(b"GRAPH_CALLERS ");
+    req.extend_from_slice(fn_name.as_bytes());
+    req.push(b'\n');
+    send_and_read(addr, &req, timeout)
+}
+
+// ── plumbing ────────────────────────────────────────────────────────
+
+fn send_and_read(
+    addr: (&str, u16),
+    request: &[u8],
+    timeout: Duration,
+) -> Result<ProxyResponse, ProxyError> {
+    let target: SocketAddr = (addr.0, addr.1)
+        .to_socket_addrs()?
+        .next()
+        .ok_or(ProxyError::NoAddr)?;
+
+    let mut stream = TcpStream::connect_timeout(&target, Duration::from_secs(5))?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+    stream.write_all(request)?;
+    stream.flush()?;
+
+    // Read [u32 status][u32 len] header.
+    let mut hdr = [0u8; 8];
+    stream.read_exact(&mut hdr)?;
+    let status = u32::from_le_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
+    let len = u32::from_le_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]) as usize;
+
+    let mut body = vec![0u8; len];
+    if len > 0 {
+        match stream.read_exact(&mut body) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                return Err(ProxyError::ShortResponse { wanted: len, got: 0 });
+            }
+            Err(e) => return Err(ProxyError::Io(e)),
+        }
+    }
+
+    Ok(ProxyResponse { status, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live test against a running proxy. Skipped when port 14711 isn't
+    /// open — keeps `cargo test` green on machines that don't have the
+    /// proxy running.
+    #[test]
+    fn live_graph_callers_when_proxy_up() {
+        let addr = (DEFAULT_HOST, DEFAULT_PORT);
+        let probe = TcpStream::connect_timeout(
+            &(addr.0, addr.1).to_socket_addrs().unwrap().next().unwrap(),
+            Duration::from_millis(200),
+        );
+        if probe.is_err() {
+            eprintln!("[skip] proxy not reachable on {DEFAULT_HOST}:{DEFAULT_PORT}");
+            return;
+        }
+        drop(probe);
+
+        // Use a fn we know exists in the running proxy's loaded CSR.
+        // pop_i32_slot has 29 callers; status=0 + non-empty body expected.
+        let resp = graph_callers(addr, "pop_i32_slot", Duration::from_secs(5))
+            .expect("graph_callers");
+        assert_eq!(resp.status, 0, "GRAPH_CALLERS pop_i32_slot expected status=0");
+        assert!(!resp.body.is_empty(), "expected non-empty body");
+        let s = resp.body_str().unwrap();
+        assert!(s.contains("Lowerer"), "expected qualified caller, got {s:?}");
+    }
+}

--- a/tools/draug-eval-runner/src/source_extract.rs
+++ b/tools/draug-eval-runner/src/source_extract.rs
@@ -1,0 +1,472 @@
+//! Locate and extract a function's source text from a `.rs` file.
+//!
+//! The extractor is the part of the refactor flow that gives Draug
+//! something concrete to refactor. We want the *original text* (not a
+//! pretty-printed AST round-trip) so layout, comments, and blank lines
+//! survive into the prompt.
+//!
+//! Strategy:
+//! 1. Parse the file with `syn` to confirm a fn with that name exists.
+//!    Fails fast if the task fixture points at a typo or moved fn.
+//! 2. Text-scan for `fn <name>` with word boundaries, then walk back
+//!    over `pub`/`pub(...)` visibility and `#[...]` attributes, then
+//!    walk forward through the signature `(...)` + optional return
+//!    type and into the body `{ ... }` with brace counting that skips
+//!    string and char literals + comments.
+//! 3. Return the resulting slice `[start..end]` as `String`.
+//!
+//! Brace counting is intentionally simple — it handles the conventions
+//! actually used in folkering (no raw-string `r#"…"#` with `{` inside,
+//! no nested raw-strings). If a future fn breaks it, the test for that
+//! specific function will catch it and we add cases.
+
+use std::path::Path;
+use syn::visit::Visit;
+
+#[derive(Debug)]
+pub enum ExtractError {
+    Io(std::io::Error),
+    Parse(String),
+    NotFound(String),
+    Ambiguous { name: String, count: usize },
+    UnbalancedBraces,
+}
+
+impl std::fmt::Display for ExtractError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtractError::Io(e) => write!(f, "io: {e}"),
+            ExtractError::Parse(e) => write!(f, "parse: {e}"),
+            ExtractError::NotFound(n) => write!(f, "fn '{n}' not found in source"),
+            ExtractError::Ambiguous { name, count } => {
+                write!(f, "fn '{name}' appears {count} times in source — disambiguate")
+            }
+            ExtractError::UnbalancedBraces => write!(f, "fn body has unbalanced braces"),
+        }
+    }
+}
+
+impl std::error::Error for ExtractError {}
+
+/// Result of extracting a fn from a source file.
+#[derive(Debug)]
+pub struct Extracted {
+    /// The full text of the fn, including attributes and visibility.
+    pub source: String,
+    /// 1-indexed line number where the extracted slice starts.
+    pub start_line: usize,
+    /// 1-indexed line number where the extracted slice ends (inclusive).
+    pub end_line: usize,
+}
+
+pub fn extract_fn(path: &Path, fn_name: &str) -> Result<Extracted, ExtractError> {
+    let raw = std::fs::read_to_string(path).map_err(ExtractError::Io)?;
+
+    // (1) Validate the fn actually exists. We use syn for this rather
+    //     than trusting raw text-search, because text-search would happily
+    //     match a `// fn foo` comment or a `fn foo` substring inside a
+    //     macro_rules! body.
+    let parsed = syn::parse_file(&raw)
+        .map_err(|e| ExtractError::Parse(e.to_string()))?;
+    let mut counter = NameCounter { target: fn_name, free: 0, method: 0 };
+    counter.visit_file(&parsed);
+    let total = counter.free + counter.method;
+    if total == 0 {
+        return Err(ExtractError::NotFound(fn_name.to_string()));
+    }
+    // Disambiguation rule: prefer a free fn when one exists alongside
+    // impl methods of the same name (free fns are typically the public
+    // API; the impl method is usually a private helper that happens to
+    // share a name). Only fail Ambiguous when there are multiple frees
+    // or multiple impl methods with no free.
+    let prefer_free = counter.free >= 1;
+    if prefer_free && counter.free > 1 {
+        return Err(ExtractError::Ambiguous { name: fn_name.to_string(), count: counter.free });
+    }
+    if !prefer_free && counter.method > 1 {
+        return Err(ExtractError::Ambiguous { name: fn_name.to_string(), count: counter.method });
+    }
+
+    // (2) Locate the `fn <name>` token in the raw text. With prefer_free
+    //     we want the match at impl-depth 0; otherwise pick the first.
+    let fn_pos = find_fn_keyword(&raw, fn_name, prefer_free)
+        .ok_or_else(|| ExtractError::NotFound(fn_name.to_string()))?;
+
+    // (3) Walk back from fn_pos over visibility / attributes to find the
+    //     real start of the item.
+    let start = walk_back_to_item_start(&raw, fn_pos);
+
+    // (4) Walk forward to find the `{` that opens the body, skipping the
+    //     `(args)` parens and any return type / where clause.
+    let body_open = match find_body_open(&raw, fn_pos) {
+        Some(p) => p,
+        None => {
+            // Trait fn / extern fn with no body — return up to the trailing `;`.
+            // For our 5 tasks this never fires; keep the path for completeness.
+            let semi = raw[fn_pos..].find(';')
+                .ok_or(ExtractError::UnbalancedBraces)?;
+            let end = fn_pos + semi + 1;
+            return Ok(slice(&raw, start, end));
+        }
+    };
+
+    // (5) Brace-count from body_open until balanced.
+    let body_close = match_brace(&raw, body_open)
+        .ok_or(ExtractError::UnbalancedBraces)?;
+
+    Ok(slice(&raw, start, body_close + 1))
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+struct NameCounter<'a> {
+    target: &'a str,
+    free: usize,    // free `fn` items
+    method: usize,  // `impl X { fn ... }` and trait methods
+}
+
+impl<'ast, 'a> Visit<'ast> for NameCounter<'a> {
+    fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+        if f.sig.ident == self.target { self.free += 1; }
+        syn::visit::visit_item_fn(self, f);
+    }
+    fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+        if f.sig.ident == self.target { self.method += 1; }
+        syn::visit::visit_impl_item_fn(self, f);
+    }
+    fn visit_trait_item_fn(&mut self, f: &'ast syn::TraitItemFn) {
+        if f.sig.ident == self.target { self.method += 1; }
+        syn::visit::visit_trait_item_fn(self, f);
+    }
+}
+
+/// Find the `fn` keyword that introduces the named function. Returns the
+/// byte offset of the `f` in `fn`. When `prefer_free` is true and the file
+/// has both a free fn and impl methods of the same name, the free one
+/// (top-level, brace-depth 0 outside any `impl/trait` block) wins.
+fn find_fn_keyword(src: &str, name: &str, prefer_free: bool) -> Option<usize> {
+    let needle = format!("fn {name}");
+    let bytes = src.as_bytes();
+
+    let mut matches: Vec<(usize, bool)> = Vec::new(); // (pos, is_free)
+    let mut i = 0;
+    let mut item_depth: i32 = 0; // braces opened by `impl`/`trait` blocks
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        // Skip strings + comments so the depth counter doesn't see them.
+        if b == b'"' {
+            if let Some(end) = skip_string(src, i) { i = end; continue; }
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' { i += 1; }
+            continue;
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
+
+        // Track `impl ... {` and `trait ... {` blocks. Anything inside
+        // those is a method. Anything outside is a free fn.
+        if (starts_keyword(src, i, "impl") || starts_keyword(src, i, "trait"))
+            && item_depth == 0
+        {
+            // Consume up to the next `{` or `;` (forward decl).
+            let mut j = i;
+            while j < bytes.len() && bytes[j] != b'{' && bytes[j] != b';' { j += 1; }
+            if j < bytes.len() && bytes[j] == b'{' {
+                item_depth = 1;
+                i = j + 1;
+                continue;
+            }
+            i = j + 1;
+            continue;
+        }
+
+        // Track brace depth INSIDE an impl/trait block.
+        if item_depth > 0 {
+            if b == b'{' { item_depth += 1; }
+            else if b == b'}' { item_depth -= 1; }
+        }
+
+        // Detect `fn <name>` matches with proper word boundaries.
+        if b == b'f' && src.as_bytes().get(i..i + needle.len()) == Some(needle.as_bytes()) {
+            let after = i + needle.len();
+            let after_ok = bytes.get(after).is_none_or(|c| !is_ident_byte(*c));
+            let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+            if after_ok && before_ok {
+                matches.push((i, item_depth == 0));
+            }
+        }
+        i += 1;
+    }
+
+    if matches.is_empty() { return None; }
+    if prefer_free {
+        if let Some((p, _)) = matches.iter().find(|(_, free)| *free) {
+            return Some(*p);
+        }
+    }
+    Some(matches[0].0)
+}
+
+fn starts_keyword(src: &str, i: usize, kw: &str) -> bool {
+    let bytes = src.as_bytes();
+    if src.as_bytes().get(i..i + kw.len()) != Some(kw.as_bytes()) { return false; }
+    let after = i + kw.len();
+    let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+    let after_ok = bytes.get(after).is_none_or(|c| !is_ident_byte(*c));
+    before_ok && after_ok
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Walk backward from `fn_pos` to capture preceding visibility (`pub`,
+/// `pub(crate)`, `pub(super)`, `pub(in path)`) and any `#[...]` attribute
+/// blocks attached to this item. Stops at the first blank line or
+/// previous item.
+fn walk_back_to_item_start(src: &str, fn_pos: usize) -> usize {
+    let bytes = src.as_bytes();
+    // Find start of the line containing `fn`.
+    let mut line_start = fn_pos;
+    while line_start > 0 && bytes[line_start - 1] != b'\n' {
+        line_start -= 1;
+    }
+
+    // From line_start, walk back over preceding lines as long as they
+    // are attribute lines (`#[...]`), doc comments (`///`/`//!`), or
+    // blank/whitespace continuation. Stop at any other content.
+    let mut start = line_start;
+    while start > 0 {
+        // Find start of previous line.
+        let mut prev_end = start - 1; // newline
+        let mut prev_start = prev_end;
+        while prev_start > 0 && bytes[prev_start - 1] != b'\n' {
+            prev_start -= 1;
+        }
+        let line = &src[prev_start..prev_end];
+        let trimmed = line.trim_start();
+        let attached =
+            trimmed.starts_with("#[")
+            || trimmed.starts_with("///")
+            || trimmed.starts_with("//!")
+            || trimmed.is_empty();
+        if !attached { break; }
+        if trimmed.is_empty() {
+            // Blank line — break the chain. The current item starts after
+            // this blank, not before.
+            break;
+        }
+        start = prev_start;
+    }
+    start
+}
+
+/// From `fn_pos` (pointing at `f` in `fn name`), walk forward through the
+/// signature and find the byte offset of the `{` that opens the body.
+fn find_body_open(src: &str, fn_pos: usize) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut i = fn_pos;
+    // Walk to the first `(` (start of arg list). syn confirmed there is
+    // a fn here, so this is well-defined.
+    while i < bytes.len() && bytes[i] != b'(' { i += 1; }
+    // Match the paren pair.
+    let close_paren = match_paren(src, i)?;
+    // After the args, find the next `{` that's not inside a `<...>` type
+    // arg, string, or comment. For our 5 tasks the next `{` after the
+    // arg-list close is the body — keep the simple form.
+    let mut j = close_paren + 1;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'{' => return Some(j),
+            b';' => return None, // fn declaration only, no body
+            _ => {}
+        }
+        j += 1;
+    }
+    None
+}
+
+/// Match `(` at `open` to its closing `)` with depth tracking that skips
+/// string and char literals + line/block comments.
+fn match_paren(src: &str, open: usize) -> Option<usize> {
+    match_bracketed(src, open, b'(', b')')
+}
+
+fn match_brace(src: &str, open: usize) -> Option<usize> {
+    match_bracketed(src, open, b'{', b'}')
+}
+
+fn match_bracketed(src: &str, open: usize, op: u8, cl: u8) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = open;
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        // Skip string literal "...".
+        if b == b'"' {
+            i = skip_string(src, i)?;
+            continue;
+        }
+        // Skip char literal '...'.
+        if b == b'\'' {
+            if let Some(end) = skip_char_literal(src, i) {
+                i = end;
+                continue;
+            }
+            // Otherwise it's a lifetime like 'a — let it fall through.
+        }
+        // Skip line comment to end of line.
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' { i += 1; }
+            continue;
+        }
+        // Skip block comment /* ... */.
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
+
+        if b == op { depth += 1; }
+        else if b == cl {
+            depth -= 1;
+            if depth == 0 { return Some(i); }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Given `i` pointing at the opening `"`, return the byte offset just
+/// past the closing `"`. Handles `\"` escapes.
+fn skip_string(src: &str, i: usize) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut j = i + 1;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'\\' => j += 2, // skip escaped char (including \")
+            b'"' => return Some(j + 1),
+            _ => j += 1,
+        }
+    }
+    None
+}
+
+/// Char literal `'x'` or `'\n'` etc. Returns None if it looks like a
+/// lifetime (e.g. `'a` not followed by `'`).
+fn skip_char_literal(src: &str, i: usize) -> Option<usize> {
+    let bytes = src.as_bytes();
+    let mut j = i + 1;
+    if j >= bytes.len() { return None; }
+    if bytes[j] == b'\\' {
+        j += 2;
+    } else {
+        j += 1;
+    }
+    if j < bytes.len() && bytes[j] == b'\'' {
+        return Some(j + 1);
+    }
+    None
+}
+
+/// Quick sanity check that a position isn't inside a string or comment.
+/// Linear scan from start of file; OK for the usage pattern (1 call per
+/// fn extraction). If extract_fn ever becomes hot, swap for a one-pass
+/// tokenizer.
+fn is_inside_skip_zone(src: &str, pos: usize) -> bool {
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    while i < pos {
+        let b = bytes[i];
+        if b == b'"' {
+            if let Some(end) = skip_string(src, i) {
+                if pos < end { return true; }
+                i = end;
+                continue;
+            }
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            // Line comment
+            let line_end = src[i..].find('\n').map(|d| i + d + 1).unwrap_or(bytes.len());
+            if pos < line_end { return true; }
+            i = line_end;
+            continue;
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            let mut j = i + 2;
+            while j + 1 < bytes.len() && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+                j += 1;
+            }
+            let block_end = (j + 2).min(bytes.len());
+            if pos < block_end { return true; }
+            i = block_end;
+            continue;
+        }
+        i += 1;
+    }
+    false
+}
+
+fn slice(src: &str, start: usize, end: usize) -> Extracted {
+    let source = src[start..end].to_string();
+    let start_line = src[..start].matches('\n').count() + 1;
+    let end_line = start_line + source.matches('\n').count();
+    Extracted { source, start_line, end_line }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn folkering_root() -> PathBuf {
+        // tools/draug-eval-runner → folkering-os
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap().parent().unwrap().to_path_buf()
+    }
+
+    #[test]
+    fn extracts_pop_i32_slot_from_real_source() {
+        let path = folkering_root()
+            .join("tools/a64-encoder/src/wasm_lower/stack.rs");
+        let ex = extract_fn(&path, "pop_i32_slot").expect("extract");
+        assert!(ex.source.contains("fn pop_i32_slot"),
+            "extracted slice must contain the fn signature");
+        assert!(ex.source.contains("StackUnderflow"),
+            "extracted slice must contain the body using StackUnderflow");
+        assert!(ex.source.trim_end().ends_with('}'),
+            "must end with closing brace; got tail = {:?}",
+            &ex.source[ex.source.len().saturating_sub(40)..]);
+    }
+
+    #[test]
+    fn extracts_alloc_pages_kernel_fn() {
+        let path = folkering_root()
+            .join("kernel/src/memory/physical.rs");
+        let ex = extract_fn(&path, "alloc_pages").expect("extract");
+        assert!(ex.source.contains("fn alloc_pages"));
+        assert!(ex.source.trim_end().ends_with('}'));
+    }
+
+    #[test]
+    fn returns_not_found_for_typo() {
+        let path = folkering_root()
+            .join("kernel/src/memory/physical.rs");
+        let err = extract_fn(&path, "alocate_pages").unwrap_err(); // typo
+        assert!(matches!(err, ExtractError::NotFound(_)),
+            "expected NotFound, got {err:?}");
+    }
+}

--- a/tools/draug-eval-runner/tasks.toml
+++ b/tools/draug-eval-runner/tasks.toml
@@ -47,7 +47,7 @@ sites can match on intent rather than chase a boolean. 10 call sites
 in 2 files (memory.rs, simd.rs) — moderate blast radius.
 """
 target_fn = "maybe_bounds_check"
-target_file = "tools/a64-encoder/src/wasm_lower/bounds.rs"
+target_file = "tools/a64-encoder/src/wasm_lower/memory.rs"
 expected_caller_count = 10
 expected_caller_files = [
     "tools/a64-encoder/src/wasm_lower/memory.rs",
@@ -80,7 +80,7 @@ radius. Examples are intentionally included; refactor must keep them
 working.
 """
 target_fn = "compile_module"
-target_file = "tools/a64-encoder/src/wasm_lower/mod.rs"
+target_file = "tools/a64-encoder/src/wasm_lower/module_lower.rs"
 expected_caller_count = 5
 expected_caller_files = [
     "tools/a64-encoder/examples/bench_mlp_ablation.rs",


### PR DESCRIPTION
## Summary

Step 3 of the post-CodeGraph plan, in two pieces. This PR is **Phase 2A**: the host-side infrastructure that produces an LLM-ready refactor prompt and ships it to the proxy. **Phase 2B** (apply patch + \`cargo check\` + caller-compat scoring) is the follow-up PR that closes the eval loop.

The eval-runner that landed in PR #40 was a static CSR regression check. With this PR it can actually drive a refactor end-to-end.

## What lands

| Module | Role |
|---|---|
| \`source_extract.rs\` | Locates a fn by name + slices source verbatim from a .rs file. syn-validated, text-extracted (preserves layout). Disambiguates free-fn vs impl-method by name collision. |
| \`prompt.rs\` | Folds source + caller list (from CodeGraph) + goal into a Markdown refactor prompt. Sorted + deduped → stable across runs for prompt-cache hits. |
| \`proxy.rs\` | Sync TCP client for proxy's LLM + GRAPH_CALLERS endpoints. Same wire format the kernel uses; live test against running proxy. |
| \`main.rs\` | Three subcommands: \`verify\` (default), \`prompt <id>\`, \`refactor <id>\`. |

Plus: README updated, \`output/\` gitignored, two stale target_file paths in tasks.toml fixed (\`maybe_bounds_check\` is in memory.rs, \`compile_module\` is in module_lower.rs).

## Live verification

\`\`\`
$ draug-eval verify                                   # 5/5 PASS, 770 ms
$ draug-eval prompt 03_alloc_pages
  [prompt] 1730 bytes → output/03_alloc_pages/prompt.md
  [prompt] 4 caller(s) across 1 file(s)
$ draug-eval refactor 03_alloc_pages
  [refactor] task=03_alloc_pages model=qwen2.5-coder:7b prompt_bytes=1722
  [refactor] calling proxy 127.0.0.1:14711 ...
  [refactor] status=0 body_bytes=754 elapsed=35.4s
  [refactor] saved → output/03_alloc_pages/refactor.md
\`\`\`

The 7b coder produced a \`pub fn alloc_pages_with_layout(size, align)\` + a \`log2_ceil\` helper. Quality is roughly what we'd expect from a small model — the math has issues and it didn't preserve the original \`alloc_pages\`. **Phase 2B's compile + caller-compat scoring is what will honestly filter output quality** — that's the headline metric the harness was designed for.

## What Phase 2B will add

- Apply the extracted code block to a sandbox copy of the monorepo
- \`cargo check\` on the target file + every caller file
- Score per task on (compiles? all callers compile?) → JSON report
- That's the actual measurement of \"does CodeGraph integration help?\"

## Test plan

- [x] \`cargo build --release\`: clean
- [x] \`cargo test --release\`: 11/11 (3 source_extract + 1 prompt + 1 proxy live + 6 main)
- [x] \`draug-eval verify\`: 5/5 PASS, ~770 ms
- [x] \`draug-eval prompt 03_alloc_pages\`: produces well-formed prompt.md
- [x] \`draug-eval refactor 03_alloc_pages\`: end-to-end against running proxy in 35s