### PR TITLE
feat(draug-eval): refactor flow Phase 2B — sandbox + cargo check + score

### DIFF
--- a/tools/draug-eval-runner/.gitignore
+++ b/tools/draug-eval-runner/.gitignore
@@ -1,3 +1,8 @@
 # LLM responses + assembled prompts. Per-run output that varies with
 # the model, sampling, and the current state of the tree — not source.
 output/
+
+# Persistent git worktree used for cargo-check sandboxing. Created on
+# first run by `score`/`eval`. Resetting to clean HEAD between tasks
+# is cheap, so we don't track it.
+sandbox/

--- a/tools/draug-eval-runner/Cargo.toml
+++ b/tools/draug-eval-runner/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 folkering-codegraph = { path = "../folkering-codegraph" }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+# JSON output for `score` / `eval` reports — drives downstream
+# aggregation tooling without needing to parse text logs.
+serde_json = "1"
 # syn parses target Rust files to validate fn existence + locate the
 # byte range of the fn item before we slice the source for the prompt.
 # Already a transitive dep via folkering-codegraph; declared explicitly

--- a/tools/draug-eval-runner/README.md
+++ b/tools/draug-eval-runner/README.md
@@ -46,13 +46,35 @@ The prompt folds together three things:
   3. The refactor goal + a small constraint set (preserve signature
      unless authorized, output a single fenced block, no diff format).
 
-## Phase 2B: applying + scoring (next PR)
+## Phase 2B: applying + scoring (live now)
 
