### PR TITLE
docs: Copilot review nits from #50-#64 (companion to #67)

### DIFF
--- a/debug_log_archive_synapse_btree_2026-04.md
+++ b/debug_log_archive_synapse_btree_2026-04.md
@@ -4,7 +4,7 @@
 `[SYNAPSE] insert: unexpected page type 0x00` when writing files to SQLite VFS.
 Blocks all persistence: WASM app caching, AutoDream, driver version control.
 
-## Session 7. april 2026
+## Session 7. April 2026
 
 ### Attempt 1: FOLKDISK header not updated after flush
 - **Hypothesis:** `flush_sqlite_to_disk()` writes new pages to disk but never updates `synapse_db_size` in sector 0 header. On reboot, fewer sectors are loaded → new pages are zeroed.

--- a/kernel/src/arch/x86_64/syscall/dispatch.rs
+++ b/kernel/src/arch/x86_64/syscall/dispatch.rs
@@ -121,7 +121,9 @@ pub(super) extern "C" fn syscall_handler(
         // Issue #58: UDP variant of proxy_ping. Uses smoltcp's UDP socket
         // type (different code path than tcp_plain) so hibernation can
         // recover from a TCP-specific wedge. Sends "PING", awaits "PONG"
-        // within 1s. Returns 1 if PONG received, 0 otherwise.
+        // (timeout is in tsc_ms units — ≈1s on a well-calibrated TSC,
+        // see syscall_proxy_ping_udp doc for caveats). Returns 1 if
+        // PONG received, 0 otherwise.
         0x68 => syscall_proxy_ping_udp(),
         // Folkering CodeGraph: query callers of a fn name via the
         // proxy's GRAPH_CALLERS command. Same packed-lengths shape

--- a/kernel/src/arch/x86_64/syscall/handlers/net.rs
+++ b/kernel/src/arch/x86_64/syscall/handlers/net.rs
@@ -1044,7 +1044,12 @@ pub fn syscall_graph_callers(
 
 /// Stability Fix 7 — Proxy health check.
 ///
-/// Sends `PING\n` to the proxy with a 5_000 tsc_ms timeout (~2s).
+/// Sends `PING\n` to the proxy. Worst-case wall time = 15s connect
+/// timeout (in `tcp_plain::tcp_request_with_timeout`'s `may_send`
+/// loop) + the 5_000 `tsc_ms` read budget passed below (≈2s on a
+/// well-calibrated TSC). If the proxy is reachable but slow, return
+/// is bounded by the read budget; if it's wedged at the TCP level,
+/// return is bounded by the connect cap.
 /// Returns 1 if proxy responds with PONG, 0 otherwise.
 /// Used before expensive LLM calls to fail fast when proxy is down.
 pub fn syscall_proxy_ping() -> u64 {
@@ -1088,10 +1093,16 @@ pub fn syscall_proxy_ping() -> u64 {
 
 /// Issue #58 — UDP variant of proxy_ping.
 ///
-/// Sends a 4-byte "PING" UDP datagram to the proxy and awaits "PONG"
-/// within 1 second. Uses smoltcp's UDP socket type, which is a
-/// different code path than `tcp_plain` — so this can succeed even
-/// when the TCP-side state is wedged (post-flood scenario from #58).
+/// Sends a 4-byte "PING" UDP datagram to the proxy and awaits "PONG".
+/// Uses smoltcp's UDP socket type, which is a different code path
+/// than `tcp_plain` — so this can succeed even when the TCP-side
+/// state is wedged (post-flood scenario from #58).
+///
+/// Timeout is 1000 in `tsc_ms` units — `udp_send_recv` polls
+/// `tls::tsc_ms()`, which is calibrated TSC ticks divided down to
+/// milliseconds (≈1s wall-clock when the IQE TSC calibration
+/// succeeded; on a fallback-to-3 GHz host the value can drift
+/// proportionally to the real CPU frequency).
 ///
 /// Returns 1 on PONG received, 0 otherwise.
 pub fn syscall_proxy_ping_udp() -> u64 {
@@ -1105,7 +1116,7 @@ pub fn syscall_proxy_ping_udp() -> u64 {
         PROXY_IP, PROXY_PORT,
         b"PING",
         &mut response,
-        1000, // 1s timeout
+        1000, // tsc_ms — see fn-doc above for the wall-clock caveat
     );
 
     if n == 0 {

--- a/kernel/src/drivers/iqe.rs
+++ b/kernel/src/drivers/iqe.rs
@@ -54,11 +54,14 @@ pub fn calibrate_tsc() {
 
         let tsc_start = rdtsc();
 
-        // Poll PIT Channel 2 output (bit 5 of port 0x61 goes high when done).
-        // Capped at 10M iters — at ~3 GHz that's ~3 ms wall-clock, way past
-        // the ~50 ms PIT delay. If we exit without seeing the done bit,
-        // the calibration is unreliable and we hard-code a default
-        // (Issue #56 follow-up).
+        // Poll PIT Channel 2 output (bit 5 of port 0x61 goes high when
+        // done). Capped at 10M iterations. Each iteration is one x86
+        // `IN` from port 0x61, which is bus-serialised and costs on
+        // the order of ~1 µs on real hardware (and several hundred ns
+        // even under fast hypervisors), so the cap covers comfortably
+        // more than the `DELAY_MS` (= 10) PIT window above. If we
+        // exit without seeing the done bit, calibration is unreliable
+        // and we hard-code a default (Issue #56 follow-up).
         let mut calibrated = false;
         for _ in 0..10_000_000u64 {
             let status = x86_64::instructions::port::Port::<u8>::new(0x61).read();
@@ -79,11 +82,19 @@ pub fn calibrate_tsc() {
             3000
         };
         TSC_TICKS_PER_US.store(ticks_per_us, Ordering::Relaxed);
-    }
 
-    crate::serial_str!("[IQE] TSC calibrated: ");
-    crate::drivers::serial::write_dec(TSC_TICKS_PER_US.load(Ordering::Relaxed) as u32);
-    crate::serial_strln!(" ticks/us");
+        // Be honest in the boot log about whether we actually
+        // calibrated or fell back to the default — otherwise the
+        // "TSC calibrated" message is misleading on hosts where the
+        // PIT poll timed out.
+        if calibrated {
+            crate::serial_str!("[IQE] TSC calibrated: ");
+        } else {
+            crate::serial_str!("[IQE] TSC defaulted: ");
+        }
+        crate::drivers::serial::write_dec(TSC_TICKS_PER_US.load(Ordering::Relaxed) as u32);
+        crate::serial_strln!(" ticks/us");
+    }
 }
 
 /// IQE event types — what happened

--- a/kernel/src/net/firewall.rs
+++ b/kernel/src/net/firewall.rs
@@ -246,9 +246,11 @@ const MAX_BLOCKLIST: usize = 16;
 /// chances to find the proxy reachable after a flood ends.
 const BLOCK_DURATION_MS: u64 = 120_000;
 
-/// Tuple: (ip, syn_count, last_seen_ms). last_seen_ms is wall-clock
-/// at the most recent SYN attempt; if `now - last_seen_ms` exceeds
-/// `BLOCK_DURATION_MS` the entry is treated as expired.
+/// Tuple: (ip, syn_count, last_seen_ms). `last_seen_ms` is the
+/// monotonic uptime timestamp from `crate::timer::uptime_ms()` at the
+/// most recent SYN attempt (NOT a wall-clock value); if
+/// `now - last_seen_ms` exceeds `BLOCK_DURATION_MS` the entry is
+/// treated as expired.
 static BLOCKLIST: spin::Mutex<([([u8; 4], u8, u64); MAX_BLOCKLIST], usize)> =
     spin::Mutex::new(([([0u8; 4], 0u8, 0u64); MAX_BLOCKLIST], 0));
 
@@ -293,7 +295,9 @@ fn record_syn_attempt(ip: [u8; 4]) {
                 list.0[i].1 = list.0[i].1.saturating_add(1);
                 list.0[i].2 = now;
                 if list.0[i].1 == 3 {
-                    // Auto-blocked! Log it
+                    // Auto-blocked! Log it. Format the expiry window
+                    // from BLOCK_DURATION_MS so the log stays accurate
+                    // if the constant changes.
                     crate::serial_str!("[FW-AI] AUTO-BLOCKED ");
                     crate::drivers::serial::write_dec(ip[0] as u32);
                     crate::serial_str!(".");
@@ -302,7 +306,9 @@ fn record_syn_attempt(ip: [u8; 4]) {
                     crate::drivers::serial::write_dec(ip[2] as u32);
                     crate::serial_str!(".");
                     crate::drivers::serial::write_dec(ip[3] as u32);
-                    crate::serial_strln!(" (3 SYN attempts, expires in 120s)");
+                    crate::serial_str!(" (3 SYN attempts, expires in ");
+                    crate::drivers::serial::write_dec((BLOCK_DURATION_MS / 1000) as u32);
+                    crate::serial_strln!("s)");
                 }
                 return;
             }

--- a/kernel/src/net/tcp_async.rs
+++ b/kernel/src/net/tcp_async.rs
@@ -339,15 +339,21 @@ pub fn syscall_tcp_poll_recv(slot_id: u64, buf_ptr: u64, buf_max: u64) -> u64 {
 pub fn syscall_tcp_close(slot_id: u64) -> u64 {
     if slot_id as usize >= MAX_ASYNC_SLOTS { return u64::MAX; }
 
-    // Issue #58 hypothesis #2: previously returned EAGAIN when
-    // NET_STATE was held by the timer ISR's poll(), causing the
-    // slot to NEVER be freed. With MAX_ASYNC_SLOTS = 4, after 4
-    // contended close attempts the pool is exhausted and Phase 17
-    // can never connect again — exactly the post-flood wedge.
+    // Issue #58 hypothesis #2: previously returned EAGAIN whenever
+    // NET_STATE was already held, causing the slot to NEVER be freed.
+    // With MAX_ASYNC_SLOTS = 4, after 4 contended close attempts the
+    // pool is exhausted and Phase 17 can never connect again —
+    // exactly the post-flood wedge.
+    //
+    // Note: timer::tick() does NOT poll the network stack — that ran
+    // in earlier prototypes but was moved off the timer ISR. Real
+    // contention sources today are `net::poll()` from the idle
+    // syscall, other TCP syscalls calling `iface.poll()`, and (once
+    // SMP lands) work on another core.
     //
     // Fix: retry the lock for up to 1000 short spins (~few µs at
-    // 3 GHz) before giving up. Even under sustained timer-poll
-    // pressure this typically wins on the first or second retry.
+    // 3 GHz) before giving up. Even under sustained NET_STATE
+    // contention this typically wins on the first or second retry.
     let mut attempts = 0u32;
     let mut guard = loop {
         if let Some(g) = NET_STATE.try_lock() { break g; }

--- a/spin_loop_audit.md
+++ b/spin_loop_audit.md
@@ -7,6 +7,13 @@
 
 **Audit scope:** kernel/src/, userspace/{compositor,libfolk,shell,...}/, drivers, syscall handlers. Skipped apps/ (sandboxed WASM).
 
+> ⚠️ **Note on line numbers below:** This document is a point-in-time
+> snapshot. Specific line numbers reflect the state of the code when
+> the audit was written and will drift as files change — refer to the
+> named function (e.g. `com2_async_poll`, `poll_com3`) rather than the
+> line number when looking something up. Findings remain valid; only
+> the locator format does.
+
 **Verdict scale:**
 - ✅ **SAFE** — explicit cap, finite-bounded, or HLT-yielding by design.
 - 🚩 **UNSAFE** — unbounded poll over a hardware register or syscall that can produce data forever.

--- a/userspace/libfolk/src/sys/task.rs
+++ b/userspace/libfolk/src/sys/task.rs
@@ -541,9 +541,14 @@ pub fn proxy_ping() -> bool {
 
 /// Issue #58 — Proxy health check (UDP).
 /// Returns true if the proxy responds to a UDP "PING" with "PONG"
-/// within 1s. Uses smoltcp's UDP socket type, a different code path
-/// than `proxy_ping()` (TCP), so it can succeed when the TCP-side
-/// state is wedged.
+/// before the kernel-side probe expires. The kernel timeout is
+/// expressed in `tsc_ms` units (calibrated TSC ticks divided down
+/// to milliseconds), which is approximately wall-clock 1s on a
+/// well-calibrated TSC; on a host where IQE fell back to the 3 GHz
+/// default it can drift proportionally to the real CPU frequency.
+/// Uses smoltcp's UDP socket type, a different code path than
+/// `proxy_ping()` (TCP), so it can succeed when the TCP-side state
+/// is wedged.
 pub fn proxy_ping_udp() -> bool {
     unsafe { crate::syscall::syscall0(0x68) == 1 }
 }


### PR DESCRIPTION
## Summary

Comment / doc / log-string cleanup from the same closed-PR audit that produced #67. **Pure clarification** — no behaviour changes, no functional code moves. Builds clean (kernel + compositor + libfolk) with no new warnings.

**Stacked on #67** so the diff is purely the doc-only changes; merge #67 first, then this rebases cleanly to main.

## Changes

| PR | File | Fix |
|---|---|---|
| #50 | `debug_log_archive_synapse_btree_2026-04.md` | typo "april" → "April" |
| #52 | `spin_loop_audit.md` | Header note that line numbers are point-in-time and may drift; readers should navigate by function name |
| #61 | `kernel/.../net.rs:syscall_proxy_ping` | Doc now states the **15 s connect cap** (from `tcp_plain`) on top of the 5_000 tsc_ms read budget |
| #62 | `kernel/.../net.rs:syscall_proxy_ping_udp`, `dispatch.rs:0x68`, `libfolk task.rs:proxy_ping_udp` | All three sites called the timeout "1 s" but the kernel uses `tsc_ms` (calibrated TSC ticks). Doc now names the unit and the calibration caveat (drifts when IQE fell back to 3 GHz default) |
| #63 | `kernel/src/drivers/iqe.rs` | PIT polling comment had wrong DELAY_MS (10 ≠ 50), wrong wall-time estimate (didn't account for bus-serialised port-IO). Rewritten with realistic timing. Boot log now reads `[IQE] TSC defaulted: ...` on fallback instead of misleadingly claiming `TSC calibrated: 3000 ticks/us` |
| #64 | `kernel/src/net/firewall.rs` | `last_seen_ms` doc said "wall-clock" but uses `crate::timer::uptime_ms()` (monotonic). Reworded. AUTO-BLOCKED log line formats expiry window from `BLOCK_DURATION_MS` instead of hard-coding "120s" |
| #64 | `kernel/src/net/tcp_async.rs` | Close-retry comment blamed "the timer ISR's poll()" but `timer::tick()` doesn't poll the net stack. Updated to name the actual NET_STATE contention sources |

## Verification

- ✅ `cargo check` clean for kernel, compositor, libfolk
- ✅ No new warnings vs baseline
- ✅ Pure doc/comment/log-string changes — no logic moved

## Note on Copilot review

Currently rate-limited on this account (until 2026-05-04). This PR will sit without an automated review until then; happy to manually re-run the prompts against the diff if a faster signal is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)