### PR TITLE
debug(#58): instrument Draug skip/hibernation transitions

### DIFF
--- a/userspace/compositor/src/draug.rs
+++ b/userspace/compositor/src/draug.rs
@@ -820,13 +820,38 @@ impl DraugDaemon {
     /// Fix 5: Record a skip (Ollama down).
     pub fn record_skip(&mut self) {
         self.consecutive_skips = self.consecutive_skips.saturating_add(1);
+        // Issue #58 instrumentation: log every skip so we can correlate
+        // with serial-side TIMEOUT events and see if hibernation triggers.
+        // Uses a small inline decimal formatter to avoid pulling in the
+        // crate::util::format_usize dep which lives in the compositor
+        // binary, not the lib.
+        let mut buf = [0u8; 4];
+        let mut len = 0usize;
+        let mut n = self.consecutive_skips;
+        if n == 0 { buf[0] = b'0'; len = 1; } else {
+            let mut tmp = [0u8; 4]; let mut i = 0usize;
+            while n > 0 { tmp[i] = b'0' + (n % 10) as u8; n /= 10; i += 1; }
+            for j in 0..i { buf[j] = tmp[i - 1 - j]; }
+            len = i;
+        }
+        libfolk::sys::io::write_str("[Draug-skip] consecutive=");
+        if let Ok(s) = core::str::from_utf8(&buf[..len]) {
+            libfolk::sys::io::write_str(s);
+        }
+        libfolk::sys::io::write_str("/30\n");
         // Fix 8: hibernate after 30 consecutive skips
         if self.consecutive_skips >= 30 && !self.refactor_hibernating {
             self.refactor_hibernating = true;
+            libfolk::sys::io::write_str("[Draug-skip] >>> HIBERNATE (waiting for proxy_ping every 60s)\n");
         }
     }
     /// Fix 5: Reset skips on success.
     pub fn reset_skips(&mut self) {
+        if self.refactor_hibernating {
+            libfolk::sys::io::write_str("[Draug-skip] <<< WAKE (proxy back, skips reset)\n");
+        } else if self.consecutive_skips > 0 {
+            libfolk::sys::io::write_str("[Draug-skip] reset to 0 (PASS)\n");
+        }
         self.consecutive_skips = 0;
         self.refactor_hibernating = false;
     }


### PR DESCRIPTION
Adds three serial log lines so the next debugger of #58 can see exactly when \`consecutive_skips\` climbs and whether hibernation triggers, instead of guessing from external behavior.

## Lines added

| Marker | When |
|---|---|
| \`[Draug-skip] consecutive=N/30\` | every \`record_skip()\` call |
| \`[Draug-skip] >>> HIBERNATE\` | when threshold (30) is hit |
| \`[Draug-skip] <<< WAKE\` | when \`reset_skips()\` un-hibernates |
| \`[Draug-skip] reset to 0 (PASS)\` | when counter was non-zero before a reset |

## Live verification

Booted on Proxmox/KVM, applied the same TCP+UDP flood as the #58 reproduction. Got 7 baseline PASSes (correctly silent — skips=0), then after the flood:

\`\`\`
[Draug-async] TIMEOUT after 90s in Reading — aborting
[Draug-skip] consecutive=1/30
[Draug-async] TIMEOUT after 90s in Sending — aborting
[Draug-skip] consecutive=2/30
[Draug-async] TIMEOUT after 90s in Sending — aborting
[Draug-skip] consecutive=3/30
... 7 total ...
\`\`\`

Confirms #58's core observation directly: skip counter climbs to 7 over the flood window, sits at 7 for 14+ minutes after the flood stops. Each timeout takes 90s so reaching the hibernation threshold of 30 would take ~45 min of wedged operation — too long for one session, but now the next session will see the threshold-hit moment in the log directly.

## Implementation note

Couldn't use \`crate::util::format_usize\` because it lives in the compositor binary not the lib. Inlined a tiny 4-byte decimal formatter — \`consecutive_skips\` is u32 but practical max is 30 anyway.

## Test plan

- [x] Builds clean (\`cargo build --release -p compositor --target x86_64-folkering-userspace.json\`)
- [x] Boots on Proxmox/KVM, no behavioral change in the no-flood baseline
- [x] Instrumentation fires correctly under flood (verified live)
- [x] Reset-on-PASS path doesn't spam (correctly silent when skips=0)

## Followup

Schedule a 60-min stress test that:
1. Applies flood for 5 min
2. Stops flood
3. Watches serial for either:
   - \`[Draug-skip] >>> HIBERNATE\` followed by \`<<< WAKE\` and recovery (good)
   - \`HIBERNATE\` with no wake-up (proxy_ping is broken under the wedge)
   - 30+ minutes of \`consecutive=30/30\` with no hibernate marker (record_skip not actually being called for some retries)

Each outcome points at a different fix.

Archive: \`proxmox-mcp/serial-logs/issue-58-instrumented/vm800.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)