### PR TITLE
feat(draug): Phase 17 autonomous refactor loop — full wiring

### DIFF
--- a/userspace/compositor/src/draug.rs
+++ b/userspace/compositor/src/draug.rs
@@ -201,6 +201,11 @@ pub fn model_for_level(level: u8) -> &'static str {
 pub const PLANNER_MODEL: &str = "gemma4:31b-cloud";
 /// Model for Phase 15 Executor persona (complex multi-step).
 pub const EXECUTOR_MODEL: &str = "gemma4:31b-cloud";
+/// Model for Phase 17 autonomous refactor LLM calls. Uses the small
+/// model to keep cloud costs bounded — the eval-runner trial 002
+/// showed gemma4:31b doesn't measurably outperform 7b on the fixture
+/// task set, while costing ~10× per call.
+pub const REFACTOR_MODEL: &str = "qwen2.5-coder:7b";
 pub const ACTIVE_SKILL_LEVELS: u8 = 3;
 pub const MAX_SKILL_LEVELS: u8 = 5;
 /// Number of tasks in REFACTOR_TASKS.
@@ -496,12 +501,39 @@ pub struct DraugDaemon {
     /// Uptime (ms) when current async phase started — for timeout.
     /// If now - async_phase_started_ms > ASYNC_TIMEOUT_MS, force abort.
     pub async_phase_started_ms: u64,
+
+    // ── Phase 17 — autonomous refactor loop ─────────────────────────
+    /// Persisted refactor task queue. Loaded from Synapse VFS at
+    /// startup (or seeded from `mcp_handler::refactor_loop::REFACTOR_FIXTURES`
+    /// on cold-boot). `None` until the loader runs at boot —
+    /// `tick_idle` treats `None` as "Phase 17 unavailable".
+    pub refactor_tasks: Option<alloc::vec::Vec<crate::refactor_types::RefactorTask>>,
+    /// Index into `refactor_tasks` for the iteration currently in
+    /// flight. `usize::MAX` = nothing in flight. Outlives the
+    /// LlmGenerate→CargoCheck transition so process_cargo_check_result
+    /// can find the task it should record_attempt against.
+    pub current_refactor_idx: usize,
+    /// Repo-relative path of the file the in-flight refactor is
+    /// targeting. Cached so `process_refactor_llm` can pass it to
+    /// `build_cargo_check_request` without re-reading the task.
+    pub current_refactor_target: alloc::string::String,
+    /// Cap on how many refactor iterations we run per boot — keeps
+    /// cloud costs bounded and means Draug eventually idles instead
+    /// of looping forever.
+    pub refactor_iterations_done: u32,
 }
 
 /// Timeout for any single async TCP phase (connect/send/read).
 /// 90 seconds wall clock — enough for cold Ollama + cargo test,
 /// but prevents permanent hang if proxy stops responding.
 pub const ASYNC_TIMEOUT_MS: u64 = 90_000;
+
+/// Cap on autonomous refactor iterations per boot. cargo check on
+/// real OS code is expensive (cold workspace ≈ 45 s) and each
+/// iteration also burns a cloud-routed LLM call. 16 iterations is
+/// enough to cycle every fixture task at the 3-attempt cap a few
+/// times before idling — see `mcp_handler::refactor_loop::pick_next_refactor_task`.
+pub const MAX_REFACTOR_ITERATIONS_PER_BOOT: u32 = 16;
 
 // ── Phase 15 types (must live in lib crate so draug.rs can own them) ──
 
@@ -588,6 +620,10 @@ impl DraugDaemon {
             async_level: 0,
             async_attempt: 0,
             async_phase_started_ms: 0,
+            refactor_tasks: None,
+            current_refactor_idx: usize::MAX,
+            current_refactor_target: alloc::string::String::new(),
+            refactor_iterations_done: 0,
         }
     }
 
@@ -685,6 +721,48 @@ impl DraugDaemon {
             }
         }
         None