-Each task's refactor patch will be applied to a sandbox copy of the
-monorepo, `cargo check` will run on the target + every caller file,
-and the score will be reported. **Compile + caller-compat is the
-headline metric** — that's what CodeGraph integration is supposed to
-enable.
+The `score` and `eval` subcommands close the loop: apply the LLM
+refactor to a sandbox, run `cargo check`, write a JSON verdict.
+
+**The sandbox** is a persistent git worktree at `sandbox/`. First
+run creates it from HEAD; subsequent runs reset uncommitted changes
+between tasks. Worktree means it shares `.git` with the main repo
+(no source duplication) but has its own `target/` for cargo's
+incremental cache. Cold first-build of the kernel workspace is ~45 s;
+warm reruns are ~2 s.
+
+**Patch application** picks one of two strategies based on the LLM's
+output:
+  - **Replace** — patch contains `fn <target_fn>` → splice into the
+    original fn's byte range, preserving indent + surrounding code.
+  - **Append** — patch defines other names (e.g. `alloc_pages_with_layout`
+    alongside the original) → insert into the same impl block when
+    the original lives in one, otherwise at end of file.
+
+**Cargo args per workspace** — kernel + userspace are `#![no_std]`
+so `--all-targets` would fail with E0463 "can't find crate for test".
+Tool crates (a64-encoder etc) keep `--all-targets` to also catch
+caller-breakage in `examples/`.
+
+**Verdict** is `PASS` only when `cargo check` exits 0. The full
+diagnostic set (errors + warnings + a stderr excerpt focused on the
+diagnostic blocks themselves, not cargo's progress noise) lands in
+`output/<id>/score.json` for downstream aggregation.
 
 ## Running
 
@@ -65,6 +87,15 @@ cargo run -p draug-eval-runner --release -- prompt 03_alloc_pages
 
 # Full refactor against the proxy (proxy must be running):
 cargo run -p draug-eval-runner --release -- refactor 03_alloc_pages
+
+# Score the existing refactor.md against cargo check (sandbox):
+cargo run -p draug-eval-runner --release -- score 03_alloc_pages
+
+# Refactor + score in one go:
+cargo run -p draug-eval-runner --release -- eval 03_alloc_pages
+
+# Run the full suite:
+cargo run -p draug-eval-runner --release -- eval --all
 
 # Use a different model:
 cargo run -p draug-eval-runner --release -- \

--- a/tools/draug-eval-runner/src/apply.rs
+++ b/tools/draug-eval-runner/src/apply.rs
@@ -1,0 +1,426 @@
+//! Apply an LLM-produced refactor patch to a target file.
+//!
+//! Two strategies, auto-detected from the patch contents:
+//!
+//!   * `Replace` — the patch contains `fn <target_fn>` at item position.
+//!     Splice it into the byte range the original fn occupies (computed
+//!     by `source_extract`), preserving everything outside that range.
+//!
+//!   * `Append`  — the patch defines other names (typically a *new*
+//!     helper fn alongside the original, like the alloc_pages_with_layout
+//!     case). Append above the last closing brace of the file's outermost
+//!     `impl` if the original fn lives inside one, otherwise at end of
+//!     file. Either way the original fn stays intact — the LLM is adding,
+//!     not rewriting.
+//!
+//! No semantic check here: we don't try to make the patch compile, only
+//! to splice it into the source so the cargo-check phase can give a
+//! verdict. That separation lets the same applier serve both
+//! "human edited the prompt and saved code by hand" and "LLM generated
+//! it" workflows.
+
+use std::path::Path;
+
+use crate::source_extract::{self, ExtractError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strategy {
+    Replace,
+    Append,
+}
+
+#[derive(Debug)]
+pub enum ApplyError {
+    Io(std::io::Error),
+    Extract(ExtractError),
+    PatchEmpty,
+    /// The patch claims to replace `fn <name>` but `<name>` doesn't
+    /// match the target — caught here so we don't silently splice an
+    /// unrelated fn into the wrong byte range.
+    NameMismatch { expected: String, found: String },
+    /// Append-mode but couldn't find a sane insertion point.
+    NoInsertionPoint,
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApplyError::Io(e) => write!(f, "io: {e}"),
+            ApplyError::Extract(e) => write!(f, "extract: {e}"),
+            ApplyError::PatchEmpty => write!(f, "patch is empty"),
+            ApplyError::NameMismatch { expected, found } =>
+                write!(f, "patch defines fn '{found}' but target is '{expected}'"),
+            ApplyError::NoInsertionPoint =>
+                write!(f, "couldn't find a sane append insertion point"),
+        }
+    }
+}
+
+impl std::error::Error for ApplyError {}
+
+#[derive(Debug)]
+pub struct ApplyResult {
+    pub strategy: Strategy,
+    /// The full patched file content. Caller writes this to disk in
+    /// the sandbox (or unit tests assert on it).
+    pub patched: String,
+    /// 1-indexed line numbers of the splice/append region in the
+    /// PATCHED file. Useful for diff display.
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+/// Decide strategy by inspecting the patch text. Replace if a top-level
+/// `fn <target_fn>` token appears; otherwise append.
+pub fn detect_strategy(patch: &str, target_fn: &str) -> Strategy {
+    if contains_fn_def(patch, target_fn) {
+        Strategy::Replace
+    } else {
+        Strategy::Append
+    }
+}
+
+fn contains_fn_def(patch: &str, name: &str) -> bool {
+    // Very small needle-search. The prompt instructs the model to emit
+    // a single fenced block, so false positives (e.g. `// fn name`) are
+    // rare. We tolerate them — `cargo check` is the actual filter.
+    let needle = format!("fn {name}");
+    let bytes = patch.as_bytes();
+    let mut i = 0;
+    while let Some(rel) = patch[i..].find(&needle) {
+        let pos = i + rel;
+        let after = pos + needle.len();
+        let before_ok = pos == 0 || !is_ident_byte(bytes[pos - 1]);
+        let after_ok = bytes.get(after).is_none_or(|c| !is_ident_byte(*c));
+        if before_ok && after_ok { return true; }
+        i = pos + 1;
+    }
+    false
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Apply `patch` to the file at `target_file`, replacing or appending
+/// according to the detected strategy. Returns the patched content (not
+/// written to disk — caller decides where it lands).
+pub fn apply(
+    target_file: &Path,
+    target_fn: &str,
+    patch: &str,
+) -> Result<ApplyResult, ApplyError> {
+    let trimmed = patch.trim();
+    if trimmed.is_empty() {
+        return Err(ApplyError::PatchEmpty);
+    }
+    let strategy = detect_strategy(trimmed, target_fn);
+
+    let raw = std::fs::read_to_string(target_file).map_err(ApplyError::Io)?;
+
+    match strategy {
+        Strategy::Replace => apply_replace(&raw, target_file, target_fn, trimmed),
+        Strategy::Append => apply_append(&raw, target_file, target_fn, trimmed),
+    }
+}
+
+fn apply_replace(
+    raw: &str,
+    target_file: &Path,
+    target_fn: &str,
+    patch: &str,
+) -> Result<ApplyResult, ApplyError> {
+    let extracted = source_extract::extract_fn(target_file, target_fn)
+        .map_err(ApplyError::Extract)?;
+    // Find the byte range of `extracted.source` inside `raw` so we can
+    // splice. `extract_fn` already validated uniqueness; `find` is OK.
+    let start_byte = raw.find(&extracted.source).ok_or_else(|| {
+        ApplyError::Extract(ExtractError::NotFound(target_fn.to_string()))
+    })?;
+    let end_byte = start_byte + extracted.source.len();
+
+    // Indent the patch to match the original's leading whitespace, so
+    // the splice doesn't disturb impl-block alignment. We pull the
+    // indent from the first line of the original slice.
+    let indent = leading_whitespace(&extracted.source);
+    let indented_patch = reindent(patch, indent);
+
+    let mut patched = String::with_capacity(raw.len() + patch.len());
+    patched.push_str(&raw[..start_byte]);
+    patched.push_str(&indented_patch);
+    if !indented_patch.ends_with('\n') { patched.push('\n'); }
+    patched.push_str(&raw[end_byte..]);
+
+    let start_line = raw[..start_byte].matches('\n').count() + 1;
+    let end_line = start_line + indented_patch.matches('\n').count();
+
+    Ok(ApplyResult {
+        strategy: Strategy::Replace,
+        patched,
+        start_line,
+        end_line,
+    })
+}
+
+fn apply_append(
+    raw: &str,
+    target_file: &Path,
+    target_fn: &str,
+    patch: &str,
+) -> Result<ApplyResult, ApplyError> {
+    // Find where the original fn lives so we know whether to append
+    // inside its impl block or at end of file.
+    let extracted = source_extract::extract_fn(target_file, target_fn)
+        .map_err(ApplyError::Extract)?;
+    let start_byte = raw.find(&extracted.source).ok_or_else(|| {
+        ApplyError::Extract(ExtractError::NotFound(target_fn.to_string()))
+    })?;
+    let end_byte = start_byte + extracted.source.len();
+
+    // Heuristic: if the byte range falls inside an `impl ... { ... }`,
+    // insert just after the original fn, before the next sibling. That
+    // keeps the new fn beside its predecessor instead of orphaning it
+    // at the end of the file.
+    let inside_impl = is_in_impl_block(raw, start_byte);
+
+    let (insert_at, indent) = if inside_impl {
+        let after = end_byte;
+        // Skip any trailing blank line that already exists.
+        let mut p = after;
+        let bytes = raw.as_bytes();
+        while p < bytes.len() && (bytes[p] == b'\n' || bytes[p] == b' ' || bytes[p] == b'\t') {
+            if bytes[p] == b'\n' { p += 1; break; }
+            p += 1;
+        }
+        let indent = leading_whitespace(&extracted.source);
+        (p, indent)
+    } else {
+        // Append at end of file (or just before trailing whitespace).
+        let trim_end = raw.trim_end_matches(|c: char| c.is_whitespace()).len();
+        (trim_end, "")
+    };
+
+    let indented_patch = reindent(patch, indent);
+    let mut patched = String::with_capacity(raw.len() + patch.len() + 4);
+    patched.push_str(&raw[..insert_at]);
+    if !patched.ends_with('\n') { patched.push('\n'); }
+    patched.push('\n');
+    patched.push_str(&indented_patch);
+    if !indented_patch.ends_with('\n') { patched.push('\n'); }
+    patched.push_str(&raw[insert_at..]);
+
+    let start_line = raw[..insert_at].matches('\n').count() + 1;
+    let end_line = start_line + indented_patch.matches('\n').count();
+
+    Ok(ApplyResult {
+        strategy: Strategy::Append,
+        patched,
+        start_line,
+        end_line,
+    })
+}
+
+fn leading_whitespace(s: &str) -> &str {
+    let line = s.lines().next().unwrap_or("");
+    let trimmed = line.trim_start();
+    &line[..line.len() - trimmed.len()]
+}
+
+fn reindent(patch: &str, indent: &str) -> String {
+    if indent.is_empty() { return patch.to_string(); }
+    let mut out = String::with_capacity(patch.len() + indent.len() * 8);
+    for (i, line) in patch.lines().enumerate() {
+        if i > 0 { out.push('\n'); }
+        if !line.is_empty() {
+            out.push_str(indent);
+        }
+        out.push_str(line);
+    }
+    if patch.ends_with('\n') { out.push('\n'); }
+    out
+}
+
+/// Cheap "are we inside an impl block at byte `pos`?" check. Walks
+/// from start of file tracking impl-block depth.
+fn is_in_impl_block(src: &str, pos: usize) -> bool {
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    let mut depth: i32 = 0;
+    while i < pos.min(bytes.len()) {
+        let b = bytes[i];
+        if b == b'"' {
+            // Skip string literal.
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' { i += 2; continue; }
+                if bytes[i] == b'"' { i += 1; break; }
+                i += 1;
+            }
+            continue;
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' { i += 1; }
+            continue;
+        }
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') { i += 1; }
+            i += 2;
+            continue;
+        }
+        if (kw_matches(src, i, "impl") || kw_matches(src, i, "trait")) && depth == 0 {
+            // Walk to next `{` or `;`.
+            let mut j = i;
+            while j < bytes.len() && bytes[j] != b'{' && bytes[j] != b';' { j += 1; }
+            if j < bytes.len() && bytes[j] == b'{' {
+                depth = 1;
+                i = j + 1;
+                continue;
+            }
+            i = j + 1;
+            continue;
+        }
+        if depth > 0 {
+            if b == b'{' { depth += 1; }
+            else if b == b'}' { depth -= 1; }
+        }
+        i += 1;
+    }
+    depth > 0
+}
+
+fn kw_matches(src: &str, i: usize, kw: &str) -> bool {
+    let bytes = src.as_bytes();
+    if src.as_bytes().get(i..i + kw.len()) != Some(kw.as_bytes()) { return false; }
+    let after = i + kw.len();
+    let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+    let after_ok = bytes.get(after).is_none_or(|c| !is_ident_byte(*c));
+    before_ok && after_ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("draug-apply-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Unique filename per test so parallel runs don't clobber.
+        let path = dir.join(format!("test_{}.rs", rand_suffix()));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    fn rand_suffix() -> u64 {
+        // No rand crate — use the system clock.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64
+    }
+
+    #[test]
+    fn detect_strategy_picks_replace_when_fn_named() {
+        assert_eq!(
+            detect_strategy("fn foo() { 42 }", "foo"),
+            Strategy::Replace
+        );
+        assert_eq!(
+            detect_strategy("pub fn foo(x: i32) -> i32 { x }", "foo"),
+            Strategy::Replace
+        );
+    }
+
+    #[test]
+    fn detect_strategy_picks_append_when_other_name() {
+        assert_eq!(
+            detect_strategy("fn helper() {}\nfn other_thing() {}", "foo"),
+            Strategy::Append,
+        );
+    }
+
+    #[test]
+    fn replace_swaps_target_fn_byte_range() {
+        let original = "\
+fn unrelated() { 1 }
+
+fn foo() {
+    panic!()
+}
+
+fn after() { 2 }
+";
+        let target = write_temp(original);
+        let patch = "fn foo() -> i32 { 42 }";
+        let result = apply(&target, "foo", patch).expect("apply");
+        assert_eq!(result.strategy, Strategy::Replace);
+        assert!(result.patched.contains("fn foo() -> i32 { 42 }"));
+        assert!(!result.patched.contains("panic!()"));
+        // Surrounding fns intact.
+        assert!(result.patched.contains("fn unrelated()"));
+        assert!(result.patched.contains("fn after()"));
+        let _ = std::fs::remove_file(&target);
+    }
+
+    #[test]
+    fn append_mode_keeps_target_intact() {
+        let original = "\
+fn unrelated() { 1 }
+
+fn foo() { 1 }
+
+fn after() { 2 }
+";
+        let target = write_temp(original);
+        let patch = "fn foo_with_layout(size: usize) -> i32 { 42 }";
+        let result = apply(&target, "foo", patch).expect("apply");
+        assert_eq!(result.strategy, Strategy::Append);
+        assert!(result.patched.contains("fn foo() { 1 }"),
+            "original foo must survive — got {:?}", result.patched);
+        assert!(result.patched.contains("fn foo_with_layout"));
+        let _ = std::fs::remove_file(&target);
+    }
+
+    #[test]
+    fn replace_inside_impl_preserves_indent() {
+        let original = "\
+struct S;
+impl S {
+    fn foo(&self) -> i32 { 1 }
+}
+";
+        let target = write_temp(original);
+        let patch = "fn foo(&self) -> i32 { 42 }";
+        let result = apply(&target, "foo", patch).expect("apply");
+        assert_eq!(result.strategy, Strategy::Replace);
+        // Indent must be preserved (4 spaces).
+        assert!(
+            result.patched.contains("    fn foo(&self) -> i32 { 42 }"),
+            "patched file must keep impl-block indent; got\n{}", result.patched,
+        );
+        let _ = std::fs::remove_file(&target);
+    }
+
+    #[test]
+    fn append_inside_impl_lands_in_block_not_eof() {
+        let original = "\
+struct S;
+impl S {
+    fn foo(&self) -> i32 { 1 }
+}
+
+fn at_end() {}
+";
+        let target = write_temp(original);
+        let patch = "fn foo_v2(&self) -> i32 { 2 }";
+        let result = apply(&target, "foo", patch).expect("apply");
+        assert_eq!(result.strategy, Strategy::Append);
+        // The new fn should appear before the `}` that closes impl S,
+        // not after `fn at_end`.
+        let foo_v2_pos = result.patched.find("foo_v2").expect("present");
+        let at_end_pos = result.patched.find("fn at_end").expect("present");
+        assert!(foo_v2_pos < at_end_pos,
+            "foo_v2 should land in impl block (before fn at_end); got\n{}", result.patched);
+        let _ = std::fs::remove_file(&target);
+    }
+}

--- a/tools/draug-eval-runner/src/cargo_check.rs
+++ b/tools/draug-eval-runner/src/cargo_check.rs
@@ -1,0 +1,239 @@
+//! Run `cargo check` in the workspace that owns a target file, and
+//! report whether the build still passes after the patch was applied.
+//!
+//! Workspace detection is path-prefix based — the repo's structure is
+//! stable enough that hard-coding the four roots is simpler and more
+//! reliable than walking up looking for `[workspace]` Cargo.tomls.
+//!
+//! `compile_module`-style tasks have callers in `examples/`, so we
+//! pass `--all-targets` to make sure those compile too.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct CheckOutcome {
+    pub workspace: String,
+    pub exit_code: i32,
+    pub elapsed: Duration,
+    /// Counted from `^error\b` lines in stderr.
+    pub error_count: u32,
+    /// Counted from `^warning\b` lines in stderr.
+    pub warning_count: u32,
+    /// First N lines of stderr, kept for the JSON report so a human can
+    /// see what broke without re-running cargo by hand.
+    pub stderr_excerpt: String,
+}
+
+impl CheckOutcome {
+    pub fn passed(&self) -> bool { self.exit_code == 0 }
+}
+
+/// Determine which workspace owns `target_file_rel` (a path relative to
+/// the repo root) and run `cargo check --all-targets` in that workspace.
+/// `sandbox_root` is the absolute path to the worktree.
+pub fn check(
+    sandbox_root: &Path,
+    target_file_rel: &Path,
+) -> Result<CheckOutcome, String> {
+    let ws = workspace_for(target_file_rel)
+        .ok_or_else(|| format!("no workspace mapped for {}", target_file_rel.display()))?;
+    let ws_dir: PathBuf = sandbox_root.join(&ws);
+    let cargo_args = cargo_args_for(&ws);
+
+    let t0 = Instant::now();
+    let out = Command::new("cargo")
+        .current_dir(&ws_dir)
+        .args(&cargo_args)
+        .output()
+        .map_err(|e| format!("spawn cargo: {e}"))?;
+    let elapsed = t0.elapsed();
+
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let (error_count, warning_count) = count_diagnostics(&stderr);
+    let excerpt = diagnostic_excerpt(&stderr);
+    let exit_code = out.status.code().unwrap_or(-1);
+
+    Ok(CheckOutcome {
+        workspace: ws,
+        exit_code,
+        elapsed,
+        error_count,
+        warning_count,
+        stderr_excerpt: excerpt,
+    })
+}
+
+/// Map a repo-relative file path to the workspace root that should be
+/// the cargo-check cwd. Returns `None` for paths outside known workspaces
+/// (top-level scripts, screenshots, etc).
+pub fn workspace_for(path: &Path) -> Option<String> {
+    let p = path.to_string_lossy().replace('\\', "/");
+
+    // Known workspace roots, longest prefix first so nested paths resolve
+    // correctly (e.g. tools/folkering-codegraph beats tools).
+    const WORKSPACES: &[&str] = &[
+        "tools/draug-eval-runner",
+        "tools/folkering-codegraph",
+        "tools/a64-encoder",
+        "tools/a64-streamer",
+        "tools/folk-pack",
+        "tools/fbp-rs",
+        "tools/proxy",
+        "kernel",
+        "userspace",
+    ];
+
+    WORKSPACES.iter()
+        .find(|root| p.starts_with(&format!("{root}/")))
+        .map(|s| (*s).to_string())
+}
+
+/// Pick cargo args appropriate for the workspace. The kernel + userspace
+/// crates are `#![no_std]` and `--all-targets` would try to compile tests
+/// against the missing `test` crate (E0463). Host-side tool crates (a64-
+/// encoder etc.) have real tests + examples and benefit from --all-targets
+/// to also catch caller breakage in `examples/`.
+fn cargo_args_for(workspace: &str) -> Vec<&'static str> {
+    let no_std_workspaces = ["kernel", "userspace"];
+    if no_std_workspaces.contains(&workspace) {
+        vec!["check"]
+    } else {
+        vec!["check", "--all-targets"]
+    }
+}
+
+fn count_diagnostics(stderr: &str) -> (u32, u32) {
+    let mut errors = 0;
+    let mut warnings = 0;
+    for line in stderr.lines() {
+        if line.starts_with("error[") || line.starts_with("error:") || line == "error" {
+            errors += 1;
+        } else if line.starts_with("warning[") || line.starts_with("warning:") {
+            warnings += 1;
+        }
+    }
+    (errors, warnings)
+}
+
+fn head(s: &str, n: usize) -> String {
+    s.lines().take(n).collect::<Vec<_>>().join("\n")
+}
+
+/// Pull just the diagnostic-relevant lines out of cargo's stderr.
+/// Cargo emits hundreds of `Compiling foo`/`Downloading bar` progress
+/// lines before the actual errors; a head-of-file excerpt typically
+/// misses every error. We instead capture each `error[…]:` /
+/// `warning[…]:` block plus its immediate context (the indented `-->`
+/// pointer, source code preview, and `note:`/`help:` follow-ups), up
+/// to a cap that keeps the JSON report readable.
+fn diagnostic_excerpt(stderr: &str) -> String {
+    const MAX_LINES: usize = 120;
+    let mut out: Vec<&str> = Vec::new();
+    let mut in_block = false;
+
+    for line in stderr.lines() {
+        let starts_diag = line.starts_with("error[")
+            || line.starts_with("error:")
+            || line.starts_with("warning[")
+            || line.starts_with("warning:");
+
+        if starts_diag {
+            in_block = true;
+            out.push(line);
+            if out.len() >= MAX_LINES { break; }
+            continue;
+        }
+
+        if in_block {
+            // Continue capturing while the block's body is still going:
+            // - `   -->`/`   |` source pointers (indented + leading space)
+            // - `note:`/`help:` follow-ups
+            // - blank lines (block separators)
+            let trimmed = line.trim_start();
+            let is_continuation = trimmed.starts_with("-->")
+                || trimmed.starts_with("|")
+                || trimmed.starts_with("=")
+                || trimmed.starts_with("note:")
+                || trimmed.starts_with("help:")
+                || line.is_empty();
+            if is_continuation {
+                out.push(line);
+                if out.len() >= MAX_LINES { break; }
+            } else {
+                in_block = false;
+            }
+        }
+    }
+
+    if out.is_empty() {
+        // Fall back to the tail — when cargo aborts before any
+        // diagnostic, the actual reason is usually in the last lines.
+        return stderr.lines().rev().take(40)
+            .collect::<Vec<_>>().into_iter().rev()
+            .collect::<Vec<_>>().join("\n");
+    }
+    out.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_for_kernel_path() {
+        assert_eq!(
+            workspace_for(Path::new("kernel/src/memory/physical.rs")),
+            Some("kernel".to_string()),
+        );
+    }
+
+    #[test]
+    fn workspace_for_a64_encoder_paths() {
+        assert_eq!(
+            workspace_for(Path::new("tools/a64-encoder/src/wasm_lower/stack.rs")),
+            Some("tools/a64-encoder".to_string()),
+        );
+        assert_eq!(
+            workspace_for(Path::new("tools/a64-encoder/examples/bench_mlp_ablation.rs")),
+            Some("tools/a64-encoder".to_string()),
+        );
+    }
+
+    #[test]
+    fn workspace_for_userspace_path() {
+        assert_eq!(
+            workspace_for(Path::new("userspace/compositor/src/main.rs")),
+            Some("userspace".to_string()),
+        );
+    }
+
+    #[test]
+    fn workspace_for_unknown_path_returns_none() {
+        assert_eq!(workspace_for(Path::new("README.md")), None);
+        assert_eq!(workspace_for(Path::new("screenshots/x.png")), None);
+    }
+
+    #[test]
+    fn workspace_for_handles_windows_separators() {
+        assert_eq!(
+            workspace_for(Path::new(r"kernel\src\memory\physical.rs")),
+            Some("kernel".to_string()),
+        );
+    }
+
+    #[test]
+    fn count_diagnostics_recognises_error_and_warning_lines() {
+        let stderr = "\
+warning: unused variable
+error[E0308]: mismatched types
+note: required by ...
+warning: dead_code
+error: aborting due to 1 previous error
+";
+        let (errs, warns) = count_diagnostics(stderr);
+        assert_eq!(errs, 2);
+        assert_eq!(warns, 2);
+    }
+}

