### PR TITLE
feat(draug-eval): position experiment — disproves goal-dilution, expo…

### DIFF
--- a/tools/draug-eval-runner/position-experiment-001.md
+++ b/tools/draug-eval-runner/position-experiment-001.md
@@ -1,0 +1,114 @@
+# Position experiment 001 — does callers-at-end rescue gemma4?
+
+**Date:** 2026-04-28
+**Hypothesis:** The cross-model trial showed gemma4:31b-cloud
+performing -10.5 pp worse with the CodeGraph caller list in the
+prompt. One explanation was **goal dilution** — the long caller
+list crowds the goal text out of the model's effective attention.
+Moving callers to the bottom of the prompt should keep goal +
+constraints adjacent and rescue pass-rate.
+
+**Verdict: hypothesis not supported. But the data tells us something
+more important.**
+
+## Per-condition pass-rates (gemma4:31b-cloud, N=3 each)
+
+| Position | with-CG | no-CG | within-batch diff |
+|---|:-:|:-:|:-:|
+| top    (original)         | 7/15 (46.7%) | 8/14 (57.1%) | -10.4 pp |
+| bottom (this experiment)  | 6/15 (40.0%) | 6/15 (40.0%) | **0.0 pp** |
+
+Two things to notice:
+
+1. **Bottom-position cg vs nocg gap collapsed to 0** — neither
+   position is "better". With callers at the bottom, the prompts
+   converge to the same pass rate.
+
+2. **The no-CG number itself dropped** from 57% (top batch) to
+   40% (bottom batch) **on identical prompts** — no-CG never had
+   a caller list to position. **That's the smoking gun: cloud
+   variance is bigger than the position effect.**
+
+## Per-task
+
+| Task | cg-top | cg-bottom | nocg-top | nocg-bottom |
+|---|:-:|:-:|:-:|:-:|
+| 01_pop_i32_slot       | 3/3 | 3/3 | 3/3 | 3/3 |
+| 02_maybe_bounds_check | 0/3 | 0/3 | 0/3 | 0/3 |
+| 03_alloc_pages        | 1/3 | 0/3 | **2/3** | **0/3** |
+| 04_compile_module     | 0/3 | 0/3 | 0/2 | 0/3 |
+| 05_push_dec           | 3/3 | 3/3 | 3/3 | 3/3 |
+
+Task 03 is the entire show. nocg-top (2/3) → nocg-bottom (0/3) on
+**identical prompts** is the cleanest evidence: cloud-routed gemma4
+gives different answers across batches, regardless of prompt content.
+
+## What this means for the cross-model headline
+
+The PR #43 headline was:
+
+> qwen2.5-coder:7b: +20 pp from CG.
+> gemma4:31b-cloud: -10.5 pp from CG.
+
+The **direction** of the qwen result is well-replicated (3 single-shot
+pilots + N=3 trial all show ≥ +20 pp). The 7b was tested locally
+where temperature is 0 by default, so seed-to-seed variance is small.
+
+The **gemma4 -10.5 pp** number was N=3 in a single cloud session.
+This experiment ran another N=3 cloud session of the same prompt
+(no-CG) and got 40% instead of 57% — a 17 pp swing on **identical
+inputs**. That makes any g4 effect smaller than 17 pp impossible
+to distinguish from session noise at N=3.
+
+So the honest revised reading:
+
+- **For 7b: CG context helps**, +20 pp, well-replicated.
+- **For gemma4: we don't know.** N=3 isn't enough to see past
+  cloud variance. The original -10.5 pp could be entirely session
+  noise.
+
+## What we actually learned
+
+This is a methodological finding more than a scientific one:
+
+1. **Cloud-routed models need either fixed seed OR N≫3** to
+   produce comparable measurements. The eval harness currently has
+   neither knob.
+
+2. **Goal dilution is not the explanation** for whatever happens
+   on g4. Moving the callers to bottom didn't differentiate cg
+   from nocg either way.
+
+3. **The 7b vs g4 comparison from PR #43 needs the caveat**
+   strengthened. "Bigger model collapses the CG advantage" is
+   plausible from the data — but **gemma4 may not actually be
+   harmed by CG**, just less helped. We can't tell from N=3.
+
+4. **The infrastructure is fine**, the trial is robust, the
+   aggregator does what it says. We have a measurement rig; we
+   don't have enough power for finely-grained cloud claims yet.
+
+## What would actually settle this
+
+1. **N=10 gemma4** at top-position cg vs nocg, run in a single
+   continuous batch so cloud session conditions are matched.
+   ~1.5 hour wall.
+2. **Set Ollama temperature=0** for both local and cloud routes
+   in the proxy LLM endpoint, so seed-to-seed variance shrinks.
+   This is a 5-line patch.
+3. **Per-batch baseline run**: every position/prompt experiment
+   should also include an unchanged baseline arm in the same
+   batch. Cross-session comparisons aren't safe.
+
+## Reproducibility
+
+```sh
+# Original cross-model trial (top-position):
+tools/draug-eval-runner/run-trials.sh 3 gemma4:31b-cloud g4 top
+# This experiment (bottom-position):
+tools/draug-eval-runner/run-trials.sh 3 gemma4:31b-cloud g4end bottom
+```
+
+All 12 g4 trials are in `output-{cg,nocg}-{g4,g4end}-r{1,2,3}/`
+with `model=gemma4:31b-cloud` and `callers_position={top,bottom}`
+in their score.json so any future re-analysis can segment cleanly.

