### PR TITLE
fix: lingering Copilot review bugs from #60-#64

### DIFF
--- a/kernel/src/net/firewall.rs
+++ b/kernel/src/net/firewall.rs
@@ -319,18 +319,28 @@ fn record_syn_attempt(ip: [u8; 4]) {
         // block threshold of 3) to fill the slot array, after which
         // their real attack IP slips through without tracking.
         //
-        // Evict the lowest-count entry that ISN'T yet blocked
-        // (count < 3). A blocked entry is load-bearing — we keep
-        // dropping that IP's traffic on every frame — so we refuse
-        // to evict it. If every slot is blocked, the table is doing
-        // its job; the new IP just isn't tracked this round.
+        // Eligible victims:
+        //  * unblocked entries (count < 3) — pick the lowest count
+        //    so we evict the least-invested tracker.
+        //  * entries whose block has already expired (`is_blocked`
+        //    won't honour them anyway). Rank these at 0 so they're
+        //    always preferred over an unblocked tracker with count
+        //    > 0 — keeps PR #64 review feedback from going stale:
+        //    if all 16 slots filled with old expired blocks, the
+        //    previous logic refused every eviction and stopped
+        //    tracking new IPs.
         let mut victim: Option<usize> = None;
-        let mut victim_count: u8 = u8::MAX;
+        let mut victim_rank: u8 = u8::MAX;
         for i in 0..MAX_BLOCKLIST {
             let c = list.0[i].1;
-            if c < 3 && c < victim_count {
-                victim_count = c;
-                victim = Some(i);
+            let is_expired_block =
+                c >= 3 && now.saturating_sub(list.0[i].2) >= BLOCK_DURATION_MS;
+            if c < 3 || is_expired_block {
+                let rank = if is_expired_block { 0 } else { c };
+                if rank < victim_rank {
+                    victim_rank = rank;
+                    victim = Some(i);
+                }
             }
         }
         if let Some(i) = victim {

--- a/kernel/src/net/tcp_async.rs
+++ b/kernel/src/net/tcp_async.rs
@@ -155,19 +155,39 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
         None => {
             // Issue #58 instrumentation: dump slot-pool census so we
             // can see the pool exhaustion pattern in the serial log.
+            //
+            // PR #64 review: snapshot the slot states first, then drop
+            // both NET_STATE and SLOTS locks before serialising the
+            // log. COM1 writes disable interrupts — keeping the locks
+            // across ~16 serial writes turned a small lock contention
+            // into a long critical section that could mask the wedge
+            // we were trying to diagnose.
+            let mut census: [(u8, u32); MAX_ASYNC_SLOTS] =
+                [(0u8, 0u32); MAX_ASYNC_SLOTS];
+            for i in 0..MAX_ASYNC_SLOTS {
+                let code = match slots[i].state {
+                    SlotState::Free => 0u8,
+                    SlotState::Connecting => 1u8,
+                    SlotState::Connected => 2u8,
+                };
+                census[i] = (code, slots[i].owner);
+            }
+            drop(slots);
+            drop(guard);
+
             crate::serial_strln!("[TCP_CONNECT] no free slots! pool census:");
             for i in 0..MAX_ASYNC_SLOTS {
                 crate::serial_str!("[TCP_CONNECT]   slot[");
                 crate::drivers::serial::write_dec(i as u32);
                 crate::serial_str!("] state=");
-                let label = match slots[i].state {
-                    SlotState::Free => "Free",
-                    SlotState::Connecting => "Connecting",
-                    SlotState::Connected => "Connected",
+                let label = match census[i].0 {
+                    0 => "Free",
+                    1 => "Connecting",
+                    _ => "Connected",
                 };
                 crate::serial_str!(label);
                 crate::serial_str!(" owner=");
-                crate::drivers::serial::write_dec(slots[i].owner);
+                crate::drivers::serial::write_dec(census[i].1);
                 crate::serial_strln!("");
             }
             return u64::MAX; // no free slots

--- a/kernel/src/net/udp.rs
+++ b/kernel/src/net/udp.rs
@@ -97,10 +97,22 @@ pub fn udp_send_recv(
         let _ = state.iface.poll(now, &mut dev, &mut state.sockets);
 
         let sock = state.sockets.get_mut::<udp::Socket>(handle);
-        if let Ok((n, _src)) = sock.recv_slice(response) {
+        if let Ok((n, src)) = sock.recv_slice(response) {
             if n > 0 {
-                received = n;
-                break;
+                // PR #62 review: filter by source endpoint. recv_slice
+                // returns the first datagram on the bound port
+                // regardless of sender; on a busy network this can
+                // yield false negatives (a stray packet consumed
+                // before the real reply). Drop unmatched datagrams
+                // and keep waiting until timeout. This is the right
+                // behaviour for every current caller (NTP, DNS,
+                // proxy_ping_udp) — none want to accept a reply from
+                // an unrelated peer.
+                if src.endpoint == endpoint {
+                    received = n;
+                    break;
+                }
+                // Wrong source — drop and continue waiting.
             }
         }
 

--- a/userspace/compositor/src/draug.rs
+++ b/userspace/compositor/src/draug.rs
@@ -833,23 +833,12 @@ impl DraugDaemon {
     pub fn record_skip(&mut self) {
         self.consecutive_skips = self.consecutive_skips.saturating_add(1);
         // Issue #58 instrumentation: log every skip so we can correlate
-        // with serial-side TIMEOUT events and see if hibernation triggers.
-        // Uses a small inline decimal formatter to avoid pulling in the
-        // crate::util::format_usize dep which lives in the compositor
-        // binary, not the lib.
-        let mut buf = [0u8; 4];
-        let mut len = 0usize;
-        let mut n = self.consecutive_skips;
-        if n == 0 { buf[0] = b'0'; len = 1; } else {
-            let mut tmp = [0u8; 4]; let mut i = 0usize;
-            while n > 0 { tmp[i] = b'0' + (n % 10) as u8; n /= 10; i += 1; }
-            for j in 0..i { buf[j] = tmp[i - 1 - j]; }
-            len = i;
-        }
+        // with serial-side TIMEOUT events and see if hibernation
+        // triggers. Use the existing 10-byte `write_dec` helper rather
+        // than an inline 4-byte buffer — the bespoke formatter would
+        // overflow once `consecutive_skips` reached 10_000+.
         libfolk::sys::io::write_str("[Draug-skip] consecutive=");
-        if let Ok(s) = core::str::from_utf8(&buf[..len]) {
-            libfolk::sys::io::write_str(s);
-        }
+        write_dec(self.consecutive_skips);
         libfolk::sys::io::write_str("/30\n");
         // Fix 8: hibernate after 30 consecutive skips
         if self.consecutive_skips >= 30 && !self.refactor_hibernating {

--- a/userspace/compositor/src/input_keyboard.rs
+++ b/userspace/compositor/src/input_keyboard.rs
@@ -64,13 +64,16 @@ pub fn process_keyboard(
     // bursts are <500 keys, autorepeat is ~30 keys/sec, so 1024 is well
     // above legitimate use. Defends against a flooded COM1 (read_key
     // falls through to serial::read_byte) pinning the compositor main
-    // loop. Unread keys stay in the kernel ring for the next tick.
+    // loop. Use a bounded `for` loop so the 1025th key stays in the
+    // kernel ring for the next tick instead of being consumed and
+    // dropped (PR #63 Copilot review).
     let mut execute_command = false;
     let mut win_execute_command: Option<u32> = None; // window id to execute from
-    let mut keys_processed = 0u32;
-    while let Some(key) = read_key() {
-        keys_processed += 1;
-        if keys_processed > 1024 { break; }
+    for _ in 0..1024 {
+        let key = match read_key() {
+            Some(k) => k,
+            None => break,
+        };
         did_work = true;
         let input_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { 0 };
         draug.on_user_input(input_ms);

--- a/userspace/compositor/src/input_mouse.rs
+++ b/userspace/compositor/src/input_mouse.rs
@@ -90,11 +90,14 @@ pub fn process_mouse(
     // Drain capped at 1024 events per call (Issue #56). PS/2 mouse
     // generates 3 bytes per event, kernel ring is small, so flood needs
     // a lot to hit 1024. Above that we yield back to the main loop and
-    // pick up the rest next tick.
-    let mut events_processed = 0u32;
-    while let Some(event) = read_mouse() {
-        events_processed += 1;
-        if events_processed > 1024 { break; }
+    // pick up the rest next tick. Use a bounded `for` loop so the
+    // 1025th event stays in the kernel ring instead of being consumed
+    // and dropped (PR #63 Copilot review).
+    for _ in 0..1024 {
+        let event = match read_mouse() {
+            Some(e) => e,
+            None => break,
+        };
         did_work = true;
         if !had_mouse_events {
             // Log first mouse event per batch to serial


### PR DESCRIPTION
## Summary

Closed-PR audit surfaced **five real bugs** that landed despite Copilot flagging them in review. All are small correctness fixes — none block functionality, but each has a plausible (if rare) trigger that's worth eliminating now rather than waiting for it to bite live.

## The five fixes

### A — `draug.rs:record_skip` decimal-formatter overflow
Old code wrote `consecutive_skips` into a 4-byte buffer; once the value reached 10 000+ the inline formatter would write past the end and panic. Replaced with the existing 10-byte `write_dec()` helper that's already in the same module.
*Source: PR #60 review / PR #61 review*

### B — `udp_send_recv` accepts datagrams from any source
`recv_slice` returns the first datagram on the bound port regardless of sender. On a busy network a stray packet could be consumed before the real reply, yielding a false negative for `proxy_ping_udp` (and theoretically NTP). Added a source-endpoint filter — drop and keep waiting if the source doesn't match the queried target.
*Source: PR #62 review*

### C — Input drain off-by-one (mouse + keyboard)
`while let Some(e) = read_mouse() { events_processed += 1; if events_processed > 1024 { break; } ... }` consumes the 1025th event from the kernel ring, then drops it on the floor. Same off-by-one pattern PR #59 fixed for net/virtio paths. Converted both drain sites to bounded `for _ in 0..1024` loops so the 1025th event stays queued for the next tick.
*Source: PR #63 review*

### D — Firewall blocklist eviction starves new IPs
Previous logic refused to evict any entry with `syn_count >= 3`, even after `BLOCK_DURATION_MS` expiration. If the 16-slot table filled with old expired blocks, new IPs simply weren't tracked anymore. Eviction now also considers expired blocks as victims, ranked ahead of unblocked-but-non-zero counters.
*Source: PR #64 review*

### E — Slot-pool census log holds both locks across serial writes
`syscall_tcp_connect`'s exhaustion log emitted ~16 COM1 writes (which disable IRQs) while still holding both `NET_STATE` and `SLOTS`. Snapshotted census into a stack-local array, dropped both locks explicitly, then serialised the log — turns a multi-millisecond critical section into a few-microsecond one.
*Source: PR #64 review*

## Verification

- ✅ `cargo check` passes clean for both kernel and compositor (no new warnings)
- ✅ Source-endpoint filter is correct for all current `udp_send_recv` callers (NTP, DNS, proxy_ping_udp — none want stray-source replies)
- ⚠️ Cannot verify on Proxmox VM 800 from this context — please re-run `deploy.py` after merge to confirm Phase 17 still produces L1 PASSes and that hibernation wake (UDP path) still works

## Out of scope (deferred)

The same Copilot reviews flagged ~8 doc/comment nits (e.g., `last_seen_ms` doc says "wall-clock" but uses monotonic uptime; `tsc_ms` vs wall-clock confusion in `proxy_ping_udp` docs; `iqe.rs` "TSC calibrated" log printing fallback values). Those will land as a separate docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)