--- a/tools/draug-eval-runner/src/main.rs
+++ b/tools/draug-eval-runner/src/main.rs
@@ -20,8 +20,11 @@
 //! compat scoring) is Phase 2B, deferred to its own PR. This crate's
 //! README documents the full plan.
 
+mod apply;
+mod cargo_check;
 mod prompt;
 mod proxy;
+mod sandbox;
 mod source_extract;
 
 use serde::Deserialize;
@@ -106,9 +109,11 @@ fn main() -> ExitCode {
 
     let cmd = subcommand.as_deref().unwrap_or("verify");
     match cmd {
-        "verify" => cmd_verify(&g),
+        "verify"   => cmd_verify(&g),
         "prompt"   => cmd_prompt(&g, &subcommand_args),
         "refactor" => cmd_refactor(&g, &subcommand_args),
+        "score"    => cmd_score(&g, &subcommand_args),
+        "eval"     => cmd_eval(&g, &subcommand_args),
         other => {
             eprintln!("unknown subcommand: {other}");
             print_help();
@@ -136,6 +141,8 @@ fn print_help() -> ExitCode {
     println!("  verify                  Verify CSR against frozen task fixtures (default)");
     println!("  prompt <task-id>        Build refactor prompt → output/<id>/prompt.md");
     println!("  refactor <task-id>      Build prompt + LLM call → output/<id>/refactor.md");
+    println!("  score <task-id>         Apply existing refactor.md to sandbox + cargo check");
+    println!("  eval [task-id|--all]    Refactor + score in one go; --all runs every task");
     println!();
     println!("GLOBAL FLAGS:");
     println!("  --tasks PATH            tasks.toml location");
@@ -375,6 +382,197 @@ fn cmd_refactor(g: &GlobalArgs, args: &[String]) -> ExitCode {
         println!("[refactor] WARNING: no ```rust block extracted — check response.txt");
     }
     ExitCode::SUCCESS
+}
+
+// ── score ───────────────────────────────────────────────────────────
+
+fn cmd_score(g: &GlobalArgs, args: &[String]) -> ExitCode {
+    let task_id = match args.first() {
+        Some(s) => s.clone(),
+        None => {
+            eprintln!("score: needs <task-id>");
+            return ExitCode::from(2);
+        }
+    };
+    let tasks = match load_tasks(&g.tasks_path) { Ok(t) => t, Err(c) => return c };
+    let task = match tasks.task.iter().find(|t| t.id == task_id) {
+        Some(t) => t,
+        None => {
+            eprintln!("score: task '{task_id}' not in {}", g.tasks_path.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    // Pull the previously-saved refactor.md and re-extract its rust block.
+    let task_out = g.output_dir.join(&task.id);
+    let refactor_path = task_out.join("refactor.md");
+    let refactor_md = match std::fs::read_to_string(&refactor_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("score: read {}: {e}\n  did you run `draug-eval refactor {task_id}` first?",
+                refactor_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let patch_code = match extract_rust_code_block(&refactor_md) {
+        Some(s) => s,
+        None => {
+            eprintln!("score: no ```rust block in {} — refactor produced no usable patch",
+                refactor_path.display());
+            return ExitCode::from(1);
+        }
+    };
+
+    score_one(g, task, &patch_code)
+}
+
+fn score_one(g: &GlobalArgs, task: &Task, patch_code: &str) -> ExitCode {
+    let task_out = g.output_dir.join(&task.id);
+    let _ = std::fs::create_dir_all(&task_out);
+
+    println!("[score] task={} patch_bytes={}", task.id, patch_code.len());
+
+    // (1) Spin up / reset the sandbox worktree.
+    println!("[score] preparing sandbox ...");
+    let sandbox = match sandbox::Sandbox::prepare(
+        &g.root_path,
+        Path::new("tools/draug-eval-runner/sandbox"),
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("score: sandbox prepare failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // (2) Apply the patch in the sandbox.
+    let target_rel = Path::new(&task.target_file);
+    let target_abs = sandbox.inside(target_rel);
+    let applied = match apply::apply(&target_abs, &task.target_fn, patch_code) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("score: apply failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if let Err(e) = std::fs::write(&target_abs, &applied.patched) {
+        eprintln!("score: write {}: {e}", target_abs.display());
+        return ExitCode::from(2);
+    }
+    println!("[score] applied: {:?} (lines {}–{})",
+        applied.strategy, applied.start_line, applied.end_line);
+
+    // (3) Run cargo check in the workspace that owns this file.
+    let outcome = match cargo_check::check(&sandbox.path, target_rel) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("score: cargo check failed to launch: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    println!(
+        "[score] cargo check: workspace={} exit={} errors={} warnings={} elapsed={:.1}s",
+        outcome.workspace, outcome.exit_code, outcome.error_count,
+        outcome.warning_count, outcome.elapsed.as_secs_f32(),
+    );
+
+    // (4) Restore the file so the sandbox is clean for the next task.
+    let _ = sandbox.restore(target_rel);
+
+    // (5) Write a JSON report so future tooling can aggregate.
+    let report = TaskReport {
+        task_id: task.id.clone(),
+        target_fn: task.target_fn.clone(),
+        target_file: task.target_file.clone(),
+        patch_strategy: format!("{:?}", applied.strategy).to_lowercase(),
+        patch_chars: patch_code.len(),
+        cargo_check: CargoReport {
+            workspace: outcome.workspace.clone(),
+            exit_code: outcome.exit_code,
+            error_count: outcome.error_count,
+            warning_count: outcome.warning_count,
+            elapsed_secs: outcome.elapsed.as_secs_f32(),
+            stderr_excerpt: outcome.stderr_excerpt.clone(),
+        },
+        verdict: if outcome.passed() { "PASS".into() } else { "FAIL".into() },
+    };
+    let json = serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".into());
+    let json_path = task_out.join("score.json");
+    if let Err(e) = std::fs::write(&json_path, &json) {
+        eprintln!("score: write {}: {e}", json_path.display());
+    } else {
+        println!("[score] report → {}", json_path.display());
+    }
+
+    println!("[score] verdict: {}", report.verdict);
+    if outcome.passed() { ExitCode::SUCCESS } else { ExitCode::from(1) }
+}
+
+// ── eval ────────────────────────────────────────────────────────────
+
+fn cmd_eval(g: &GlobalArgs, args: &[String]) -> ExitCode {
+    let tasks = match load_tasks(&g.tasks_path) { Ok(t) => t, Err(c) => return c };
+    let want_all = args.iter().any(|a| a == "--all");
+    let single_id = args.iter().find(|a| !a.starts_with("--")).cloned();
+
+    let chosen: Vec<&Task> = if want_all {
+        tasks.task.iter().collect()
+    } else if let Some(id) = single_id {
+        match tasks.task.iter().find(|t| t.id == id) {
+            Some(t) => vec![t],
+            None => {
+                eprintln!("eval: task '{id}' not in {}", g.tasks_path.display());
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        eprintln!("eval: needs <task-id> or --all");
+        return ExitCode::from(2);
+    };
+
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut skipped = 0;
+    for task in &chosen {
+        println!("\n=== eval: {} ===", task.id);
+        // Re-run refactor to get fresh LLM output.
+        let rc = cmd_refactor(g, &[task.id.clone()]);
+        if rc != ExitCode::SUCCESS {
+            eprintln!("[eval] {} refactor step failed — skipping score", task.id);
+            skipped += 1;
+            continue;
+        }
+        let rc = cmd_score(g, &[task.id.clone()]);
+        if rc == ExitCode::SUCCESS { passed += 1; }
+        else if rc == ExitCode::from(1) { failed += 1; }
+        else { skipped += 1; }
+    }
+
+    println!("\n[eval] summary: {passed} pass, {failed} fail, {skipped} skipped");
+    if failed > 0 || skipped > 0 { ExitCode::from(1) } else { ExitCode::SUCCESS }
+}
+
+// ── JSON report shapes ──────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct TaskReport {
+    task_id: String,
+    target_fn: String,
+    target_file: String,
+    patch_strategy: String,
+    patch_chars: usize,
+    cargo_check: CargoReport,
+    verdict: String,
+}
+
+#[derive(serde::Serialize)]
+struct CargoReport {
+    workspace: String,
+    exit_code: i32,
+    error_count: u32,
+    warning_count: u32,
+    elapsed_secs: f32,
+    stderr_excerpt: String,
 }
 
 /// Pull the first ```rust ... ``` fenced block out of an LLM response.

--- a/tools/draug-eval-runner/src/sandbox.rs
+++ b/tools/draug-eval-runner/src/sandbox.rs
@@ -1,0 +1,181 @@
+//! Persistent sandbox managed as a git worktree.
+//!
+//! Why a worktree:
+//!   - Shares `.git` with the main repo so `git archive` / clone of the
+//!     full source isn't needed (saves disk + time).
+//!   - Has its own working tree + its own `target/` dir, so cargo
+//!     incremental compilation works normally without contaminating
+//!     the main repo's build cache.
+//!   - Trivial to reset between runs: `git checkout -- .`
+//!
+//! The sandbox lives at `tools/draug-eval-runner/sandbox/` and is
+//! gitignored. First call to [`prepare`] creates it; subsequent calls
+//! reset any uncommitted changes (so the previous task's patch doesn't
+//! contaminate the next task's evaluation).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug)]
+pub enum SandboxError {
+    Io(std::io::Error),
+    Git { cmd: String, stderr: String },
+    NotInRepo,
+}
+
+impl std::fmt::Display for SandboxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SandboxError::Io(e) => write!(f, "io: {e}"),
+            SandboxError::Git { cmd, stderr } =>
+                write!(f, "git {cmd}: {}", stderr.trim()),
+            SandboxError::NotInRepo => write!(f, "not inside a git repository"),
+        }
+    }
+}
+
+impl std::error::Error for SandboxError {}
+
+#[derive(Debug)]
+pub struct Sandbox {
+    pub path: PathBuf,
+    repo_root: PathBuf,
+}
+
+impl Sandbox {
+    /// Prepare the sandbox at `<repo_root>/<rel_path>`. Creates the
+    /// worktree if missing, otherwise resets it to a clean HEAD.
+    ///
+    /// `rel_path` should be a path relative to `repo_root`, e.g.
+    /// `tools/draug-eval-runner/sandbox`.
+    pub fn prepare(repo_root: &Path, rel_path: &Path) -> Result<Self, SandboxError> {
+        // Don't canonicalize on Windows — that adds a `\\?\` extended-path
+        // prefix that breaks `git worktree add`. The path stays relative-ish
+        // (whatever the caller passed); git is happy with that.
+        let repo_root = repo_root.to_path_buf();
+        let abs_path = repo_root.join(rel_path);
+
+        if !is_inside_repo(&repo_root)? {
+            return Err(SandboxError::NotInRepo);
+        }
+
+        if abs_path.join(".git").exists() {
+            // Existing worktree — reset state.
+            run_git(&abs_path, &["reset", "--hard", "HEAD"])?;
+            run_git(&abs_path, &["clean", "-fd"])?;
+        } else {
+            // Need to create it. `git worktree add` requires a branch
+            // or commit ref; use the current HEAD detached so we don't
+            // tie up a branch name.
+            run_git(&repo_root, &["worktree", "add", "--detach",
+                abs_path.to_str().expect("UTF-8 path"), "HEAD"])?;
+        }
+
+        Ok(Sandbox { path: abs_path, repo_root })
+    }
+
+    /// Return the absolute path inside the sandbox for a repo-relative
+    /// path. e.g. `inside("kernel/src/lib.rs")` → `<sandbox>/kernel/src/lib.rs`.
+    pub fn inside(&self, rel: impl AsRef<Path>) -> PathBuf {
+        self.path.join(rel.as_ref())
+    }
+
+    /// Restore a single file inside the sandbox to its committed state.
+    /// Useful between tasks if you don't want a full reset.
+    pub fn restore(&self, rel: &Path) -> Result<(), SandboxError> {
+        run_git(&self.path, &["checkout", "HEAD", "--",
+            rel.to_str().expect("UTF-8 path")])?;
+        Ok(())
+    }
+
+    /// Bring the sandbox up to date with the main repo's HEAD. Use this
+    /// when the main repo has new commits the sandbox should see.
+    #[allow(dead_code)] // not yet used; will matter for the eval batch CLI
+    pub fn fast_forward(&self) -> Result<(), SandboxError> {
+        // Fetch from the main repo's HEAD via the shared object store.
+        run_git(&self.path, &["fetch"])?;
+        run_git(&self.path, &["reset", "--hard",
+            "refs/remotes/origin/HEAD"])?;
+        Ok(())
+    }
+}
+
+fn is_inside_repo(path: &Path) -> Result<bool, SandboxError> {
+    let out = Command::new("git")
+        .arg("-C").arg(path)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map_err(SandboxError::Io)?;
+    Ok(out.status.success())
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<String, SandboxError> {
+    let out = Command::new("git")
+        .arg("-C").arg(cwd)
+        .args(args)
+        .output()
+        .map_err(SandboxError::Io)?;
+    if !out.status.success() {
+        return Err(SandboxError::Git {
+            cmd: args.join(" "),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test the worktree creation against the live repo. Runs
+    /// `prepare` against a temp subdir; cleans up at the end.
+    ///
+    /// Marked `#[ignore]` because it shares the parent repo's worktree
+    /// list with the production sandbox at `tools/draug-eval-runner/
+    /// sandbox/` and racing the live `score` subcommand confuses git.
+    /// Run explicitly with `cargo test --release sandbox -- --ignored`
+    /// when there's no concurrent `score` in flight. End-to-end
+    /// verification of this module lives in the live `score`
+    /// invocation, which also exercises `prepare` + `restore`.
+    #[test]
+    #[ignore]
+    fn prepare_creates_worktree_and_can_reset() {
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap().parent().unwrap().to_path_buf();
+
+        // Use a unique subdir per test to avoid stomping concurrent runs.
+        let unique = format!("sandbox-test-{}", std::process::id());
+        let rel = PathBuf::from("tools/draug-eval-runner/target/test-tmp")
+            .join(&unique);
+
+        let sandbox = match Sandbox::prepare(&repo_root, &rel) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[skip] sandbox prepare failed (expected on shallow clones): {e}");
+                return;
+            }
+        };
+
+        // The sandbox should contain Cargo.toml at root.
+        assert!(sandbox.path.join("Cargo.toml").exists(),
+            "worktree should mirror repo root");
+
+        // Modify a file then restore it.
+        let probe_rel = Path::new("tools/draug-eval-runner/tasks.toml");
+        let probe = sandbox.inside(probe_rel);
+        let original = std::fs::read_to_string(&probe).unwrap();
+        std::fs::write(&probe, "DIRTY").unwrap();
+        assert_ne!(std::fs::read_to_string(&probe).unwrap(), original);
+
+        sandbox.restore(probe_rel).expect("restore");
+        assert_eq!(std::fs::read_to_string(&probe).unwrap(), original);
+
+        // Tear down the worktree so we don't leave a stale dir lying
+        // around. Best-effort — failures here aren't test failures.
+        let _ = run_git(&repo_root, &[
+            "worktree", "remove", "--force",
+            sandbox.path.to_str().unwrap(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the eval loop. PR #41 produced refactor.md from CodeGraph-fed LLM prompts; this PR applies that patch to a sandboxed copy of the monorepo, runs cargo check, and writes a verdict.

**The headline metric this whole step was about — does the LLM patch compile + keep callers compiling — now has a number behind it.**

## What lands

| Module | Role |
|---|---|
| \`apply.rs\` | Splices LLM patch into target file. Auto-detects \`Replace\` (patch contains \`fn <name>\`) vs \`Append\` (alongside in same impl block). Indent-preserving. |
| \`sandbox.rs\` | Persistent git worktree at \`sandbox/\`. Shares .git with main repo, own target/. Reset-to-HEAD between runs. |
| \`cargo_check.rs\` | Path-prefix workspace detection. Per-workspace cargo args (no_std workspaces skip \`--all-targets\` to dodge E0463 \"can't find crate for test\"). Diagnostic-only stderr excerpt. |
| \`score <id>\` | Apply existing refactor.md → cargo check → JSON verdict at \`output/<id>/score.json\`. |
| \`eval <id>\` / \`eval --all\` | Refactor + score in one go. |

## Live verification (headline metric, real numbers)

\`\`\`
$ draug-eval refactor 03_alloc_pages          # 46s, qwen2.5-coder:7b
$ draug-eval score 03_alloc_pages
[score] task=03_alloc_pages patch_bytes=1054
[score] preparing sandbox ...
[score] applied: Replace (lines 380–418)
[score] cargo check: workspace=kernel exit=101 errors=3 warnings=53 elapsed=1.9s
[score] report → tools/draug-eval-runner/output/03_alloc_pages/score.json
[score] verdict: FAIL
\`\`\`

**Cold sandbox build was 43s; warm rerun was 1.9s.** The 3 errors were all in physical.rs — including \`E0308 mismatched types\` at the callers, which is exactly the caller-compat signal CodeGraph integration is supposed to enable measuring. **The harness caught it.**

\`FAIL\` on this task is honest: the 7b coder produced a refactor whose signature didn't match its callers. A bigger model + tighter prompt is the experimental knob. We can now measure that.

## JSON report (for downstream aggregation)

\`\`\`json
{
  \"task_id\": \"03_alloc_pages\",
  \"target_fn\": \"alloc_pages\",
  \"target_file\": \"kernel/src/memory/physical.rs\",
  \"patch_strategy\": \"replace\",
  \"patch_chars\": 1054,
  \"cargo_check\": {
    \"workspace\": \"kernel\",
    \"exit_code\": 101,
    \"error_count\": 3,
    \"warning_count\": 53,
    \"elapsed_secs\": 1.9,
    \"stderr_excerpt\": \"...\"
  },
  \"verdict\": \"FAIL\"
}
\`\`\`

## Test plan

- [x] \`cargo build --release\`: clean
- [x] \`cargo test --release\`: 23 pass, 1 ignored (live sandbox test races production sandbox; live \`score\` exercises the same code path)
- [x] End-to-end \`score 03_alloc_pages\` against running proxy + real cargo check
- [x] Cold build: 43s, warm rerun: 1.9s, excerpt shows real diagnostics

## What this doesn't do (deferred)

- Pre-LLM caller-compat smoke: apply the original fn unchanged → cargo check should pass. If it doesn't, our sandbox or workspace detection is wrong, not the LLM. Worth adding as a baseline.
- Aggregating multiple eval runs across models / prompts. JSON shape is ready; aggregation tool isn't.