--- a/tools/draug-eval-runner/run-trials.sh
+++ b/tools/draug-eval-runner/run-trials.sh
@@ -25,6 +25,7 @@ set -uo pipefail
 N="${1:-3}"
 MODEL="${2:-qwen2.5-coder:7b}"
 LABEL="${3:-}"
+POSITION="${4:-top}"   # "top" (default) or "bottom" — adds --callers-at-end
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 BIN="$ROOT/tools/draug-eval-runner/target/release/draug-eval.exe"
 
@@ -75,14 +76,19 @@ run_trial() {
         return 0
     fi
 
+    local pos_flag=()
+    if [[ "$POSITION" == "bottom" ]]; then
+        pos_flag=(--callers-at-end)
+    fi
+
     if [[ -n "$extra_flag" ]]; then
-        "$BIN" "$extra_flag" --model "$MODEL" --output "$out" eval --all
+        "$BIN" "$extra_flag" "${pos_flag[@]}" --model "$MODEL" --output "$out" eval --all
     else
-        "$BIN" --model "$MODEL" --output "$out" eval --all
+        "$BIN" "${pos_flag[@]}" --model "$MODEL" --output "$out" eval --all
     fi
 }
 
-echo "[run-trials] N=$N MODEL=$MODEL LABEL=${LABEL:-<none>}"
+echo "[run-trials] N=$N MODEL=$MODEL LABEL=${LABEL:-<none>} POSITION=$POSITION"
 
 for i in $(seq 1 "$N"); do
     run_trial "cg"   ""               "$i"

--- a/tools/draug-eval-runner/src/main.rs
+++ b/tools/draug-eval-runner/src/main.rs
@@ -63,6 +63,10 @@ struct GlobalArgs {
     /// Used by ablation runs to measure whether feeding the call-graph
     /// to the LLM actually improves refactor quality.
     no_codegraph: bool,
+    /// When true, place the caller list AFTER the original source
+    /// instead of before. Tests the "goal-dilution" hypothesis from
+    /// the cross-model trial.
+    callers_at_end: bool,
 }
 
 impl GlobalArgs {
@@ -75,6 +79,7 @@ impl GlobalArgs {
             proxy_port: proxy::DEFAULT_PORT,
             llm_model: "qwen2.5-coder:7b".to_string(),
             no_codegraph: false,
+            callers_at_end: false,
         }
     }
 }
@@ -103,6 +108,7 @@ fn main() -> ExitCode {
             }
             "--model" => { g.llm_model = next_or_die(&raw_args, &mut i, "--model"); }
             "--no-codegraph" => { g.no_codegraph = true; }
+            "--callers-at-end" => { g.callers_at_end = true; }
             other if subcommand.is_none() => {
                 subcommand = Some(other.to_string());
             }
@@ -158,6 +164,7 @@ fn print_help() -> ExitCode {
     println!("  --proxy-port PORT       (default 14711)");
     println!("  --model NAME            LLM model name (default qwen2.5-coder:7b)");
     println!("  --no-codegraph          Redact caller list from the LLM prompt (ablation)");
+    println!("  --callers-at-end        Place caller list AFTER source instead of before");
     ExitCode::SUCCESS
 }
 
