### PR TITLE
fix(compositor): cap poll_com3 reads — fixes #49 (Tick #1 freeze)

### DIFF
--- a/active_debug_log.md
+++ b/active_debug_log.md
@@ -1,109 +1,116 @@
-# Synapse VFS B-tree Insert Bug — Debug Log
+# Issue #49 — Draug Tick #1 Freeze Debug Log
 
 ## Problem Summary
-`[SYNAPSE] insert: unexpected page type 0x00` when writing files to SQLite VFS.
-Blocks all persistence: WASM app caching, AutoDream, driver version control.
 
-## Session 7. april 2026
+After `[Draug] Tick #1 | idle: 12s | dreams: 0/10` fires, the kernel goes silent for 5+ minutes. VM stays alive at **CPU = 0% / HLT-idle** (uptime climbs normally) — so it's not a triple-fault or panic. Reproduces on **both WHPX (Windows)** AND **KVM (Proxmox VE)**, so it's a real Folkering scheduling bug, not a hypervisor quirk.
 
-### Attempt 1: FOLKDISK header not updated after flush
-- **Hypothesis:** `flush_sqlite_to_disk()` writes new pages to disk but never updates `synapse_db_size` in sector 0 header. On reboot, fewer sectors are loaded → new pages are zeroed.
-- **Changes:** Added header update in `flush_sqlite_to_disk()` (offset 56-63, LE u64 sector count)
-- **Result:** PARTIAL FIX — correct for reboot persistence, but bug ALSO occurs on first insert within a single boot session (before any flush/reboot)
-- **Conclusion:** Header fix is necessary but NOT the root cause of the initial insert failure
+Last serial bytes before silence:
+```
+[SYNAPSE] write_file: disk flush failed (data in memory only)
+[SYNAPSE] Wrote 'draug/refactor_tasks.txt' (1730 bytes, rowid=32, mime=text/plain)
+[Draug] Refactor queue: 5 tasks loaded
+[LOOP ALIVE]
+[IQE-POLL] n=2
+[MCP] TimeSyncRequest sent (NTP failed, fallback)
+[Draug] Tick #1 | idle: 12s | dreams: 0/10
+```
 
-### Attempt 2: content_buf too small (4096 bytes)
-- **Hypothesis:** WASM files >4KB silently truncated during write
-- **Changes:** Increased `content_buf` to 16KB stack buffer, added truncation warning. Also increased `cell_buf` to 16KB.
-- **Result:** N/A for current bug (test files are <4KB), but prevents future data loss
-- **Conclusion:** Good fix, not the root cause
+GitHub Issue: https://github.com/merknu/folkering-os/issues/49
+Branch: `fix/issue-49-tick-freeze`
+Test environment: Proxmox VE 8.4.1 @ 192.168.68.150, VM 800 (`folkering-os`)
 
-### Attempt 3: Data disk stale/corrupted
-- **Hypothesis:** VirtIO data disk (vm-900-disk-1) had corrupted sectors from old deploys
-- **Changes:** Re-uploaded fresh `virtio-data.img`, re-imported disk into Proxmox
-- **Result:** Fixed `[SYNAPSE] VirtIO DB read failed at sector 3584`. SQLite now loads correctly (3928 sectors, 5 files)
-- **Conclusion:** Stale data disk was a separate issue. Insert still fails after correct load.
+## Hypotheses (from issue #49)
 
