### PR TITLE
fix: rescue dropped Pass-2/3 spin-loop caps from #52 squash-merge

### DIFF
--- a/kernel/src/drivers/keyboard.rs
+++ b/kernel/src/drivers/keyboard.rs
@@ -164,11 +164,16 @@ pub const KEY_CTRL_V: u8 = 0x8B;
 /// Initialize keyboard driver
 pub fn init() {
     unsafe {
-        // Clear any pending keyboard data before enabling interrupt
+        // Clear any pending keyboard data before enabling interrupt.
+        // Capped at 256 reads — real PS/2 controllers buffer ≤16 bytes,
+        // but a broken emulator that keeps DR=1 high would otherwise
+        // freeze boot here (Issue #49 pattern, hardware-init flavour).
         let mut status = Port::<u8>::new(KEYBOARD_STATUS_PORT);
         let mut data = Port::<u8>::new(KEYBOARD_DATA_PORT);
-        while status.read() & 1 != 0 {
+        let mut drained = 0u32;
+        while status.read() & 1 != 0 && drained < 256 {
             let _ = data.read();
+            drained += 1;
         }
 
         // Enable IRQ1 (keyboard) using centralized PIC module
@@ -188,11 +193,14 @@ pub fn init_without_pic() {
     }
 
     unsafe {
-        // Clear any pending data in the keyboard buffer
+        // Clear any pending data in the keyboard buffer.
+        // Same 256-read cap as `init()` above.
         let mut status = Port::<u8>::new(KEYBOARD_STATUS_PORT);
         let mut data = Port::<u8>::new(KEYBOARD_DATA_PORT);
-        while status.read() & 1 != 0 {
+        let mut drained = 0u32;
+        while status.read() & 1 != 0 && drained < 256 {
             let _ = data.read();
+            drained += 1;
         }
 
         // Don't enable PIC IRQ - IOAPIC handles it

--- a/kernel/src/drivers/virtio_net/mod.rs
+++ b/kernel/src/drivers/virtio_net/mod.rs
@@ -59,9 +59,14 @@ static NET_DEVICE: Mutex<Option<VirtIONet>> = Mutex::new(None);
 // ── MSI-X Detection ────────────────────────────────────────────────────
 
 /// Check if the PCI device has MSI-X capability
+///
+/// Capped at 32 iterations to defend against a self-referential cap
+/// pointer (real PCI devices have at most ~16 caps; the existing
+/// `virtio_gpu/pci_setup.rs` uses the same 32-cap bound).
 fn has_msix(dev: &PciDevice) -> bool {
     let mut ptr = dev.capabilities_ptr;
-    while ptr != 0 {
+    let mut iterations = 0u8;
+    while ptr != 0 && iterations < 32 {
         let cap_id = pci::pci_read8(dev.bus, dev.device, dev.function, ptr);
         if cap_id == PCI_CAP_ID_MSIX {
             // Check if MSI-X is actually enabled (bit 15 of Message Control at cap+2)
@@ -70,6 +75,7 @@ fn has_msix(dev: &PciDevice) -> bool {
         }
         let next = pci::pci_read8(dev.bus, dev.device, dev.function, ptr + 1);
         ptr = next;
+        iterations += 1;
     }
     false
 }
@@ -236,7 +242,15 @@ pub fn poll_rx() {
         None => return,
     };
 
+    // Cap at 256 packets per poll. RX queue is 1024 deep, but a
+    // continuous flood (broadcast storm, deliberate DoS) could keep
+    // refilling faster than we drain — same Issue #49 pattern. Yields
+    // back to the caller after 256 so other ISR-driven work makes
+    // progress even under flood.
+    let mut drained = 0u32;
     while let Some((frame, len)) = rx::receive_packet_inner(dev) {
+        drained += 1;
+        if drained > 256 { break; }
         let count = RX_PACKET_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Log first 8 packets to serial for debugging

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -252,16 +252,28 @@ impl BuddyAllocator {
     }
 
     /// Check if a block is in the free list
+    ///
+    /// Capped at 1M iterations to defend against a corrupted free
+    /// list (double-free creating a cycle, driver-induced memory
+    /// stomp, etc). On a 4 GB machine the longest possible order-0
+    /// freelist is ~1M entries — the cap is "if you exceeded this,
+    /// the list is corrupt, fail closed instead of looping forever."
     fn is_block_free(&self, addr: usize, order: usize) -> bool {
         let virt_addr = crate::phys_to_virt(addr);
         let mut current = self.free_lists[order];
+        let mut hops = 0u32;
 
         while let Some(block_ptr) = current {
+            if hops > 1_000_000 {
+                crate::serial_strln!("[PMM] is_block_free: freelist walk exceeded 1M — list corrupt");
+                return false;
+            }
             if block_ptr.as_ptr() as usize == virt_addr {
                 return true;
             }
             let block = unsafe { block_ptr.as_ref() };
             current = block.next;
+            hops += 1;
         }
 
         false
@@ -272,8 +284,14 @@ impl BuddyAllocator {
         let target_ptr = crate::phys_to_virt(addr) as *mut FreeBlock;
         let mut prev: Option<NonNull<FreeBlock>> = None;
         let mut current = self.free_lists[order];
+        let mut hops = 0u32;
 
         while let Some(block_ptr) = current {
+            if hops > 1_000_000 {
+                crate::serial_strln!("[PMM] remove_from_free_list: walk exceeded 1M — list corrupt");
+                return;
+            }
+            hops += 1;
             if block_ptr.as_ptr() == target_ptr {
                 // Found it - remove from list
                 let block = unsafe { block_ptr.as_ref() };

--- a/kernel/src/net/device.rs
+++ b/kernel/src/net/device.rs
@@ -78,7 +78,10 @@ impl Device for FolkeringDevice {
                 return None;
             }
         }
-        // Fallback to VirtIO — loop to skip dropped packets
+        // Fallback to VirtIO — loop to skip dropped packets. Capped at
+        // 256 dropped frames per receive() so a flood of denied packets
+        // (Issue #49 pattern) can't pin smoltcp's poll cycle.
+        let mut skipped = 0u32;
         loop {
             let (frame, len) = match virtio_net::receive_raw() {
                 Some(f) => f,
@@ -88,6 +91,8 @@ impl Device for FolkeringDevice {
                 let rx = FolkeringRxToken { buffer: frame[..len].to_vec() };
                 return Some((rx, FolkeringTxToken));
             }
+            skipped += 1;
+            if skipped > 256 { return None; }
         }
     }
 

--- a/spin_loop_audit.md
+++ b/spin_loop_audit.md
@@ -84,11 +84,51 @@ Established pattern: every hardware poll either (a) caps iterations, OR (b) yiel
 
 ---
 
-## Action plan
+## Pass 2 — deeper sweep (network, TLS, GPU, ACPI)
 
-- **This PR:** apply fix #2 (`com3_write_byte`) — minimal, surgical, mirrors existing COM2 pattern, eliminates kernel-wide hang on broken-COM3-emulator configs. Same risk profile as PR #50.
-- **Follow-up issue / PR:** apply caps to #5–#8 as defense-in-depth. #3 and #4 can wait until someone reports an RTC issue or until the cleanup agent's work in 14 days picks them up incidentally.
-- **No action needed:** the reference patterns and verified-safe samples — they're calibrated correctly.
+Re-ran with broader patterns: `while !.*\.load`, `while \w+ [!=<>]+`, `read_volatile`, `mmio_read`, every `loop {}` in kernel/src/net/. Verified each match against actual code rather than sampling. Three additional findings, all in network code:
+
+### 9. `kernel/src/drivers/virtio_net/mod.rs:64` — PCI cap chain walk — **NEW**
+- **Severity:** LOW (real PCI hardware doesn't loop) but trivial fix.
+- **Pattern:** `while ptr != 0 { ... ptr = next; }` with no cycle detection.
+- **Reference:** `virtio_gpu/pci_setup.rs:29` already caps at `iterations < 32`.
+- **Fix:** mirror that — `while ptr != 0 && iterations < 32`.
+
+### 10. `kernel/src/drivers/virtio_net/mod.rs:239` — `poll_rx` packet drain — **NEW**
+- **Severity:** MEDIUM (broadcast storm / flood DoS).
+- **Pattern:** `while let Some((frame, len)) = rx::receive_packet_inner(dev) { ... }` — no cap. RX queue is 1024 deep but a continuous arrival rate exceeding our drain rate keeps the loop going.
+- **Fix:** 256 packets per poll; yield back so other ISR-driven work makes progress.
+
+### 11. `kernel/src/net/device.rs:82` — firewall-drop drain — **NEW**
+- **Severity:** MEDIUM (deliberate flood with denied packets pins smoltcp).
+- **Pattern:** `loop { virtio_net::receive_raw() ... if firewall.allow { return } }` with no cap. If every packet is dropped by firewall, the loop eats whatever the queue serves until it empties — but a faster flood prevents that.
+- **Fix:** cap at 256 skipped frames per `receive()` call.
+
+## Verified safe in Pass 2
+
+- All `kernel/src/net/tcp_plain.rs` loops (10s/15s/per-call timeouts)
+- All `kernel/src/net/tls/{mod,io}.rs` loops (10s/30s/60s timeouts)
+- `kernel/src/net/gemini.rs` loops (60s overall)
+- `kernel/src/net/websocket.rs` loops (10s)
+- `kernel/src/net/dns.rs:49` (10s timeout)
+- `kernel/src/net/udp.rs:95` (per-call timeout)
+- `kernel/src/net/a64_stream.rs` all loops (10s timeouts + try_lock cap)
+- `kernel/src/net/mod.rs:130` DHCP wait (10s)
+- `kernel/src/drivers/nvme.rs:1260` (`for _ in 0..2_000_000`)
+- `kernel/src/drivers/virtio_blk.rs:845` (100_000 iter + HLT)
+- `kernel/src/drivers/virtio_gpu/flush.rs:253` (timeout + HLT)
+- `userspace/compositor/src/main.rs:86` (IPC event loop, yields on WouldBlock)
+
+## Userspace draug-streamer — confirmed earlier observation
+
+`userspace/draug-streamer/src/tcp.rs:69` (and the parallel send_all/recv_exact) — `loop { match tcp_connect_async { TCP_EAGAIN => yield_cpu(), ... } }`. **No timeout.** This is the source of the "ARPs forever" behavior we observed in PR #51. The cleanup-agent (\`trig_01JRiN4Zhpby7Wr8DUHfnn7G\`) is queued to fix it with retry-with-backoff in 14 days; not duplicating the work here.
+
+## Action plan (updated)
+
+- **PR #52 (already filed):** com3_write_byte cap.
+- **This PR (extending #52):** + virtio-net PCI cap walk + virtio-net poll_rx + firewall drop drain. Three more network defense-in-depth fixes, all surgical, all building on the same audit lineage.
+- **Cleanup-agent territory (2026-05-13):** draug-streamer retry-with-backoff (already in its prompt).
+- **Lower priority (someone files an issue first):** cmos.rs RTC waits, input_keyboard/mouse drains, iqe.rs PIT calibration. Each is real but requires more thought (e.g., what's "too long" for an RTC update? does input_keyboard need to sleep 16ms between drains for typematic pacing?).
 
 ---
 

--- a/spin_loop_audit.md
+++ b/spin_loop_audit.md
@@ -84,6 +84,62 @@ Established pattern: every hardware poll either (a) caps iterations, OR (b) yiel
 
 ---
 
+## Pass 3 — exhaustive sweep (kernel arch, scheduler, IPC, allocator, drivers, ALL userspace)
+
+Walked every directory in `kernel/src/` (arch/, task/, ipc/, memory/, fs/, jit/, bridge/, capability/, timer/, drivers/{ac97,iommu,iqe,keyboard,mod,mouse,msix,nvme,pci,rng,serial,storage_bench,telemetry,virtio,virtio_blk,virtio_gpu,virtio_net}) and `userspace/{compositor,libfolk,libsqlite,libtensor,inference-server,intent-bus,intent-service,neural-scheduler,shell,synapse,synapse-service,wasm-runtime}`. Searched for `loop {}`, `while let Some`, `while !.*\.load`, `while \w+ [!=<>]+`, `for _ in 0..[huge]`, `try_lock`, `compare_exchange`, `read_volatile`, `mmio_read`. Read every match.
+
+### 12. `kernel/src/drivers/keyboard.rs:170, 194` — boot-time PS/2 buffer drain — **NEW**
+- **Severity:** LOW (real PS/2 controllers buffer ≤16 bytes)
+- **Pattern:** `while status.read() & 1 != 0 { let _ = data.read(); }` — no cap. Boot freezes if a broken emulator keeps DR=1 high.
+- **Sites:** Both `init()` and `init_without_pic()` — duplicated bug.
+- **Fix:** 256-read cap on each.
+
+### 13. `kernel/src/memory/physical.rs:259, 276` — buddy allocator freelist walks — **NEW**
+- **Severity:** LOW (only manifests under memory corruption — double-free, stack stomp, driver bug)
+- **Pattern:** `while let Some(block_ptr) = current { current = block.next; }` — no cycle detection. If the freelist is ever corrupt (e.g. self-referential `next`), every alloc/free freezes the kernel.
+- **Sites:** `is_block_free` (line 259) and `remove_from_free_list` (line 276)
+- **Fix:** 1M-hop cap with serial warning. On a 4 GB machine longest legitimate order-0 freelist is ~1M; exceeding it = corrupt = fail closed.
+
+### 14. `kernel/src/arch/x86_64/smp.rs:155` — AP worker spin
+- **Severity:** ⚠️ INEFFICIENT, not unsafe.
+- **Pattern:** `while WORK_READY[cpu_index].load(...) == 0 { spin_loop(); }` — no HLT yield. Burns AP CPU at 100% during idle. Comment says "PAUSE-based spin wait... reducing power" — true for the CPU itself, but on WHPX/KVM each vCPU is a host thread so this still steals cycles.
+- **NOT FIXED:** changing the wakeup model from spin to HLT+IPI would touch the parallel-GEMM dispatch path. Different scope.
+
+## Verified safe in Pass 3 (full inventory)
+
+**Kernel domain functions** — every loop has a bound or HLT yield:
+- `task/scheduler.rs:423` — idle scheduler (HLT)
+- `arch/x86_64/syscall/handlers/{io.rs:81, task.rs:124}` — poweroff/exit (HLT, intentional)
+- `arch/x86_64/idt.rs:153/163/175` — fault halt loops (intentional)
+- `arch/x86_64/smp.rs:85/260` — AP-ready waits (100M and 500M iter caps)
+- `arch/x86_64/acpi.rs:296` — page-mapping loop (bounded by size)
+- `drivers/keyboard.rs:377/390` — `read_key_blocking` (HLT yield)
+- `drivers/mouse.rs:111/121` — PS/2 wait (100K iter cap)
+- `drivers/nvme.rs:185, 764, 1260` — CAS retry, completion poll (caps + HLT), wait_ready (2M cap)
+- `drivers/virtio_blk.rs:577, 681, 845` — I/O waits (50K, 500K, 100K caps)
+- `drivers/virtio.rs:277` — descriptor-chain follow (bounded by queue size)
+- `drivers/virtio_gpu/{commands.rs:215, flush.rs:253}` — bounded
+- `drivers/cmos.rs:224` — year-from-epoch (~150 iters max)
+- `drivers/telemetry.rs:224` — bounded by `max_count`
+- `drivers/msix.rs:170` — bit-allocator CAS (returns None on exhaustion)
+- `drivers/iommu.rs` — accessor functions (no loops)
+
+**Userspace tasks** — all confirmed safe:
+- `compositor/src/main.rs:86, 696` — IPC + main event loop
+- `intent-service/src/main.rs:185` — IPC event loop
+- `intent-bus/src/main.rs:49` — async channel rx
+- `synapse-service/src/main.rs:131` — IPC event loop
+- `synapse-service/src/btree.rs:1117` — BFS graph walk (depth+visited bounded)
+- `shell/src/main.rs:30/34` — IPC drain loops (yield)
+- `inference-server/src/handlers.rs:659` — tool-result wait (500K cap)
+- `inference-server/src/bin/main.rs:66, 163, 226` — yield loops (intentional idle)
+- `libfolk/src/sys/{io.rs:90, task.rs:13}` — failsafe post-syscall hangs (exit/poweroff never return; loop is correct)
+- `libtensor/src/{arena.rs:61, tokenizer.rs:365/573/952}` — CAS/algorithmic, bounded
+- `libsqlite/src/{varint.rs:78, shadow.rs:223, btree.rs:40}` — algorithmic, bounded by data size
+- `compositor/src/mcp_handler/{knowledge_hunt.rs:368, agent_planner.rs:341}` — retry loops with `attempt < MAX_RETRIES` bound
+
+**Total verified-safe loop sites:** 30+. The `loop`/`while let Some` pattern is used pervasively but ALL of them either have explicit caps, finite iteration bounds, HLT yields, or yield_cpu yields — except the 14 sites flagged across all three passes.
+
 ## Pass 2 — deeper sweep (network, TLS, GPU, ACPI)
 
 Re-ran with broader patterns: `while !.*\.load`, `while \w+ [!=<>]+`, `read_volatile`, `mmio_read`, every `loop {}` in kernel/src/net/. Verified each match against actual code rather than sampling. Three additional findings, all in network code:


### PR DESCRIPTION
## Summary

PR #52 was squash-merged with only its first commit (\`com3_write_byte\`). The two follow-up commits — \`410cf87\` (Pass-2 net-side caps) and \`d2c2c97\` (Pass-3 keyboard + freelist caps) — were lost. This PR re-picks those exact commits onto a fresh branch from main.

Both commits live-verified on Proxmox/KVM before the original merge; this PR just brings them back.

## Commits being re-merged

### \`eca163b\` — Pass-2 net-side caps
- \`kernel/src/drivers/virtio_net/mod.rs:64\` — \`has_msix\` PCI cap walk capped at 32 iterations
- \`kernel/src/drivers/virtio_net/mod.rs:239\` — \`poll_rx\` packet drain capped at 256 packets/call
- \`kernel/src/net/device.rs:82\` — firewall-denied frame drain capped at 256 frames/call

### \`255dd74\` — Pass-3 kernel-init + allocator caps
- \`kernel/src/drivers/keyboard.rs:170, 194\` — boot-time PS/2 buffer drain capped at 256 reads (both \`init\` and \`init_without_pic\`)
- \`kernel/src/memory/physical.rs:259, 276\` — buddy allocator freelist walks capped at 1M hops with \"list corrupt\" warning

## Repro test against #53 — IMPORTANT FINDING

Re-ran the exact stress reproduction from #53 (TCP SYN flood @ 200 pps + UDP flood @ 300 pps for ~10 min, then stop, watch for recovery). Result:

> **The Pass-2/3 caps do NOT by themselves resolve #53.**
>
> Same TIMEOUT-loop-after-flood pattern: PASS=2, TIMEOUT=8 throughout. System stays alive, kernel keeps ticking, but Phase 17's outbound TCP path doesn't recover even after floods stop and proxy is fully responsive.

This means #53 has a **deeper cause** than just the unbounded loops the audit found. Suspects worth investigating:
1. \`Draug.refactor_hibernating\` mode — once \`consecutive_skips\` exceeds threshold, draug enters hibernation and only wakes via \`proxy_ping()\`. If proxy_ping itself wedges (it's a sync TCP call that probably hits the same broken state), draug stays hibernated forever.
2. smoltcp socket state pollution from the flood that survives \`tcp_close_async\` cleanup
3. ARP cache stale for the proxy host post-flood; subsequent TCP send waits on ARP that takes >90s

Filed as #57 — followup investigation. The Pass-2/3 caps are still real defense-in-depth wins for the bugs they target (PCI cap-loop hardening, broadcast-storm survival, allocator-corruption fail-fast, broken-emulator-init hardening) — they just don't paper over the deeper TCP-state wedge.

## Test plan

- [x] Builds clean (\`cargo build --release -p folkering-kernel ...\`)
- [x] Boots cleanly on Proxmox VE / KVM (VM 800)
- [x] First Phase 17 \`fib_iter L1 PASS\` and \`factorial L1 PASS\` produced before flood (pipeline still works)
- [x] No new freezes or panics introduced
- [x] Side-by-side diff is exactly the two cherry-picked commits + their audit-doc updates

## Artifacts

- \`proxmox-mcp/serial-logs/repro-53-with-pass2-3/vm800.log\` — full serial of the repro run
- \`proxmox-mcp/serial-logs/repro-53-with-pass2-3/proxy.log\` — proxy activity during the run
- \`spin_loop_audit.md\` — full Pass-2/3 documentation already in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)