@@ -237,6 +244,11 @@ fn cmd_prompt(g: &GlobalArgs, args: &[String]) -> ExitCode {
         target_file: &target_file,
         graph: &graph,
         include_callers: !g.no_codegraph,
+        callers_position: if g.callers_at_end {
+            prompt::CallersPosition::Bottom
+        } else {
+            prompt::CallersPosition::Top
+        },
     };
     let built = match prompt::build(&input) {
         Ok(b) => b,
@@ -297,6 +309,11 @@ fn cmd_refactor(g: &GlobalArgs, args: &[String]) -> ExitCode {
         target_file: &target_file,
         graph: &graph,
         include_callers: !g.no_codegraph,
+        callers_position: if g.callers_at_end {
+            prompt::CallersPosition::Bottom
+        } else {
+            prompt::CallersPosition::Top
+        },
     };
     let built = match prompt::build(&input) {
         Ok(b) => b,
@@ -497,6 +514,7 @@ fn score_one(g: &GlobalArgs, task: &Task, patch_code: &str) -> ExitCode {
         patch_chars: patch_code.len(),
         codegraph_in_prompt: !g.no_codegraph,
         model: g.llm_model.clone(),
+        callers_position: if g.callers_at_end { "bottom".into() } else { "top".into() },
         cargo_check: CargoReport {
             workspace: outcome.workspace.clone(),
             exit_code: outcome.exit_code,
@@ -582,6 +600,10 @@ struct TaskReport {
     /// the aggregator can compare across models without inferring
     /// from output dir names.
     model: String,
+    /// "top" or "bottom" — where the blast-radius caller list lived
+    /// in the prompt for this run. "top" matches the historic shape;
+    /// "bottom" is the goal-dilution-hypothesis variant.
+    callers_position: String,
     cargo_check: CargoReport,
     verdict: String,
 }

--- a/tools/draug-eval-runner/src/prompt.rs
+++ b/tools/draug-eval-runner/src/prompt.rs
@@ -22,6 +22,27 @@ use std::path::Path;
 
 use crate::source_extract::{self, ExtractError};
 
+/// Where the "Blast radius — callers" section appears relative to
+/// the original source. Default `Top` matches the historic prompt
+/// shape and is what the N=3 + cross-model trials measured.
+/// `Bottom` is the position-experiment variant.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CallersPosition {
+    /// Goal → Blast radius → Constraints → Original source
+    Top,
+    /// Goal → Constraints → Original source → Blast radius
+    Bottom,
+}
+
+impl CallersPosition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CallersPosition::Top => "top",
+            CallersPosition::Bottom => "bottom",
+        }
+    }
+}
+
 /// Inputs needed to build a refactor prompt for one task.
 pub struct RefactorPromptInput<'a> {
     pub task_id: &'a str,
@@ -37,6 +58,12 @@ pub struct RefactorPromptInput<'a> {
     /// measure whether feeding the caller list to the LLM actually
     /// improves refactor quality, or whether the model ignores it.
     pub include_callers: bool,
+    /// Where the caller list appears in the prompt. Tests the
+    /// "goal-dilution" hypothesis from the cross-model trial: did
+    /// gemma4:31b-cloud lose pass-rate because the long caller list
+    /// crowded the goal text, or for some other reason? Bottom-
+    /// position keeps goal + constraints adjacent.
+    pub callers_position: CallersPosition,
 }
 
 #[derive(Debug)]