-### Attempt 4: Debug B-tree traversal (CURRENT)
-- **Hypothesis:** B-tree right-pointer leads to an out-of-range or zeroed page
-- **Changes:** Added detailed logging in `sqlite_insert_file()`:
-  - root_page, page_count, db_size
-  - Each traversal step: depth, page number, page type
-  - Out-of-range checks before page access
-  - Interior page right-pointer value
-- **Result:** ROOT CAUSE FOUND!
-  - root_page=2, page_count=491, db_size=2011136
-  - Page 2 is interior (0x05) with 4 cells + right-ptr
-  - Child pages: [30, 31, 355, 359, **495**]
-  - **Right-pointer = 495 but page_count = 491!**
-  - Page 495 is at offset 2,023,424 — 12,288 bytes BEYOND the loaded DB
-  - Synapse loads only 491 pages (based on page_count) → page 495 is zeroed → type 0x00
-- **Conclusion:** The initial SQLite DB created by `folk-pack create-sqlite` has a corrupted page_count. The B-tree references page 495 but header says 491 pages.
+1. **Timer IRQ wiring after Tick #1.** Tick #1 fires at uptime 12s, then nothing. Either timer source (LAPIC/PIT/HPET) gets masked, or its handler unmasks itself only on a path the first tick doesn't take.
+2. **`should_run_refactor_step` cadence.** Compositor's `tick_idle` only invokes the body when this gates true.
+3. **Heartbeat loop conditioned out.** `[LOOP ALIVE]` only printed once.
+4. **HLT path not waking on serial RX/timer.** With CPU=0% and serial silent, CPU is parked in HLT.
 
-### Attempt 5: Fix page_count in virtio-data.img ✅ B-TREE INSERT FIXED
-- **Hypothesis:** Setting page_count=495 and updating db_sectors will fix the insert
-- **Changes:** Python script to patch SQLite header offset 28 (page_count: 491→495) and FOLKDISK header offset 56 (db_sectors: 3928→3960)
-- **Result:** SUCCESS! All writes now work:
-  - `test.txt` (23 bytes, rowid=29) ✓
-  - `hello.txt` (31 bytes, rowid=30) ✓
-  - `config.json` (24 bytes, rowid=31) ✓
-  - MIME auto-detection works (text/plain, application/json)
-  - Zero crashes, zero panics
-- **Conclusion:** The root cause was `folk-pack create-sqlite` writing page_count=491 but creating a B-tree that references page 495. Patching the header fixes it permanently.
+## Session 2026-04-29
 
