### PR TITLE
fix: address Copilot off-by-one nits from #57

### DIFF
--- a/kernel/src/drivers/virtio_net/mod.rs
+++ b/kernel/src/drivers/virtio_net/mod.rs
@@ -247,10 +247,12 @@ pub fn poll_rx() {
     // refilling faster than we drain — same Issue #49 pattern. Yields
     // back to the caller after 256 so other ISR-driven work makes
     // progress even under flood.
-    let mut drained = 0u32;
-    while let Some((frame, len)) = rx::receive_packet_inner(dev) {
-        drained += 1;
-        if drained > 256 { break; }
+    // Bounded for-loop so the 257th packet is never dequeued under flood.
+    for _ in 0..256 {
+        let (frame, len) = match rx::receive_packet_inner(dev) {
+            Some(packet) => packet,
+            None => break,
+        };
         let count = RX_PACKET_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Log first 8 packets to serial for debugging

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -264,7 +264,7 @@ impl BuddyAllocator {
         let mut hops = 0u32;
 
         while let Some(block_ptr) = current {
-            if hops > 1_000_000 {
+            if hops >= 1_000_000 {
                 crate::serial_strln!("[PMM] is_block_free: freelist walk exceeded 1M — list corrupt");
                 return false;
             }
@@ -287,7 +287,7 @@ impl BuddyAllocator {
         let mut hops = 0u32;
 
         while let Some(block_ptr) = current {
-            if hops > 1_000_000 {
+            if hops >= 1_000_000 {
                 crate::serial_strln!("[PMM] remove_from_free_list: walk exceeded 1M — list corrupt");
                 return;
             }

--- a/kernel/src/net/device.rs
+++ b/kernel/src/net/device.rs
@@ -92,7 +92,7 @@ impl Device for FolkeringDevice {
                 return Some((rx, FolkeringTxToken));
             }
             skipped += 1;
-            if skipped > 256 { return None; }
+            if skipped >= 256 { return None; }
         }
     }
 


### PR DESCRIPTION
Copilot's review of #57 caught four off-by-one bugs in the spin-loop caps. Each cap allowed exactly one iteration past its documented limit. Fixes them all.

| Site | Before | After | Effect |
|---|---|---|---|
| \`net/device.rs:82\` firewall drop drain | \`> 256\` | \`>= 256\` | 257 → 256 dropped frames |
| \`virtio_net/mod.rs:251\` poll_rx | \`while let Some\` + \`> 256\` post-check | \`for _ in 0..256\` + \`match\` | 257 packets dequeued (1 dropped) → 256 packets dequeued, 257th stays queued |
| \`memory/physical.rs:267\` is_block_free | \`> 1_000_000\` | \`>= 1_000_000\` | 1M+1 → exactly 1M hops |
| \`memory/physical.rs:290\` remove_from_free_list | same | same | same |

The poll_rx fix is more than a comparison flip — it restructures the loop so we never pay the cost of dequeuing a packet we're going to drop. The other three are single-character edits.

## Test plan

- [x] Builds clean (\`cargo build --release -p folkering-kernel\`)
- [x] Diff is exactly +9/-7 in three kernel files, no audit-doc churn
- [ ] Behavioural test on Proxmox unnecessary — single-iteration off-by-one is below detection threshold; the value comes from matching the documented contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)