### PR TITLE
fix(#58): firewall auto-block timeout (ROOT CAUSE) + tcp_close lock retry

### DIFF
--- a/kernel/src/net/firewall.rs
+++ b/kernel/src/net/firewall.rs
@@ -235,15 +235,38 @@ pub fn filter_packet(frame: &[u8]) -> FirewallAction {
 /// Dynamic blocklist: IPs that have been caught SYN-scanning repeatedly.
 /// After 3 SYN attempts from the same IP, ALL packets from that IP are dropped.
 const MAX_BLOCKLIST: usize = 16;
-static BLOCKLIST: spin::Mutex<([([u8; 4], u8); MAX_BLOCKLIST], usize)> =
-    spin::Mutex::new(([([0u8; 4], 0u8); MAX_BLOCKLIST], 0));
+
+/// Issue #58 root cause: blocklist entries used to be permanent. After a
+/// SYN flood from any IP — including a host we legitimately talk to —
+/// the IP would be auto-blocked forever, dropping every subsequent
+/// SYN-ACK reply from that host. Time-out the block so post-flood
+/// traffic recovers naturally.
+///
+/// 120 s gives Draug's hibernation cycle (60 s wake-period) two
+/// chances to find the proxy reachable after a flood ends.
+const BLOCK_DURATION_MS: u64 = 120_000;
+
+/// Tuple: (ip, syn_count, last_seen_ms). last_seen_ms is wall-clock
+/// at the most recent SYN attempt; if `now - last_seen_ms` exceeds
+/// `BLOCK_DURATION_MS` the entry is treated as expired.
+static BLOCKLIST: spin::Mutex<([([u8; 4], u8, u64); MAX_BLOCKLIST], usize)> =
+    spin::Mutex::new(([([0u8; 4], 0u8, 0u64); MAX_BLOCKLIST], 0));
 
 /// Check if an IP is in the dynamic blocklist
 fn is_blocked(ip: [u8; 4]) -> bool {
+    let now = crate::timer::uptime_ms();
     if let Some(list) = BLOCKLIST.try_lock() {
         for i in 0..list.1 {
             if list.0[i].0 == ip && list.0[i].1 >= 3 {
-                return true;
+                // Issue #58 fix: only honour the block if it hasn't
+                // expired. If `now - last_seen >= BLOCK_DURATION_MS`,
+                // the IP has been quiet long enough that we let it
+                // back in. Re-blocking happens automatically on the
+                // next 3 SYN attempts.
+                let last_seen = list.0[i].2;
+                if now.saturating_sub(last_seen) < BLOCK_DURATION_MS {
+                    return true;
+                }
             }
         }
     }
@@ -252,11 +275,23 @@ fn is_blocked(ip: [u8; 4]) -> bool {
 
 /// Record a SYN attempt from an IP. After 3 attempts, auto-block.
 fn record_syn_attempt(ip: [u8; 4]) {
+    let now = crate::timer::uptime_ms();
     if let Some(mut list) = BLOCKLIST.try_lock() {
         // Check if already tracked
         for i in 0..list.1 {
             if list.0[i].0 == ip {
+                // Issue #58: if the prior block expired, reset the
+                // counter so the IP gets a fresh chance. Otherwise
+                // keep counting up.
+                if list.0[i].1 >= 3
+                    && now.saturating_sub(list.0[i].2) >= BLOCK_DURATION_MS
+                {
+                    list.0[i].1 = 1;
+                    list.0[i].2 = now;
+                    return;
+                }
                 list.0[i].1 = list.0[i].1.saturating_add(1);
+                list.0[i].2 = now;
                 if list.0[i].1 == 3 {
                     // Auto-blocked! Log it
                     crate::serial_str!("[FW-AI] AUTO-BLOCKED ");
@@ -267,7 +302,7 @@ fn record_syn_attempt(ip: [u8; 4]) {
                     crate::drivers::serial::write_dec(ip[2] as u32);
                     crate::serial_str!(".");
                     crate::drivers::serial::write_dec(ip[3] as u32);
-                    crate::serial_strln!(" (3 SYN attempts)");
+                    crate::serial_strln!(" (3 SYN attempts, expires in 120s)");
                 }
                 return;
             }
@@ -275,7 +310,7 @@ fn record_syn_attempt(ip: [u8; 4]) {
         // New IP — add to tracker
         let idx = list.1;
         if idx < MAX_BLOCKLIST {
-            list.0[idx] = (ip, 1);
+            list.0[idx] = (ip, 1, now);
             list.1 = idx + 1;
             return;
         }
@@ -299,7 +334,7 @@ fn record_syn_attempt(ip: [u8; 4]) {
             }
         }
         if let Some(i) = victim {
-            list.0[i] = (ip, 1);
+            list.0[i] = (ip, 1, now);
         }
     }
 }

--- a/kernel/src/net/tcp_async.rs
+++ b/kernel/src/net/tcp_async.rs
@@ -152,7 +152,26 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
         .find(|&i| matches!(slots[i].state, SlotState::Free));
     let slot_idx = match free_slot {
         Some(i) => i,
-        None => return u64::MAX, // no free slots
+        None => {
+            // Issue #58 instrumentation: dump slot-pool census so we
+            // can see the pool exhaustion pattern in the serial log.
+            crate::serial_strln!("[TCP_CONNECT] no free slots! pool census:");
+            for i in 0..MAX_ASYNC_SLOTS {
+                crate::serial_str!("[TCP_CONNECT]   slot[");
+                crate::drivers::serial::write_dec(i as u32);
+                crate::serial_str!("] state=");
+                let label = match slots[i].state {
+                    SlotState::Free => "Free",
+                    SlotState::Connecting => "Connecting",
+                    SlotState::Connected => "Connected",
+                };
+                crate::serial_str!(label);
+                crate::serial_str!(" owner=");
+                crate::drivers::serial::write_dec(slots[i].owner);
+                crate::serial_strln!("");
+            }
+            return u64::MAX; // no free slots
+        }
     };
 
     let tcp_rx = tcp::SocketBuffer::new(alloc::vec![0u8; 8192]);
@@ -300,10 +319,30 @@ pub fn syscall_tcp_poll_recv(slot_id: u64, buf_ptr: u64, buf_max: u64) -> u64 {
 pub fn syscall_tcp_close(slot_id: u64) -> u64 {
     if slot_id as usize >= MAX_ASYNC_SLOTS { return u64::MAX; }
 
-    let mut guard = match NET_STATE.try_lock() {
-        Some(g) => g,
-        None => return EAGAIN,
+    // Issue #58 hypothesis #2: previously returned EAGAIN when
+    // NET_STATE was held by the timer ISR's poll(), causing the
+    // slot to NEVER be freed. With MAX_ASYNC_SLOTS = 4, after 4
+    // contended close attempts the pool is exhausted and Phase 17
+    // can never connect again — exactly the post-flood wedge.
+    //
+    // Fix: retry the lock for up to 1000 short spins (~few µs at
+    // 3 GHz) before giving up. Even under sustained timer-poll
+    // pressure this typically wins on the first or second retry.
+    let mut attempts = 0u32;
+    let mut guard = loop {
+        if let Some(g) = NET_STATE.try_lock() { break g; }
+        attempts += 1;
+        if attempts > 1000 {
+            crate::serial_strln!("[TCP_CLOSE] NET_STATE locked after 1000 spins — slot NOT freed");
+            return EAGAIN;
+        }
+        core::hint::spin_loop();
     };
+    if attempts > 0 {
+        crate::serial_str!("[TCP_CLOSE] won lock after ");
+        crate::drivers::serial::write_dec(attempts);
+        crate::serial_strln!(" spins");
+    }
     let state = match guard.as_mut() {
         Some(s) => s,
         None => return u64::MAX,


### PR DESCRIPTION
## tl;dr

**Found the root cause of #58.** The smoltcp TCP wedge wasn't smoltcp at all — it was the AI firewall auto-blocking the proxy IP in response to nping SYN-flood test traffic, then never expiring the block. Every legitimate SYN-ACK from the proxy got dropped silently after that, leaving Phase 17 stuck retransmitting SYN forever.

Closes **#58**.

## How we found it

After hypotheses #1 (UDP wedge — partial fix in #62), #3 (stale ARP — disproved), and #2 (slot pool leak — disproved), packet capture on tap800i0 during the wedge showed:

\`\`\`
192.168.68.65.49218 > 192.168.68.150.14711: Flags [S]    ← VM sends SYN
192.168.68.150.14711 > 192.168.68.65.49218: Flags [S.]   ← proxy sends SYN-ACK
192.168.68.150.14711 > 192.168.68.65.49218: Flags [S.]   ← proxy retransmits 8s later
192.168.68.65.49218 > 192.168.68.150.14711: Flags [S]    ← VM never ACKed,
                                                          retransmits same SYN seq
\`\`\`

SYN-ACK arrived at vmbr0/tap, but smoltcp never advanced state from SYN_SENT to ESTABLISHED. That isolated the bug to "something between the wire and smoltcp" — which is exactly the firewall.

\`[FW-AI] AUTO-BLOCKED 192.168.68.150 (3 SYN attempts)\` was sitting in the serial log the whole time, just waiting for someone to ask the right question.

## What was wrong

\`kernel/src/net/firewall.rs\`:
- \`record_syn_attempt(ip)\` increments a per-IP counter on every unsolicited SYN
- After 3 SYN attempts to non-whitelisted ports, the IP gets put on the BLOCKLIST
- \`is_blocked(ip)\` returns true forever — entries had no expiration
- nping SYN-flood from 192.168.68.150 (Proxmox host = our proxy host) auto-blocked the proxy permanently
- Every subsequent SYN-ACK from the proxy responding to legitimate VM-initiated TCP got silently dropped

## The fix

| Change | What |
|---|---|
| \`firewall.rs\` BLOCKLIST tuple | \`(ip, count, last_seen_ms)\` — adds timestamp |
| \`is_blocked()\` | Honour block only if \`now - last_seen_ms < 120_000\` |
| \`record_syn_attempt()\` | Reset counter when re-engaging an expired entry |
| Eviction path | Updated tuple init to include timestamp |

**120 s window** picked so Draug's 60 s hibernation cycle has two chances to find the proxy reachable after a flood ends.

## Bonus fix in tcp_async

While investigating, also found \`syscall_tcp_close\` returns EAGAIN if NET_STATE is contended → slot leaks → with 4 slot pool, latent wedge under sustained timer-poll contention.

Replaced single \`try_lock\` with 1000-spin retry (mirrors \`tcp_plain\`). Plus added pool-census logging in \`syscall_tcp_connect\` for the "all slots stuck" failure mode so future investigators see it directly.

## Live verification

\`\`\`
Pre-flood:                                                    PASS=1
Flood (90s, 200 pps SYN to ports 80/443/...):
  [FW-AI] AUTO-BLOCKED 192.168.68.150 (expires in 120s)
Post-flood, block still active:
  [Draug-async] TIMEOUT after 90s in Sending — aborting
Block expires (120s after last flood SYN):
  [Draug-async] factorial L1 PASS                             PASS=2
  [Draug-async] gcd L1 PASS                                   PASS=3
  [Draug-async] is_prime L1 PASS                              PASS=4
  [Draug-async] reverse_u32 L1 PASS                           PASS=5
\`\`\`

Compare to pre-fix: PASS stuck at 1 forever, every Phase 17 attempt timed out until shutdown. Now we have **clean recovery** — flood pollutes the network, system gracefully degrades to TIMEOUT-loop, 120s after flood stops the block expires and Phase 17 catches the recovery window.

Archive: \`proxmox-mcp/serial-logs/issue-58-firewall-timeout-FIXED/\`

## Test plan

- [x] Kernel builds clean
- [x] Boots cleanly on Proxmox/KVM, baseline behaviour unchanged
- [x] AUTO-BLOCKED still fires under flood (security feature still works)
- [x] Block expires after 120 s (verified by 5 successive PASSes)
- [x] tcp_close retry instrumentation present (`[TCP_CLOSE] won lock after N spins`) but never fires under typical load — defense-in-depth only

🤖 Generated with [Claude Code](https://claude.com/claude-code)