@@ -120,45 +147,44 @@ pub fn build(input: &RefactorPromptInput<'_>) -> Result<BuiltPrompt, PromptError
     md.push_str(&extracted.end_line.to_string());
     md.push_str(")\n\n");
 
-    if input.include_callers {
-        md.push_str("## Blast radius — callers from the static call-graph\n\n");
-        md.push_str(&caller_count.to_string());
-        md.push_str(" caller(s) across ");
-        md.push_str(&caller_files.len().to_string());
-        md.push_str(" file(s):\n\n");
-        for c in &caller_lines {
-            md.push_str("- `");
-            md.push_str(c);
-            md.push_str("`\n");
-        }
-        md.push('\n');
-    } else {
-        // Ablation mode: no blast-radius section. We still know the
-        // count (from CSR) and surface it as a single number so the
-        // post-hoc analysis can see whether the model used the absence
-        // as a signal to take more risks. Caller-files are still
-        // returned in BuiltPrompt for downstream tooling.
-        md.push_str("## Blast radius\n\n");
-        md.push_str("(call-graph context redacted for this ablation run)\n\n");
-    }
-
-    md.push_str("## Constraints\n\n");
-    md.push_str(
-        "- Preserve the public signature of the target fn unless the goal \
-        explicitly authorizes changing it. If you must change it, list \
-        every caller you would need to update, file by file.\n\
-        - Don't introduce new external dependencies.\n\
-        - Match the existing surrounding style (no_std discipline, error \
-        types, lifetime patterns).\n\
-        - Output only the refactored function inside a single fenced \
-        ```rust block. No prose outside the block, no `// Before:`/`// After:` \
-        comments, no diff format.\n\n",
+    let blast_section = build_blast_section(
+        input.include_callers, caller_count, &caller_files, &caller_lines,
     );
 
-    md.push_str("## Original source\n\n```rust\n");
-    md.push_str(&extracted.source);
-    if !extracted.source.ends_with('\n') { md.push('\n'); }
-    md.push_str("```\n");
+    let constraints_section: &str =
+        "## Constraints\n\n\
+         - Preserve the public signature of the target fn unless the goal \
+         explicitly authorizes changing it. If you must change it, list \
+         every caller you would need to update, file by file.\n\
+         - Don't introduce new external dependencies.\n\
+         - Match the existing surrounding style (no_std discipline, error \
+         types, lifetime patterns).\n\
+         - Output only the refactored function inside a single fenced \
+         ```rust block. No prose outside the block, no `// Before:`/`// After:` \
+         comments, no diff format.\n\n";
+
+    let mut source_section = String::with_capacity(extracted.source.len() + 64);
+    source_section.push_str("## Original source\n\n```rust\n");
+    source_section.push_str(&extracted.source);
+    if !extracted.source.ends_with('\n') { source_section.push('\n'); }
+    source_section.push_str("```\n");
+
+    match input.callers_position {
+        CallersPosition::Top => {
+            md.push_str(&blast_section);
+            md.push_str(constraints_section);
+            md.push_str(&source_section);
+        }
+        CallersPosition::Bottom => {
+            md.push_str(constraints_section);
+            md.push_str(&source_section);
+            // Trailing newline before the appended blast section so
+            // it's visually separated from the closing ``` of the
+            // source block.
+            if !md.ends_with("\n\n") { md.push('\n'); }
+            md.push_str(&blast_section);
+        }
+    }
 
     Ok(BuiltPrompt {
         markdown: md,
@@ -170,6 +196,35 @@ pub fn build(input: &RefactorPromptInput<'_>) -> Result<BuiltPrompt, PromptError
 fn normalise(p: &str) -> String {
     let mut s = p.replace('\\', "/");
     if let Some(stripped) = s.strip_prefix("./") { s = stripped.to_string(); }
+    s
+}
+
+/// Compose just the "## Blast radius …" section so the main builder
+/// can splice it at top-of-prompt or bottom-of-prompt depending on
+/// `CallersPosition`.
+fn build_blast_section(
+    include_callers: bool,
+    caller_count: usize,
+    caller_files: &BTreeSet<String>,
+    caller_lines: &BTreeSet<String>,
+) -> String {
+    let mut s = String::with_capacity(256 + caller_lines.len() * 80);
+    if include_callers {
+        s.push_str("## Blast radius — callers from the static call-graph\n\n");
+        s.push_str(&caller_count.to_string());
+        s.push_str(" caller(s) across ");
+        s.push_str(&caller_files.len().to_string());
+        s.push_str(" file(s):\n\n");
+        for c in caller_lines {
+            s.push_str("- `");
+            s.push_str(c);
+            s.push_str("`\n");
+        }
+        s.push('\n');
+    } else {
+        s.push_str("## Blast radius\n\n");
+        s.push_str("(call-graph context redacted for this ablation run)\n\n");
+    }
     s
 }
 
@@ -195,6 +250,7 @@ mod tests {
             target_file: &target_file,
             graph: &graph,
             include_callers: true,
+            callers_position: CallersPosition::Top,
         };
         let built = build(&input).expect("build");
         assert!(built.markdown.contains("# Refactor task: smoke"));
@@ -205,6 +261,31 @@ mod tests {
             "prompt must include the original fn body");
         assert!(built.caller_count >= 1, "expected ≥1 caller from real graph");
         assert!(!built.caller_files.is_empty());
+    }
+
+    /// Bottom-position keeps every section, but reorders so the
+    /// caller list lands AFTER the original source. Verifies the
+    /// goal-dilution-hypothesis variant prompt.
+    #[test]
+    fn callers_at_bottom_appear_after_source() {
+        let root = folkering_root();
+        let graph = folkering_codegraph::build_from_dir(&root).expect("graph");
+        let target_file = root.join("kernel/src/memory/physical.rs");
+        let input = RefactorPromptInput {
+            task_id: "smoke-bottom",
+            goal: "Add a Layout-style API.",
+            target_fn: "alloc_pages",
+            target_file: &target_file,
+            graph: &graph,
+            include_callers: true,
+            callers_position: CallersPosition::Bottom,
+        };
+        let built = build(&input).expect("build");
+        let source_pos = built.markdown.find("## Original source").unwrap();
+        let blast_pos = built.markdown.find("## Blast radius").unwrap();
+        assert!(source_pos < blast_pos,
+            "with CallersPosition::Bottom the source section must appear \
+             before the blast-radius section; got source@{source_pos} blast@{blast_pos}");
     }
 
     /// Ablation mode: no caller list, but the rest of the prompt
@@ -221,6 +302,7 @@ mod tests {
             target_file: &target_file,
             graph: &graph,
             include_callers: false,
+            callers_position: CallersPosition::Top,
         };
         let built = build(&input).expect("build");
         assert!(built.markdown.contains("call-graph context redacted"),


### PR DESCRIPTION
…ses cloud variance

Tested whether moving the CodeGraph caller list AFTER the original source (instead of before) rescues gemma4:31b-cloud's pass-rate.

Hypothesis: long caller list dilutes the goal text by pushing it out of effective attention. Bottom-position keeps goal+constraints adjacent, should help.

Result: hypothesis NOT supported. The data tells a different story.

By position (gemma4, N=3 each)

    | Position | with-CG       | no-CG         | within-batch diff |
    |----------|---------------|---------------|-------------------|
    | top      | 7/15  (46.7%) | 8/14  (57.1%) | -10.4 pp          |
    | bottom   | 6/15  (40.0%) | 6/15  (40.0%) |   0.0 pp          |

The smoking gun

  no-CG dropped from 57% (top batch) to 40% (bottom batch) on
  IDENTICAL PROMPTS. no-CG never had a caller list to position.
  17 pp swing on identical inputs => cloud variance is bigger than
  the position effect we tried to measure.

Implication for PR #43's cross-model headline

  The 7b +20 pp result is well-replicated (3 pilots + N=3 trial).
  Local Ollama, default temperature, seed-stable enough.

  The g4 -10.5 pp result is N=3 in a SINGLE cloud session. This
  experiment's identical-prompt comparison shows that single-batch
  N=3 on cloud can swing by 17 pp on its own. So:
    - "CG hurts gemma4" might be true. Or session noise.
    - We can't tell from this N. Honest answer: "we don't know".

What lands

  * `CallersPosition::{Top,Bottom}` enum on RefactorPromptInput
  * `--callers-at-end` CLI flag
  * `callers_position` field in score.json (`"top" | "bottom"`)
  * `run-trials.sh [N] [MODEL] [LABEL] [POSITION]` 4th arg
  * `position-experiment-001.md` — full write-up incl the methodology finding

What would actually settle the cloud question

  1. N=10 g4 in a single continuous batch (matched session conditions)
  2. temperature=0 in the proxy LLM endpoint (5-line patch)
  3. Per-batch baseline arm in every prompt experiment

Tests
  - cargo test --release: 25 passed, 1 ignored (1 new — bottom-position)
  - run-trials.sh 3 gemma4:31b-cloud g4end bottom: 6 trials, ~80 min
  - Manual segmentation script reconciles to per-(position, condition) cell counts