### PR TITLE
fix(#56): cap remaining audit-deferred spin sites (cmos, iqe, input drains)

### DIFF
--- a/kernel/src/drivers/cmos.rs
+++ b/kernel/src/drivers/cmos.rs
@@ -44,10 +44,16 @@ fn bcd_to_bin(bcd: u8) -> u8 {
 
 /// Read date/time from CMOS RTC.
 /// Handles update-in-progress and BCD/binary format detection.
+///
+/// Capped wait: real RTCs clear bit 7 of register 0x0A within ~1 ms.
+/// 100_000 polls is overkill on real silicon but defends against a
+/// virtualised RTC that never clears the bit (Issue #56 follow-up to
+/// the spin-loop audit). On overflow we read anyway — values may be
+/// torn but that's better than a dead kernel.
 pub fn read_rtc() -> DateTime {
     unsafe {
         // Wait for update-in-progress to clear
-        loop {
+        for _ in 0..100_000 {
             if (cmos_read(0x0A) & 0x80) == 0 {
                 break;
             }
@@ -156,10 +162,12 @@ pub fn unix_timestamp() -> u64 {
 
 /// Write date/time to CMOS RTC.
 /// Detects BCD vs binary format and writes accordingly.
+///
+/// Same 100_000-iter cap as `read_rtc` — see its doc-comment for why.
 pub fn write_rtc(dt: &DateTime) {
     unsafe {
         // Wait for any in-progress update to complete
-        loop {
+        for _ in 0..100_000 {
             if (cmos_read(0x0A) & 0x80) == 0 {
                 break;
             }

--- a/kernel/src/drivers/iqe.rs
+++ b/kernel/src/drivers/iqe.rs
@@ -54,10 +54,15 @@ pub fn calibrate_tsc() {
 
         let tsc_start = rdtsc();
 
-        // Poll PIT Channel 2 output (bit 5 of port 0x61 goes high when done)
-        loop {
+        // Poll PIT Channel 2 output (bit 5 of port 0x61 goes high when done).
+        // Capped at 10M iters — at ~3 GHz that's ~3 ms wall-clock, way past
+        // the ~50 ms PIT delay. If we exit without seeing the done bit,
+        // the calibration is unreliable and we hard-code a default
+        // (Issue #56 follow-up).
+        let mut calibrated = false;
+        for _ in 0..10_000_000u64 {
             let status = x86_64::instructions::port::Port::<u8>::new(0x61).read();
-            if status & 0x20 != 0 { break; }
+            if status & 0x20 != 0 { calibrated = true; break; }
         }
 
         let tsc_end = rdtsc();
@@ -65,7 +70,14 @@ pub fn calibrate_tsc() {
         // Restore port 0x61
         x86_64::instructions::port::Port::<u8>::new(0x61).write(port61_val);
 
-        let ticks_per_us = (tsc_end - tsc_start) / (DELAY_MS * 1000);
+        let ticks_per_us = if calibrated {
+            (tsc_end - tsc_start) / (DELAY_MS * 1000)
+        } else {
+            // PIT didn't report done — fall back to 3 GHz default.
+            // Better a wrong-but-bounded value than a dead kernel.
+            crate::serial_strln!("[IQE] PIT calibration timeout — defaulting to 3 GHz");
+            3000
+        };
         TSC_TICKS_PER_US.store(ticks_per_us, Ordering::Relaxed);
     }
 

--- a/userspace/compositor/src/input_keyboard.rs
+++ b/userspace/compositor/src/input_keyboard.rs
@@ -58,10 +58,19 @@ pub fn process_keyboard(
     let mut need_redraw = false;
 
     // ===== Process keyboard input =====
-    // First, collect all pending keys without redrawing
+    // First, collect all pending keys without redrawing.
+    //
+    // Drain capped at 1024 keys per call (Issue #56) — practical paste
+    // bursts are <500 keys, autorepeat is ~30 keys/sec, so 1024 is well
+    // above legitimate use. Defends against a flooded COM1 (read_key
+    // falls through to serial::read_byte) pinning the compositor main
+    // loop. Unread keys stay in the kernel ring for the next tick.
     let mut execute_command = false;
     let mut win_execute_command: Option<u32> = None; // window id to execute from
+    let mut keys_processed = 0u32;
     while let Some(key) = read_key() {
+        keys_processed += 1;
+        if keys_processed > 1024 { break; }
         did_work = true;
         let input_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { 0 };
         draug.on_user_input(input_ms);

--- a/userspace/compositor/src/input_mouse.rs
+++ b/userspace/compositor/src/input_mouse.rs
@@ -87,7 +87,14 @@ pub fn process_mouse(
     let mut latest_buttons: u8 = *last_buttons;
     let mut had_mouse_events = false;
 
+    // Drain capped at 1024 events per call (Issue #56). PS/2 mouse
+    // generates 3 bytes per event, kernel ring is small, so flood needs
+    // a lot to hit 1024. Above that we yield back to the main loop and
+    // pick up the rest next tick.
+    let mut events_processed = 0u32;
     while let Some(event) = read_mouse() {
+        events_processed += 1;
+        if events_processed > 1024 { break; }
         did_work = true;
         if !had_mouse_events {
             // Log first mouse event per batch to serial


### PR DESCRIPTION
Closes the four defense-in-depth spin-loop sites that were deliberately deferred from #52/#57 because each needed a design call about what to do when the cap fires.

This PR makes those calls.

## Sites + decisions

| Site | Before | After | Fallback |
|---|---|---|---|
| \`cmos.rs:50\` read_rtc UIP wait | unbounded | 100K iter | proceed (read may tear) |
| \`cmos.rs:162\` write_rtc UIP wait | unbounded | 100K iter | proceed |
| \`iqe.rs:58\` PIT calibration | unbounded | 10M iter | hardcode \`tsc_per_us = 3000\` + warn |
| \`input_keyboard.rs:64\` key drain | unbounded | 1024 keys | leave rest in ring |
| \`input_mouse.rs:90\` event drain | unbounded | 1024 events | leave rest in ring |

Reasoning per site is in the commit message and inline doc-comments.

## Live verification

Booted VM 800 with all four caps:

\`\`\`
[IQE] TSC calibrated: 2200 ticks/us            ← real PIT cal still works, cap inert
[Draug] Tick #1 | idle: 12s | dreams: 0/10
[Draug] Tick #2 | idle: 86s | dreams: 0/10
[Draug] Tick #3 | idle: 96s | dreams: 0/10
\`\`\`

No PIT timeout warning, no RTC weirdness, no panic. Caps only kick in under broken-emulator / flood scenarios — healthy baseline is unchanged.

## Not in this PR

\`smp.rs:155\` AP worker spin — separate scope (efficiency, not correctness, touches parallel-GEMM dispatch model).

## Test plan

- [x] Builds clean (kernel + userspace)
- [x] Boots cleanly on Proxmox/KVM
- [x] PIT calibration succeeds (2200 us reported)
- [x] Compositor main loop stable through Tick #1 → #2 → #3
- [x] No new panics/faults

Archive: \`proxmox-mcp/serial-logs/issue-56-deferred-caps/vm800.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)