-## Key Findings
-1. **Root cause:** `folk-pack create-sqlite` creates a DB where the B-tree interior node (page 2) references page 495, but the SQLite header says only 491 pages exist
-2. Synapse loads `page_count * page_size` bytes from disk → pages 492-495 are never loaded → zeroed
-3. The fix is two-fold:
-   a. Patch the existing DB (page_count=495)
-   b. Fix `folk-pack` to write correct page_count (long-term)
-4. The FOLKDISK header fix (attempt 1) was also correct — needed for persistence after page allocation
+### Attempt 0: Map the code (read-only)
+- **Hypothesis/Goal:** Find where `[Draug] Tick #1` prints, what gates Tick #2, and what blocking syscalls are between them.
+- **Changes:** None — read-only investigation.
+- **Result:**
+  - Tick prints at `userspace/compositor/src/mcp_handler/agent_logic.rs:71`. Print condition is `count % 6 == 1 || count <= 3` → Ticks #1, #2, #3 SHOULD all print on cold boot.
+  - `Draug::should_tick` (`draug.rs:1001`) requires `self.active && now_ms - last_tick_ms >= 10_000`. Tick interval = 10s. After Tick #1 at uptime ~12s, Tick #2 should fire at uptime ~22s.
+  - `now_ms` source: `if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { uptime() }`.
+  - Main loop (`main.rs:696`) has NO HLT — only `for _ in 0..5_000 { spin_loop() }` when `!did_work`. Spinning means CPU should be 100%, but Proxmox shows CPU=0%. Either compositor is preempted to HLT by kernel, or a syscall is blocking in the kernel.
+  - Between Tick #1 and Tick #2 candidates for blocking call:
+    - `tick_async` (Phase 13/17 refactor) — calls `fetch_source` SYNCHRONOUSLY at `draug_async.rs:258`. But gated on `should_run_refactor_step` which requires `idle >= 30s`. At uptime 12-15s, idle=12-15s → NOT eligible. Eliminated for the period 12-22s.
+    - `knowledge_hunt::run` (`knowledge_hunt.rs:72`) — gated on `idle >= 15s` (KNOWLEDGE_HUNT_IDLE_MS). Eligible from uptime 15s onward. Calls `fbp_request` (synchronous syscall). If KHunt fires and freezes, we'd see `[KGraph] test start` (line 888 of knowledge_hunt.rs) FIRST. We do NOT see it → KHunt is never reached, OR run_graph_supersession_test prints fail somehow. Most likely KHunt iter never executes because freeze happens before idle=15s.
+    - `draug_bridge_update` (syscall 0xD0) — atomic stores only, kernel `dispatch.rs:137-153`. Non-blocking. Eliminated.
+    - `gpu_flush` (syscall 0x80) — called by `present_and_flush` once per clock tick (every 1s). Has been called ~12 times BEFORE Tick #1 successfully. Not a "first-time" failure, but could degrade.
+    - Various input syscalls (mouse/keyboard polls). Typically non-blocking.
+  - Synapse persistence is broken on the Proxmox raw 64MB scsi0 image: `[SYNAPSE] VirtIO header read failed: IoError`, `disk flush failed (data in memory only)`. Does NOT block the boot — Synapse falls back to in-memory.
+- **Conclusion:**
+  - The freeze is most likely between uptime 12s (Tick #1) and 15s (KHunt eligibility) — short 3-second window, no obvious blocking call in the path.
+  - OR the freeze is in something running EVERY loop iteration that suddenly fails after Tick #1 has fired.
+  - Need actual evidence. Next step: instrument the loop with a periodic heartbeat to prove whether the loop is alive at all after Tick #1.
 
-### Attempt 6-8: VirtIO block write status=255 (SECOND BUG)
-After fixing the B-tree insert, writes succeed IN MEMORY but `flush_sqlite_to_disk()` fails. VirtIO block_write returns status=0xFF (device never wrote status byte).
+### Attempt 1: Heartbeat instrumentation
+- **Hypothesis/Goal:** Add `[HB iter=N now_ms=M]` print every 5 seconds at the top of the main loop. Two outcomes:
+  - **Heartbeats continue but no Tick #2** → loop is alive; freeze is in Draug-tick logic.
+  - **Heartbeats stop after some N** → loop is dead; the iteration that printed last heartbeat blocked downstream.
+- **Changes:** Added `hb_iter` counter and 5s-throttled `[HB iter=N now=Mms]` print at top of main loop in `userspace/compositor/src/main.rs` right after the existing `[LOOP ALIVE]` one-shot.
+- **Side issue found:** `deploy.py` had a bug picking the **oldest** unused disk slot from `qm config` instead of the slot the most recent `qm importdisk` landed in. Caused redeploys to boot the original 8GB blank disk after the first deploy. Fixed: parse the importdisk output for `unusedN:storage:vm-VMID-disk-X`, fall back to highest-numbered unused slot. **Manually re-attached `vm-800-disk-2` to scsi0 to get this experiment running.**
+- **Result:** Serial log shows ONE heartbeat at the very moment Tick #1 prints — no second iteration ever runs:
+  ```
+  582:[BOOT] All tasks spawned, starting scheduler...
+  587:[HB] kernel_ticks=0 uptime_ms=10 debug_marker=0xbeef        ← kernel-side, not mine
+  768:[HB iter=1 now=12375ms]                                      ← my instrumentation, iter 1
+  771:[Draug] Tick #1 | idle: 12s | dreams: 0/10
+  ```
+  Drained for ~6 minutes — last serial line is `[Draug] Tick #1`. No `[HB iter=2`.
+- **Conclusion:**
+  - The compositor main loop runs **exactly one iteration** before the freeze. The body of iteration #1 never returns to the top of the loop.
+  - The freeze happens AFTER `[HB iter=1]` (top of loop) AND AFTER `[Draug] Tick #1` (printed inside `mcp_handler::tick_ai_systems`).
+  - The freeze must be somewhere between Tick #1 print (in `agent_logic::tick`, line 71) and the bottom of the loop body. Candidates remaining inside `tick_ai_systems`:
+    - rest of agent_logic::tick (Pattern Mining, Phase 13 refactor, Bridge update — but bridge is called every iter, so first call would have run earlier in the same iteration before the print)
+    - Knowledge hunt and AutoDream gates closed at idle=12s
+    - MCP `poll()` — `tz_sync_pending` is true at this point because `[MCP] TimeSyncRequest sent` already printed; `poll()` is non-blocking by inspection (`com2_async_poll` is async)
+  - Outside `tick_ai_systems`: god_mode::poll_com3, process_mouse, caret blink, process_keyboard, command_dispatch, render_frame, present_and_flush.
+  - Need finer markers to localize.
 
-**Tested:**
-- Volatile read + retry: Still 0xFF
-- Disable journal writes: Still fails (earlier, sector 2063 → 2048)
-- Busy-poll ISR without sti: System hangs (KVM needs IF=1 for ISR update)
-- sti + busy-poll: Fails at first sector (#0/3960)
+### Attempt 2: Finer-grained markers in main loop body
+- **Hypothesis/Goal:** Print short `[L.X]` markers (A through I) at section boundaries inside the main loop, gated on `hb_iter <= 3` so we see which section iteration #1 reaches before freezing.
+- **Changes:** Added 9 markers in `main.rs`: pre-aitick, post-aitick, post-com3, pre-mouse, post-mouse, pre-kbd, post-kbd, post-render, post-present.
+- **Result:** Serial output before freeze (after first deploy.py bug-fix run):
+  ```
+  768:[HB iter=1 now=12735ms]
+  771:[L.A pre-aitick]
+  772:[Draug] Tick #1 | idle: 12s | dreams: 0/10
+  773:[L.B post-aitick]
+  ```
+  After `[L.B post-aitick]` — nothing. NO `[L.C post-com3]`. Drained 5+ minutes.
+- **Conclusion:**
+  - Freeze is in `god_mode::poll_com3()` at `main.rs` line 871 (call site) → `userspace/compositor/src/god_mode.rs`.
+  - Looking at the function: a `while let Some(byte) = libfolk::sys::com3_read() { ... }` with NO iteration cap.
+  - On QEMU with no COM3 backend (true on both Proxmox/KVM and the Windows host with WHPX), reading port 0x3E8 with LSR DR=1 indefinitely is a known emulator behavior — kernel `com3_read_byte` faithfully returns `Some(_)` every time, looping forever.
+  - The compositor co-author already knew this pattern bites, see `kernel/src/drivers/serial.rs:170` which caps `com2_async_poll` at 4096 reads with the comment "to avoid starving the main loop". COM3 was missed.
+  - Fix: cap `poll_com3` at 4096 iterations per call, mirror the COM2 defense.
 
-**Key observations:**
-- Self-test (boot, kernel context) writes to sector 2148: PASSES
-- Synapse flush (userspace syscall) writes to sector 2048: FAILS with 0xFF
-- Same `block_write` → `do_io` function in both cases
-- The device responds (IO_COMPLETE set) but status byte is never overwritten
-- QEMU/KVM host has no I/O errors (dmesg clean)
+### Attempt 3: Fix poll_com3 with 4096-iteration cap
+- **Hypothesis/Goal:** Replace unbounded `while let Some(byte) = com3_read()` with `for _ in 0..4096 { let Some(byte) = com3_read() else { break }; ... }`. This bounds the worst-case work per frame regardless of what the emulated UART reports, while still draining real injected commands (which are limited to a few hundred bytes anyway).
+- **Changes:** Edited `userspace/compositor/src/god_mode.rs:13-31`. Documented why the cap exists (Issue #49 root cause + parallel to com2_async_poll).
+- **Result:** Loop runs to completion every iteration:
+  ```
+  HB iter=1   now=12496ms   (Tick #1 fires here, idle 12s)
+  HB iter=69  now=17551ms   (KGraph self-test passes between)
+  HB iter=137 now=22557ms   Tick #2 fires (idle 22s)
+  HB iter=205 now=27577ms
+  ...
+  Tick #3 fires at idle 32s → triggers Phase 17 path:
+    [Draug-async] fib_iter L1 → LLM
+    [Draug-async] connect failed (no slots)   ← expected: no proxy in this VM
+    [Draug] Tick #3 | idle: 32s | dreams: 0/10
+  ```
+  Loop runs at ~70 iter/5s, Phase 17 wiring activates correctly. `connect failed` is environment (no LLM proxy on Proxmox VM 800), not a bug — the code path handles it gracefully via `record_skip`.
+- **Conclusion:**
+  - Issue #49 ROOT CAUSE FIXED.
+  - The single-line semantic change (unbounded `while` → bounded `for`) eliminates the freeze on every QEMU configuration where COM3 has no backend (which is the default for most users).
+  - Removed all instrumentation (HB heartbeat + 9 L.X markers); only the actual fix remains.
+  - Archived first-boot serial log (with freeze) and fix-verified serial log (with progression) at `proxmox-mcp/serial-logs/`.
+  - Side-fix: corrected `proxmox-mcp/deploy.py` to parse `qm importdisk` output for the actual landing slot instead of picking the oldest unused slot.
 
-**Possible causes still to investigate:**
-- IRQ handler and do_io might have a race where the handler sets IO_COMPLETE from a STALE interrupt (previous I/O), masking the fact that the current I/O hasn't completed yet
-- The `pop_used()` call might be popping the WRONG used ring entry
-- Timer interrupt (which fires between do_io calls) might interfere with VirtIO state
-
-### Attempt 9: Retry + read-verify workaround + resilient flush ✅ PERSISTENCE WORKING
-- **Hypothesis:** VirtIO writes succeed but status byte stays 0xFF. Read-back verifies the write actually happened.
-- **Changes:**
-  1. `block_write()`: 3 retries per sector, each with write-then-read-verify
-  2. `flush_sqlite_to_disk()`: continues past individual sector errors, reports total
-  3. Reduced I/O poll timeout from 10M to 500K iterations
-  4. Suppressed repetitive "I/O error, status=255" logging
-- **Result:** SUCCESS! 3886/3960 sectors written (98% success rate). File persisted across reboot — 8 files after restart (was 7 before write + restart).
-- **Root cause of status=0xFF:** Race between KVM VirtIO interrupt delivery and do_io completion check. The device writes data correctly but the status byte isn't visible to the CPU before the ISR fires. Workaround: verify by reading back.
-
-**Status:** BOTH bugs fixed:
-1. ✅ B-tree page_count mismatch (folk-pack + DB header patch)
-2. ✅ VirtIO write status=0xFF (retry + read-verify workaround)
-3. ✅ Persistence verified — files survive reboot!
-
-## Architecture Notes
-- SQLite page size: 4096 bytes (from header offset 16)
-- Page types: 0x0D=leaf table, 0x05=interior table, 0x0A=leaf index, 0x02=interior index
-- Page 1 is special: first 100 bytes are the DB header, B-tree header starts at offset 100
-- Root page for tables is found via sqlite_master (page 1) → column 3 (rootpage)
-- SQLITE_STATE buffer: 2MB max (MAX_DB_SIZE), SQLITE_STATE.size tracks actual loaded size
-
-## Files Involved
-- `userspace/synapse-service/src/main.rs` — Synapse service (B-tree insert at ~line 1440)
-- `tools/folk-pack/` — Tool that creates the initial SQLite DB
-- `boot/virtio-data.img` — VirtIO data disk with FOLKDISK header + SQLite
-- `kernel/src/drivers/virtio_blk.rs` — VirtIO block driver
+## Status: RESOLVED (pending PR + commit)

--- a/debug_log_archive_synapse_btree_2026-04.md
+++ b/debug_log_archive_synapse_btree_2026-04.md
@@ -1,0 +1,109 @@
+# Synapse VFS B-tree Insert Bug — Debug Log
+
+## Problem Summary
+`[SYNAPSE] insert: unexpected page type 0x00` when writing files to SQLite VFS.
+Blocks all persistence: WASM app caching, AutoDream, driver version control.
+
+## Session 7. april 2026
+
+### Attempt 1: FOLKDISK header not updated after flush
+- **Hypothesis:** `flush_sqlite_to_disk()` writes new pages to disk but never updates `synapse_db_size` in sector 0 header. On reboot, fewer sectors are loaded → new pages are zeroed.
+- **Changes:** Added header update in `flush_sqlite_to_disk()` (offset 56-63, LE u64 sector count)
+- **Result:** PARTIAL FIX — correct for reboot persistence, but bug ALSO occurs on first insert within a single boot session (before any flush/reboot)
+- **Conclusion:** Header fix is necessary but NOT the root cause of the initial insert failure
+
+### Attempt 2: content_buf too small (4096 bytes)
+- **Hypothesis:** WASM files >4KB silently truncated during write
+- **Changes:** Increased `content_buf` to 16KB stack buffer, added truncation warning. Also increased `cell_buf` to 16KB.
+- **Result:** N/A for current bug (test files are <4KB), but prevents future data loss
+- **Conclusion:** Good fix, not the root cause
+
+### Attempt 3: Data disk stale/corrupted
+- **Hypothesis:** VirtIO data disk (vm-900-disk-1) had corrupted sectors from old deploys
+- **Changes:** Re-uploaded fresh `virtio-data.img`, re-imported disk into Proxmox
+- **Result:** Fixed `[SYNAPSE] VirtIO DB read failed at sector 3584`. SQLite now loads correctly (3928 sectors, 5 files)
+- **Conclusion:** Stale data disk was a separate issue. Insert still fails after correct load.
+
+### Attempt 4: Debug B-tree traversal (CURRENT)
+- **Hypothesis:** B-tree right-pointer leads to an out-of-range or zeroed page
+- **Changes:** Added detailed logging in `sqlite_insert_file()`:
+  - root_page, page_count, db_size
+  - Each traversal step: depth, page number, page type
+  - Out-of-range checks before page access
+  - Interior page right-pointer value
+- **Result:** ROOT CAUSE FOUND!
+  - root_page=2, page_count=491, db_size=2011136
+  - Page 2 is interior (0x05) with 4 cells + right-ptr
+  - Child pages: [30, 31, 355, 359, **495**]
+  - **Right-pointer = 495 but page_count = 491!**
+  - Page 495 is at offset 2,023,424 — 12,288 bytes BEYOND the loaded DB
+  - Synapse loads only 491 pages (based on page_count) → page 495 is zeroed → type 0x00
+- **Conclusion:** The initial SQLite DB created by `folk-pack create-sqlite` has a corrupted page_count. The B-tree references page 495 but header says 491 pages.
+
+### Attempt 5: Fix page_count in virtio-data.img ✅ B-TREE INSERT FIXED
+- **Hypothesis:** Setting page_count=495 and updating db_sectors will fix the insert
+- **Changes:** Python script to patch SQLite header offset 28 (page_count: 491→495) and FOLKDISK header offset 56 (db_sectors: 3928→3960)
+- **Result:** SUCCESS! All writes now work:
+  - `test.txt` (23 bytes, rowid=29) ✓
+  - `hello.txt` (31 bytes, rowid=30) ✓
+  - `config.json` (24 bytes, rowid=31) ✓
+  - MIME auto-detection works (text/plain, application/json)
+  - Zero crashes, zero panics
+- **Conclusion:** The root cause was `folk-pack create-sqlite` writing page_count=491 but creating a B-tree that references page 495. Patching the header fixes it permanently.
+
+## Key Findings
+1. **Root cause:** `folk-pack create-sqlite` creates a DB where the B-tree interior node (page 2) references page 495, but the SQLite header says only 491 pages exist
+2. Synapse loads `page_count * page_size` bytes from disk → pages 492-495 are never loaded → zeroed
+3. The fix is two-fold:
+   a. Patch the existing DB (page_count=495)
+   b. Fix `folk-pack` to write correct page_count (long-term)
+4. The FOLKDISK header fix (attempt 1) was also correct — needed for persistence after page allocation
+
+### Attempt 6-8: VirtIO block write status=255 (SECOND BUG)
+After fixing the B-tree insert, writes succeed IN MEMORY but `flush_sqlite_to_disk()` fails. VirtIO block_write returns status=0xFF (device never wrote status byte).
+
+**Tested:**
+- Volatile read + retry: Still 0xFF
+- Disable journal writes: Still fails (earlier, sector 2063 → 2048)
+- Busy-poll ISR without sti: System hangs (KVM needs IF=1 for ISR update)
+- sti + busy-poll: Fails at first sector (#0/3960)
+
+**Key observations:**
+- Self-test (boot, kernel context) writes to sector 2148: PASSES
+- Synapse flush (userspace syscall) writes to sector 2048: FAILS with 0xFF
+- Same `block_write` → `do_io` function in both cases
+- The device responds (IO_COMPLETE set) but status byte is never overwritten
+- QEMU/KVM host has no I/O errors (dmesg clean)
+
+**Possible causes still to investigate:**
+- IRQ handler and do_io might have a race where the handler sets IO_COMPLETE from a STALE interrupt (previous I/O), masking the fact that the current I/O hasn't completed yet
+- The `pop_used()` call might be popping the WRONG used ring entry
+- Timer interrupt (which fires between do_io calls) might interfere with VirtIO state
+
+### Attempt 9: Retry + read-verify workaround + resilient flush ✅ PERSISTENCE WORKING
+- **Hypothesis:** VirtIO writes succeed but status byte stays 0xFF. Read-back verifies the write actually happened.
+- **Changes:**
+  1. `block_write()`: 3 retries per sector, each with write-then-read-verify
+  2. `flush_sqlite_to_disk()`: continues past individual sector errors, reports total
+  3. Reduced I/O poll timeout from 10M to 500K iterations
+  4. Suppressed repetitive "I/O error, status=255" logging
+- **Result:** SUCCESS! 3886/3960 sectors written (98% success rate). File persisted across reboot — 8 files after restart (was 7 before write + restart).
+- **Root cause of status=0xFF:** Race between KVM VirtIO interrupt delivery and do_io completion check. The device writes data correctly but the status byte isn't visible to the CPU before the ISR fires. Workaround: verify by reading back.
+
+**Status:** BOTH bugs fixed:
+1. ✅ B-tree page_count mismatch (folk-pack + DB header patch)
+2. ✅ VirtIO write status=0xFF (retry + read-verify workaround)
+3. ✅ Persistence verified — files survive reboot!
+
+## Architecture Notes
+- SQLite page size: 4096 bytes (from header offset 16)
+- Page types: 0x0D=leaf table, 0x05=interior table, 0x0A=leaf index, 0x02=interior index
+- Page 1 is special: first 100 bytes are the DB header, B-tree header starts at offset 100
+- Root page for tables is found via sqlite_master (page 1) → column 3 (rootpage)
+- SQLITE_STATE buffer: 2MB max (MAX_DB_SIZE), SQLITE_STATE.size tracks actual loaded size
+
+## Files Involved
+- `userspace/synapse-service/src/main.rs` — Synapse service (B-tree insert at ~line 1440)
+- `tools/folk-pack/` — Tool that creates the initial SQLite DB
+- `boot/virtio-data.img` — VirtIO data disk with FOLKDISK header + SQLite
+- `kernel/src/drivers/virtio_blk.rs` — VirtIO block driver

--- a/userspace/compositor/src/god_mode.rs
+++ b/userspace/compositor/src/god_mode.rs
@@ -10,9 +10,16 @@ use libfolk::sys::io::write_str;
 
 /// Poll COM3 serial port for injected commands.
 /// Returns true if any work was done.
+///
+/// Cap: at most 4096 bytes are drained per call. Without this cap a
+/// QEMU/KVM (or WHPX) backend that reports LSR DR=1 indefinitely on an
+/// unconnected COM3 would lock the compositor's main loop on iteration
+/// #1 — root cause of Issue #49. Same defensive cap used by
+/// `com2_async_poll` in the kernel for the analogous COM2 ring drain.
 pub fn poll_com3(buf: &mut [u8; 512], len: &mut usize, queue: &mut Vec<String>) -> bool {
     let mut did_work = false;
-    while let Some(byte) = libfolk::sys::com3_read() {
+    for _ in 0..4096 {
+        let Some(byte) = libfolk::sys::com3_read() else { break; };
         if byte == b'\n' && *len > 0 {
             if let Ok(cmd) = alloc::str::from_utf8(&buf[..*len]) {
                 write_str("[COM3] Inject: ");


### PR DESCRIPTION
## Summary

Closes #49.

`userspace/compositor/src/god_mode.rs::poll_com3` had an unbounded `while let Some(byte) = com3_read()` loop. On any QEMU configuration without a COM3 backend (WHPX on Windows, KVM on Linux/Proxmox, default local config), the emulated 16550 reports LSR DR=1 indefinitely on the unconnected port. \`com3_read\` faithfully returns \`Some(_)\` forever, and the compositor's main loop deadlocks on **iteration #1**, right after \`[Draug] Tick #1\` prints.

This mirrors the existing 4096-iteration defense in \`com2_async_poll\` (\`kernel/src/drivers/serial.rs:170\`) — same problem, same fix shape, just for COM3 instead of COM2.

## Diff

- ~3 net lines of behavior change in \`god_mode.rs\` (\`while\` → \`for ..0..4096\`).
- Added a doc-comment block explaining why the cap exists.
- Stripped the diagnostic instrumentation used to localize the freeze.
- Bonus: \`active_debug_log.md\` checked in per the CLAUDE.md scientific-debugging protocol — full Hypothesis/Changes/Result/Conclusion trail across three attempts.
- Archived the unrelated old SQLite-bug log to \`debug_log_archive_synapse_btree_2026-04.md\`.

## How it was localized

1. **Attempt 0** — read the code. Catalogued every gated/blocking call between Tick #1 and the next expected Tick #2.
2. **Attempt 1** — added a 5s-throttled \`[HB iter=N now=Mms]\` heartbeat at the top of the main loop. Saw exactly one \`HB iter=1\` then silence → loop never reached iteration 2.
3. **Attempt 2** — added 9 \`[L.A]\`-\`[L.I]\` markers between major sections of the loop body, gated on \`hb_iter <= 3\`. Output stopped between \`[L.B post-aitick]\` and \`[L.C post-com3]\`. Pinpointed \`poll_com3\`.
4. **Attempt 3** — applied 4096-iter cap. Loop now runs ~70 iter/5s; Tick #1 → Tick #2 → Tick #3 → Phase 17 skill tree fires \`fib_iter L1 → LLM\` (which then \`connect failed (no slots)\` because this Proxmox VM has no proxy on \`10.0.2.2:14711\` — expected, code path handles via \`record_skip\`).

## Side fix in deploy.py

Found while doing the experiment: \`proxmox-mcp/deploy.py\` was parsing the *first* unused disk slot from \`qm config\` instead of the slot that the most recent \`qm importdisk\` actually landed in. After the second deploy on a VM with stale unused slots, \`scsi0\` would get re-attached to the original blank 8 GB disk and the VM would silently boot nothing. Fixed in the proxmox-mcp tree (not part of this PR), but worth noting because the bug confused the experiment for one cycle.

## Test plan

- [x] Builds clean (\`cargo build --release -p compositor --target x86_64-folkering-userspace.json\`)
- [x] Verified live on Proxmox VE 8.4.1 / KVM (VM 800). Serial logs:
  - \`proxmox-mcp/serial-logs/vm-800-2026-04-29-firstboot.log\` — frozen
  - \`proxmox-mcp/serial-logs/vm-800-2026-04-29-fix-verified.log\` — Tick #1 → #2 → #3 + Phase 17 activates
- [x] No behavior regression for real COM3 commands (cap is 4096 ≫ practical command size of ≤512 bytes)
- [ ] Worth re-verifying on local QEMU+WHPX next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)