### PR TITLE
debug(#58): instrument proxy_ping — confirms hibernation wedge

### DIFF
--- a/kernel/src/arch/x86_64/syscall/handlers/net.rs
+++ b/kernel/src/arch/x86_64/syscall/handlers/net.rs
@@ -1051,6 +1051,11 @@ pub fn syscall_proxy_ping() -> u64 {
     const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
     const PROXY_PORT: u16 = 14711;
 
+    // Issue #58 instrumentation: log every ping attempt + outcome so we
+    // can see whether hibernation's wakeup path is itself broken under
+    // the post-flood TCP wedge.
+    crate::serial_strln!("[PROXY_PING] requesting");
+
     let response = match crate::net::tcp_plain::tcp_request_with_timeout(
         PROXY_IP,
         PROXY_PORT,
@@ -1058,12 +1063,27 @@ pub fn syscall_proxy_ping() -> u64 {
         64,
         5_000, // ~2s wall clock
     ) {
-        Ok(data) => data,
-        Err(_) => return 0,
+        Ok(data) => {
+            crate::serial_str!("[PROXY_PING] tcp_request OK, ");
+            crate::drivers::serial::write_dec(data.len() as u32);
+            crate::serial_strln!(" bytes");
+            data
+        }
+        Err(e) => {
+            crate::serial_str!("[PROXY_PING] tcp_request failed: ");
+            crate::serial_strln!(e);
+            return 0;
+        }
     };
 
     // Proxy returns "PONG\n"
-    if response.len() >= 4 && &response[..4] == b"PONG" { 1 } else { 0 }
+    if response.len() >= 4 && &response[..4] == b"PONG" {
+        crate::serial_strln!("[PROXY_PING] PONG → result=1 (waking Draug)");
+        1
+    } else {
+        crate::serial_strln!("[PROXY_PING] no PONG in response → result=0");
+        0
+    }
 }
 
 /// Phase 16 — WASM compilation.

--- a/userspace/compositor/src/draug.rs
+++ b/userspace/compositor/src/draug.rs
@@ -652,11 +652,14 @@ impl DraugDaemon {
         if self.refactor_hibernating {
             if now_ms.saturating_sub(self.last_refactor_ms) >= 60_000 {
                 self.last_refactor_ms = now_ms;
+                libfolk::sys::io::write_str("[Draug-hib] 60s elapsed → calling proxy_ping\n");
                 if libfolk::sys::proxy_ping() {
+                    libfolk::sys::io::write_str("[Draug-hib] proxy_ping=true → resetting skips, resuming\n");
                     self.consecutive_skips = 0;
                     self.refactor_hibernating = false;
                     // Fall through to normal scheduling
                 } else {
+                    libfolk::sys::io::write_str("[Draug-hib] proxy_ping=false → still hibernating, retry in 60s\n");
                     return false;
                 }
             } else {

--- a/userspace/compositor/src/draug.rs
+++ b/userspace/compositor/src/draug.rs
@@ -820,13 +820,38 @@ impl DraugDaemon {
     /// Fix 5: Record a skip (Ollama down).
     pub fn record_skip(&mut self) {
         self.consecutive_skips = self.consecutive_skips.saturating_add(1);
+        // Issue #58 instrumentation: log every skip so we can correlate
+        // with serial-side TIMEOUT events and see if hibernation triggers.
+        // Uses a small inline decimal formatter to avoid pulling in the
+        // crate::util::format_usize dep which lives in the compositor
+        // binary, not the lib.
+        let mut buf = [0u8; 4];
+        let mut len = 0usize;
+        let mut n = self.consecutive_skips;
+        if n == 0 { buf[0] = b'0'; len = 1; } else {
+            let mut tmp = [0u8; 4]; let mut i = 0usize;
+            while n > 0 { tmp[i] = b'0' + (n % 10) as u8; n /= 10; i += 1; }
+            for j in 0..i { buf[j] = tmp[i - 1 - j]; }
+            len = i;
+        }
+        libfolk::sys::io::write_str("[Draug-skip] consecutive=");
+        if let Ok(s) = core::str::from_utf8(&buf[..len]) {
+            libfolk::sys::io::write_str(s);
+        }
+        libfolk::sys::io::write_str("/30\n");
         // Fix 8: hibernate after 30 consecutive skips
         if self.consecutive_skips >= 30 && !self.refactor_hibernating {
             self.refactor_hibernating = true;
+            libfolk::sys::io::write_str("[Draug-skip] >>> HIBERNATE (waiting for proxy_ping every 60s)\n");
         }
     }
     /// Fix 5: Reset skips on success.
     pub fn reset_skips(&mut self) {
+        if self.refactor_hibernating {
+            libfolk::sys::io::write_str("[Draug-skip] <<< WAKE (proxy back, skips reset)\n");
+        } else if self.consecutive_skips > 0 {
+            libfolk::sys::io::write_str("[Draug-skip] reset to 0 (PASS)\n");
+        }
         self.consecutive_skips = 0;
         self.refactor_hibernating = false;
     }


### PR DESCRIPTION
Adds five trace lines to the proxy_ping path so the hibernation-wakeup wedge described in #58 is directly visible in the serial log instead of inferred.

## What's instrumented

| Marker | Where |
|---|---|
| \`[PROXY_PING] requesting\` | kernel \`syscall_proxy_ping\` entry |
| \`[PROXY_PING] tcp_request OK, N bytes\` / \`failed: <error>\` | kernel TCP outcome |
| \`[PROXY_PING] PONG → result=1\` / \`no PONG → result=0\` | kernel return value |
| \`[Draug-hib] 60s elapsed → calling proxy_ping\` | userspace hibernation gate |
| \`[Draug-hib] proxy_ping=true|false → ...\` | userspace verdict |

## What this proved

Live test on Proxmox/KVM with hibernation threshold temporarily lowered to 3 (so we could observe in 5 min instead of 45). After the flood:

\`\`\`
[Draug-skip] consecutive=3/30
[Draug-skip] >>> HIBERNATE
[Draug-hib] 60s elapsed → calling proxy_ping
[PROXY_PING] requesting
[PROXY_PING] tcp_request failed: TCP connect timeout    ← 15s tcp_plain timeout
[Draug-hib] proxy_ping=false → still hibernating, retry in 60s
[Draug-hib] 60s elapsed → calling proxy_ping
[PROXY_PING] requesting
[PROXY_PING] tcp_request failed: TCP connect timeout
[Draug-hib] proxy_ping=false → still hibernating, retry in 60s
\`\`\`

**proxy_ping shares the wedged TCP state with Phase 17.** It uses \`tcp_plain::tcp_request_with_timeout\` — same code path as every other outbound TCP call. So once the smoltcp wedge sets in, hibernation is a forever-stuck state, not a recovery mechanism.

This is hypothesis #1 from #58 directly confirmed. Issue #58 has been updated with full findings + three ranked fix options.

## Threshold revert

The temporary threshold-lower from 30 → 3 was reverted before this commit. The diff in this PR is **exactly the trace lines** — no behavioural change.

## Test plan

- [x] Builds clean (\`cargo build --release\` for both kernel and userspace)
- [x] Boots cleanly on Proxmox/KVM
- [x] Trace lines fire at the right places (verified live)
- [x] No log spam in the no-flood baseline (proxy_ping never called when not hibernating)

## Test plan for the actual fix (separate work)

Once a fix lands, re-run the same flood + hibernation scenario. Success looks like:

\`\`\`
[Draug-hib] 60s elapsed → calling proxy_ping
[PROXY_PING] requesting
[PROXY_PING] tcp_request OK, 5 bytes        ← proxy responds via fix
[PROXY_PING] PONG → result=1 (waking Draug)
[Draug-skip] <<< WAKE (proxy back, skips reset)
[Draug-async] is_prime L1 PASS              ← Phase 17 resumes
\`\`\`

Archive: \`proxmox-mcp/serial-logs/issue-58-proxy-ping-wedge/vm800.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)