+    }
+
+    /// Phase 17 — find the next refactor task eligible for an
+    /// attempt. Mirrors the eval-runner's pick logic: first
+    /// `Pending`, then any failed entry under the per-task retry
+    /// cap (3). Returns `None` when every task has settled — caller
+    /// should fall through to `start_phase15` then.
+    pub fn pick_next_refactor(&self) -> Option<usize> {
+        const MAX_ATTEMPTS_PER_TASK: u32 = 3;
+        let tasks = self.refactor_tasks.as_ref()?;
+        for (idx, t) in tasks.iter().enumerate() {
+            use crate::refactor_types::TaskStatus;
+            match t.last_status {
+                TaskStatus::Pending => return Some(idx),
+                TaskStatus::Pass | TaskStatus::Skip => continue,
+                TaskStatus::FailCompile | TaskStatus::FailCallerCompat => {
+                    if t.attempts < MAX_ATTEMPTS_PER_TASK {
+                        return Some(idx);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Phase 17 — caller-side guard for the per-boot iteration cap.
+    /// `tick_idle` calls this before picking a refactor task to
+    /// short-circuit when we've already done MAX_REFACTOR_ITERATIONS_PER_BOOT.
+    pub fn refactor_budget_remaining(&self) -> bool {
+        self.refactor_iterations_done < MAX_REFACTOR_ITERATIONS_PER_BOOT
+    }
+
+    /// Phase 17 — install the refactor task queue. Caller is the
+    /// boot path in `main.rs`, which loads from Synapse VFS via
+    /// `task_store::load()` (and seeds from REFACTOR_FIXTURES on
+    /// cold boot). Stored as `Some(_)` so `tick_idle` can tell
+    /// "queue available" from "queue not yet loaded".
+    pub fn install_refactor_tasks(
+        &mut self,
+        tasks: alloc::vec::Vec<crate::refactor_types::RefactorTask>,
+    ) {
+        self.refactor_tasks = Some(tasks);
     }
 
     /// Record that task `idx` passed its current level.

--- a/userspace/compositor/src/lib.rs
+++ b/userspace/compositor/src/lib.rs
@@ -68,6 +68,7 @@ pub mod slm_runtime;
 pub mod window_manager;
 pub mod agent;
 pub mod draug;
+pub mod refactor_types;
 
 extern crate alloc;
 

--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -651,6 +651,24 @@ fn main() -> ! {
         );
     }
 
+    // Phase 17 — load (or seed) the autonomous refactor task queue.
+    // Failures are tolerated: if Synapse VFS read returns an error,
+    // we still seed from REFACTOR_FIXTURES so the loop has work.
+    {
+        let existing = mcp_handler::task_store::load().unwrap_or_default();
+        let merged = mcp_handler::task_store::seed_or_merge(
+            &existing,
+            mcp_handler::refactor_loop::REFACTOR_FIXTURES,
+        );
+        // Persist immediately so first-boot writes the seeded list to disk.
+        let _ = mcp_handler::task_store::save(&merged);
+        libfolk::sys::io::write_str("[Draug] Refactor queue: ");
+        let mut nb = [0u8; 16];
+        libfolk::sys::io::write_str(crate::util::format_usize(merged.len(), &mut nb));
+        libfolk::sys::io::write_str(" tasks loaded\n");
+        draug.install_refactor_tasks(merged);
+    }
+
     // Pillar 4: WASM warm cache — pre-compiled modules for instant response
     // wasm.cache initialized by WasmState::new()
     const MAX_CACHE_ENTRIES: usize = 4;

--- a/userspace/compositor/src/mcp_handler/draug_async.rs
+++ b/userspace/compositor/src/mcp_handler/draug_async.rs
@@ -75,7 +75,20 @@ fn tick_idle(draug: &mut DraugDaemon, now_ms: u64) -> bool {
 
     match draug.next_task_and_level() {
         Some((task_idx, level)) => start_skill_tree(draug, task_idx, level, now_ms),
-        None => start_phase15(draug, now_ms),
+        None => {
+            // Skill-tree complete — try Phase 17 autonomous refactor
+            // before falling through to Phase 15. Refactor work is
+            // gated on (a) the task queue being loaded and (b) the
+            // per-boot iteration cap. `start_refactor_iteration`
+            // returns false when no refactor work is available, so
+            // we cleanly fall through.
+            if draug.refactor_budget_remaining()
+                && start_refactor_iteration(draug, now_ms)
+            {
+                return true;
+            }
+            start_phase15(draug, now_ms)
+        }
     }
 }
 
@@ -199,6 +212,122 @@ fn start_executor_step(draug: &mut DraugDaemon, step_idx: usize, now_ms: u64) ->
     draug.async_operation = AsyncOp::ExecutorLlm;
     draug.async_phase_started_ms = now_ms;
     start_llm_request(draug, compositor::draug::EXECUTOR_MODEL, &prompt)
+}
+
+/// Phase 17 — pick the next pending refactor task, fetch its source
+/// from the host via the FETCH_SOURCE syscall, build the refactor
+/// prompt (with model-conditional caller list), and fire LlmGenerate.
+///
+/// Returns true if the iteration started (or terminally short-
+/// circuited — no work, fetch_source failed, etc). The caller in
+/// `tick_idle` interprets `true` as "we did something this tick".
+pub(super) fn start_refactor_iteration(draug: &mut DraugDaemon, now_ms: u64) -> bool {
+    let task_idx = match draug.pick_next_refactor() {
+        Some(i) => i,
+        None => return false, // No work — caller falls through to phase15.
+    };
+
+    // Snapshot the task fields so we can drop the immutable borrow
+    // before mutating draug below.
+    let (task_id, target_file, target_fn, goal, attempts) = {
+        let tasks = draug.refactor_tasks.as_ref().unwrap();
+        let t = &tasks[task_idx];
+        (
+            t.id.clone(),
+            t.target_file.clone(),
+            t.target_fn.clone(),
+            t.goal.clone(),
+            t.attempts,
+        )
+    };
+
+    write_str("\n[Draug-async] [REFACTOR] ");
+    write_str(&task_id);
+    write_str(" attempt ");
+    write_dec(attempts + 1);
+    write_str(" → FETCH_SOURCE\n");
+
+    libfolk::sys::draug_bridge_set_task(&task_id);
+
+    // Fetch the original source from the host. Synchronous syscall —
+    // fast (single tcp_request, ≪ 1 s on the LAN). For files larger
+    // than 64 KB we'd need a chunked path; the fixture targets are
+    // all well below that.
+    let mut fetch_buf = alloc::vec::Vec::with_capacity(64 * 1024);
+    fetch_buf.resize(64 * 1024, 0u8);
+    let fetch_res = libfolk::sys::fetch_source(&target_file, &mut fetch_buf);
+    let source = match fetch_res {
+        Some(p) if p.status == libfolk::sys::FS_STATUS_OK => {
+            fetch_buf.truncate(p.output_len);
+            match alloc::string::String::from_utf8(fetch_buf) {
+                Ok(s) => s,
+                Err(_) => {
+                    write_str("[Draug-async] FETCH_SOURCE: non-UTF-8 body\n");
+                    record_refactor_failure(draug, task_idx, "non-UTF-8 source");
+                    return true;
+                }
+            }
+        }
+        Some(p) => {
+            write_str("[Draug-async] FETCH_SOURCE failed status=");
+            write_dec(p.status);
+            write_str("\n");
+            record_refactor_failure(draug, task_idx, "fetch_source non-OK");
+            return true;
+        }
+        None => {
+            write_str("[Draug-async] FETCH_SOURCE: TCP/syscall failure\n");
+            record_refactor_failure(draug, task_idx, "fetch_source transport");
+            return true;
+        }
+    };
+
+    write_str("[Draug-async] FETCH_SOURCE OK ");
+    write_dec(source.len() as u32);
+    write_str("B\n");
+
+    // Build prompt with the same shape the eval-runner uses. The
+    // caller list is pulled in only when `codegraph_for_model` says
+    // so — for qwen-coder:7b that's "yes", which improves pass-rate
+    // by +20 pp on the fixture set per cross-model trial 001.
+    let task = compositor::refactor_types::RefactorTask {
+        id: task_id.clone(),
+        target_file: target_file.clone(),
+        target_fn,
+        goal,
+        attempts,
+        last_status: compositor::refactor_types::TaskStatus::Pending,
+    };
+    let prompt = super::refactor_loop::build_refactor_prompt(
+        &task, &source, compositor::draug::REFACTOR_MODEL,
+    );
+
+    write_str("[Draug-async] prompt ");
+    write_dec(prompt.len() as u32);
+    write_str("B → LLM\n");
+
+    draug.current_refactor_idx = task_idx;
+    draug.current_refactor_target = target_file;
+    draug.async_operation = AsyncOp::RefactorLlm;
+    draug.async_phase_started_ms = now_ms;
+    draug.refactor_iterations_done = draug.refactor_iterations_done.saturating_add(1);
+    start_llm_request(draug, compositor::draug::REFACTOR_MODEL, &prompt)
+}
+
+/// Persist a refactor failure that hit before the LLM was even
+/// queried (FETCH_SOURCE failed, etc). Increments attempts +
+/// records Skip so the loop moves on instead of retrying forever.
+fn record_refactor_failure(draug: &mut DraugDaemon, task_idx: usize, _reason: &str) {
+    if let Some(tasks) = draug.refactor_tasks.as_mut() {
+        if task_idx < tasks.len() {
+            tasks[task_idx].attempts = tasks[task_idx].attempts.saturating_add(1);
+            tasks[task_idx].last_status = compositor::refactor_types::TaskStatus::Skip;
+        }
+    }
+    if let Some(ref tasks) = draug.refactor_tasks {
+        let _ = super::task_store::save(tasks);
+    }
+    draug.record_skip();
 }
 
 // ── Shared: build LLM wire frame and start TCP connect ──────────────
@@ -340,14 +469,15 @@ fn tick_processing(draug: &mut DraugDaemon, now_ms: u64) -> bool {
 }
 
 /// Phase 17 — handle the LLM's response to a refactor prompt.
-/// Extracts the rust code block from the response and is the natural
-/// place to fire the follow-up CARGO_CHECK request. Compile-only
-/// today: tick_idle does not yet drive the loop into this state.
-fn process_refactor_llm(draug: &mut DraugDaemon, response: &[u8], _now_ms: u64) -> bool {
+/// Extracts the rust code block, builds a CARGO_CHECK request frame,
+/// and fires another async TCP round-trip — same shape as the skill-
+/// tree LLM→PATCH transition.
+fn process_refactor_llm(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -> bool {
     let code = match parse_llm_response(response) {
         Some(c) => c,
         None => {
             write_str("[Draug-async] Refactor LLM: parse failed\n");
+            persist_refactor_skip(draug);
             draug.async_phase = AsyncPhase::Idle;
             draug.async_operation = AsyncOp::None;
             draug.record_skip();
@@ -357,47 +487,124 @@ fn process_refactor_llm(draug: &mut DraugDaemon, response: &[u8], _now_ms: u64) 
 
     write_str("[Draug-async] Refactor LLM OK → ");
     write_dec(code.len() as u32);
-    write_str("B (CARGO_CHECK wiring lands with tick_idle integration)\n");
+    write_str("B → CARGO_CHECK\n");
 
-    // Next session: thread `current_refactor_target` through DraugDaemon,
-    // call `super::refactor_loop::build_cargo_check_request(target, &code)`,
-    // stash into `draug.async_request`, set `async_operation = AsyncOp::CargoCheck`,
-    // and re-fire `tcp_connect_async` exactly like start_patch_request does.
-    draug.async_phase = AsyncPhase::Idle;
-    draug.async_operation = AsyncOp::None;
-    draug.record_skip();
+    // Build the proxy request. `build_cargo_check_request` is unit-
+    // tested in refactor_loop so the wire shape stays in sync with
+    // what the proxy parses.
+    let target = draug.current_refactor_target.clone();
+    let req = super::refactor_loop::build_cargo_check_request(&target, &code);
+
+    draug.async_request = req;
+    draug.async_sent = 0;
+    if draug.async_response.capacity() < 8192 {
+        draug.async_response.reserve(8192);
+    }
+    draug.async_response.clear();
+    draug.async_operation = AsyncOp::CargoCheck;
+    draug.async_phase_started_ms = now_ms;
+
+    let result = libfolk::sys::tcp_connect_async(PROXY_IP, PROXY_PORT);
+    if result == u64::MAX {
+        write_str("[Draug-async] CARGO_CHECK connect failed (no slots)\n");
+        persist_refactor_skip(draug);
+        draug.async_phase = AsyncPhase::Idle;
+        draug.async_operation = AsyncOp::None;
+        draug.record_skip();
+        return true;
+    }
+    draug.async_tcp_slot = result;
+    draug.async_phase = AsyncPhase::Sending;
     true
 }
 
+/// Persist a Skip verdict for the in-flight refactor. Used when
+/// the loop hits an infrastructure problem (LLM parse failure,
+/// connect-no-slots, etc) where we don't want the failure to count
+/// against the model's own retry budget.
+fn persist_refactor_skip(draug: &mut DraugDaemon) {
+    let idx = draug.current_refactor_idx;
+    if idx == usize::MAX { return; }
+    if let Some(tasks) = draug.refactor_tasks.as_mut() {
+        if idx < tasks.len() {
+            tasks[idx].attempts = tasks[idx].attempts.saturating_add(1);
+            tasks[idx].last_status = compositor::refactor_types::TaskStatus::Skip;
+        }
+    }
+    if let Some(ref tasks) = draug.refactor_tasks {
+        let _ = super::task_store::save(tasks);
+    }
+    draug.current_refactor_idx = usize::MAX;
+    draug.current_refactor_target.clear();
+}
+
 /// Phase 17 — handle the proxy's CARGO_CHECK reply for a refactor
-/// task. The 8-byte header gives `[u32 status LE][u32 output_len LE]`;
-/// the status maps to `AttemptVerdict` via
-/// `refactor_loop::verdict_from_cargo_check_status`. Compile-only:
-/// the persistence step (`task_store::save`) lands when tick_idle
-/// drives this state.
+/// task. Maps status to a verdict, calls `record_attempt`, persists
+/// the queue back to Synapse VFS, and clears the in-flight pointer.
 fn process_cargo_check_result(
     draug: &mut DraugDaemon,
     response: &[u8],
     _now_ms: u64,
 ) -> bool {
+    let idx = draug.current_refactor_idx;
+
     let header = super::refactor_loop::parse_cargo_check_header(response);
-    match header {
-        Some((status, output_len)) => {
+    let status = match header {
+        Some((s, output_len)) => {
             write_str("[Draug-async] CARGO_CHECK status=");
-            write_dec(status);
+            write_dec(s);
             write_str(" output=");
             write_dec(output_len);
-            write_str("B (verdict→record_attempt wiring lands next)\n");
-            // Next session: pull current task index, call
-            // `refactor_loop::record_attempt(&mut tasks[idx], verdict)`,
-            // then `task_store::save(&tasks)`. Verdict comes from
-            // `refactor_loop::verdict_from_cargo_check_status(status)`.
+            write_str("B\n");
+            s
         }
         None => {
-            write_str("[Draug-async] CARGO_CHECK: short/empty response\n");
+            write_str("[Draug-async] CARGO_CHECK: short/empty reply\n");
             draug.record_skip();
+            // Treat short reply as Skip — protocol error, not the model's fault.
+            persist_refactor_skip(draug);
+            draug.async_phase = AsyncPhase::Idle;
+            draug.async_operation = AsyncOp::None;
+            return true;
+        }
+    };
+
+    if idx == usize::MAX {
+        write_str("[Draug-async] CARGO_CHECK: stale (no in-flight idx)\n");
+        draug.async_phase = AsyncPhase::Idle;
+        draug.async_operation = AsyncOp::None;
+        return true;
+    }
+
+    let verdict = super::refactor_loop::verdict_from_cargo_check_status(status);
+    if let Some(tasks) = draug.refactor_tasks.as_mut() {
+        if idx < tasks.len() {
+            super::refactor_loop::record_attempt(&mut tasks[idx], verdict);
         }
     }
+
+    // Persist immediately so a crash mid-loop doesn't lose the verdict.
+    if let Some(ref tasks) = draug.refactor_tasks {
+        if let Err(e) = super::task_store::save(tasks) {
+            write_str("[Draug-async] task_store::save failed: ");
+            // StoreError doesn't implement no_std `core::fmt::Display`
+            // beyond Debug, so just stringify a tag.
+            let _ = e; // suppress unused warning when not displayed
+            write_str("(see prior log)\n");
+        }
+    }
+
+    // Verdict-aware tracking: bump pass/fail counters for the shell badge.
+    use super::refactor_loop::AttemptVerdict;
+    match verdict {
+        AttemptVerdict::Pass             => draug.record_refactor_pass(),
+        AttemptVerdict::FailCompile
+        | AttemptVerdict::FailCallerCompat => draug.record_refactor_fail(),
+        AttemptVerdict::Skip             => draug.record_skip(),
+    }
+
+    draug.current_refactor_idx = usize::MAX;
+    draug.current_refactor_target.clear();
     draug.async_phase = AsyncPhase::Idle;
     draug.async_operation = AsyncOp::None;
     true

--- a/userspace/compositor/src/mcp_handler/task_store.rs
+++ b/userspace/compositor/src/mcp_handler/task_store.rs
@@ -43,62 +43,15 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+// Re-export the carriers from the lib so existing call sites
+// (`task_store::RefactorTask`, `task_store::TaskStatus`) keep working.
+// The actual definitions live in `compositor::refactor_types` because
+// `DraugDaemon` (in the lib) needs to hold a `Vec<RefactorTask>` and
+// the lib can't see this `mcp_handler` module (which is in the bin).
+pub use compositor::refactor_types::{RefactorTask, TaskStatus};
+
 const STORE_PATH: &str = "draug/refactor_tasks.txt";
 const FORMAT_VERSION: &str = "v1";
-
-/// One task in the autonomous refactor queue. Fixture data carried
-/// in static arrays before; persisted in Synapse VFS now so the
-/// autonomous loop survives reboots.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RefactorTask {
-    pub id: String,
-    pub target_file: String,
-    pub target_fn: String,
-    pub goal: String,
-    pub attempts: u32,
-    pub last_status: TaskStatus,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskStatus {
-    /// Never attempted. Initial state for fresh tasks.
-    Pending,
-    /// Last attempt produced a refactor that compiled and kept
-    /// callers compiling. Locked in.
-    Pass,
-    /// Last attempt produced code that didn't compile (any cargo
-    /// check error in the target file itself).
-    FailCompile,
-    /// Last attempt compiled but broke a caller. Strongest signal
-    /// for "the LLM changed the signature without updating callers".
-    FailCallerCompat,
-    /// Skipped because some pre-flight check failed (target fn not
-    /// in the graph, source extraction failed, etc).
-    Skip,
-}
-
-impl TaskStatus {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            TaskStatus::Pending          => "Pending",
-            TaskStatus::Pass             => "Pass",
-            TaskStatus::FailCompile      => "FailCompile",
-            TaskStatus::FailCallerCompat => "FailCallerCompat",
-            TaskStatus::Skip             => "Skip",
-        }
-    }
-
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "Pending"          => Some(TaskStatus::Pending),
-            "Pass"             => Some(TaskStatus::Pass),
-            "FailCompile"      => Some(TaskStatus::FailCompile),
-            "FailCallerCompat" => Some(TaskStatus::FailCallerCompat),
-            "Skip"             => Some(TaskStatus::Skip),
-            _ => None,
-        }
-    }
-}
 
 #[derive(Debug)]
 pub enum StoreError {

--- a/userspace/compositor/src/refactor_types.rs
+++ b/userspace/compositor/src/refactor_types.rs
@@ -1,0 +1,63 @@
+//! Shared Phase 17 refactor-loop types.
+//!
+//! `DraugDaemon` lives in the lib (`compositor::draug`) but the
+//! task_store / refactor_loop logic lives in the bin's
+//! `mcp_handler` module. To let the lib hold a `Vec<RefactorTask>`
+//! field without forming a lib→bin dependency, the data carriers
+//! live here in the lib and the bin's `task_store` re-exports them.
+
+extern crate alloc;
+
+use alloc::string::String;
+
+/// One task in the autonomous refactor queue. Matches the eval-runner's
+/// fixture shape (`tools/draug-eval-runner/tasks.toml`) so we can seed
+/// the in-OS queue from the same data the host harness scores.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorTask {
+    pub id: String,
+    pub target_file: String,
+    pub target_fn: String,
+    pub goal: String,
+    pub attempts: u32,
+    pub last_status: TaskStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    /// Never attempted. Initial state for fresh tasks.
+    Pending,
+    /// Last attempt produced a refactor that compiled and kept
+    /// callers compiling. Locked in.
+    Pass,
+    /// Last attempt produced code that didn't compile.
+    FailCompile,
+    /// Last attempt compiled but broke a caller. Strongest signal
+    /// for "the LLM changed the signature without updating callers".
+    FailCallerCompat,
+    /// Skipped because some pre-flight check failed.
+    Skip,
+}
+
+impl TaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskStatus::Pending          => "Pending",
+            TaskStatus::Pass             => "Pass",
+            TaskStatus::FailCompile      => "FailCompile",
+            TaskStatus::FailCallerCompat => "FailCallerCompat",
+            TaskStatus::Skip             => "Skip",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "Pending"          => Some(TaskStatus::Pending),
+            "Pass"             => Some(TaskStatus::Pass),
+            "FailCompile"      => Some(TaskStatus::FailCompile),
+            "FailCallerCompat" => Some(TaskStatus::FailCallerCompat),
+            "Skip"             => Some(TaskStatus::Skip),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Wires every piece of the Phase 17 autonomous refactor pipeline from \`tick_idle\` → LLM → CARGO_CHECK → \`record_attempt\` → \`save\`. **Compile-clean; boot-test deferred — host hypervisor in a bad state, needs Windows reboot.**

## What lands
- \`compositor::refactor_types\` (new lib module): \`RefactorTask\` + \`TaskStatus\` lifted from the bin so \`DraugDaemon\` (in the lib) can hold \`Vec<RefactorTask>\`. The bin's \`task_store\` re-exports them, so existing call sites are unchanged.
- \`DraugDaemon\`: 4 new fields, \`pick_next_refactor()\`, \`refactor_budget_remaining()\`, \`install_refactor_tasks()\`. Per-boot iteration cap = 16.
- \`tick_idle\`: skill-tree → refactor (if budget left) → phase 15 dispatch
- \`start_refactor_iteration\`: \`fetch_source\` syscall (synchronous, ~1s) → \`build_refactor_prompt\` (model-conditional caller list) → fire LlmGenerate
- \`process_refactor_llm\`: parse code → \`build_cargo_check_request\` → fire CARGO_CHECK on a fresh TCP connection (same shape as skill-tree LLM→PATCH)
- \`process_cargo_check_result\`: \`parse_cargo_check_header\` → \`verdict_from_cargo_check_status\` → \`record_attempt\` → \`task_store::save\`. **Crash-safe**: each verdict is persisted before the next iteration starts.
- \`main.rs\` boot path: \`task_store::load() ∪ REFACTOR_FIXTURES\` → install in Draug. Cold-boot writes the seeded list immediately so subsequent boots restore from the real file.
- Default model: \`qwen2.5-coder:7b\`. Trial 002 showed gemma4:31b doesn't measurably outperform 7b on the fixture set; cheap local model wins on cost.

## Boot-test status
Compile-clean. Live boot test on this Windows host failed: WHPX hit \`Unexpected VP exit code 4\` (a known issue when the Hyper-V backend is left in a bad state, in this case after an earlier \`wsl --shutdown\` while debugging an mcopy hang). \`vmcompute\` service restart did not recover. Host needs a full Windows reboot to restore acceleration.

The boot test is the obvious next step:
1. Reboot Windows (restores WHPX)
2. Start \`folkering-proxy\` with \`--codegraph /tmp/folkering-eval.fcg1 --folkering-os-root /c/Users/merkn/folkering/folkering-os\`
3. \`folkering_run\` the OS
4. Watch \`/c/Users/merkn/folkering-mcp/serial.log\` for the \`[Draug-async] [REFACTOR]\` lines + verdict serialisation
5. Verify \`draug/refactor_tasks.txt\` in Synapse VFS reflects the verdicts

## Test plan
- [x] \`cargo check -p compositor\` — clean (errors=0)
- [x] \`cargo build all\` — kernel + userspace both green
- [x] All existing unit tests in \`task_store\` and \`refactor_loop\` still pass
- [ ] Boot-test the full LLM → CARGO_CHECK → save round-trip (deferred, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)