### PR TITLE
feat(compositor): extract Morning Briefing into BriefingState

### DIFF
--- a/userspace/compositor/src/briefing.rs
+++ b/userspace/compositor/src/briefing.rs
@@ -1,0 +1,109 @@
+//! Morning Briefing state — pending creative dream results awaiting
+//! user approval.
+//!
+//! This used to live on `DraugDaemon::pending_creative` while the
+//! compositor and the agent shared a process. Now that the daemon is
+//! isolated (Phase A), the briefing is purely compositor UI state:
+//! it holds the WASM bytes the LLM produced overnight, the human-
+//! readable description for the briefing window, and the user's
+//! accept/reject decision per item. Nothing here belongs in the
+//! daemon's address space.
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+/// Cap on simultaneously-pending items. Each item carries a full
+/// WASM binary; three is plenty for a single night's dreaming and
+/// keeps the heap footprint bounded.
+pub const MAX_PENDING_BRIEFING: usize = 3;
+
+/// One creative dream result waiting for user approval.
+pub struct BriefingItem {
+    pub app_name: String,
+    /// Human-readable summary shown in the briefing window.
+    pub description: String,
+    /// The full evolved WASM binary, applied to the cache on accept.
+    pub wasm_bytes: Vec<u8>,
+    /// `None` = pending, `Some(true)` = accepted, `Some(false)` = rejected.
+    pub accepted: Option<bool>,
+}
+
+/// Compositor-side queue of pending Morning Briefing items.
+pub struct BriefingState {
+    pub items: Vec<BriefingItem>,
+}
+
+impl BriefingState {
+    pub const fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// Queue a creative-dream result for user approval. Drops the
+    /// oldest item if the queue is full.
+    pub fn queue(&mut self, app_name: &str, description: &str, wasm_bytes: Vec<u8>) {
+        if self.items.len() >= MAX_PENDING_BRIEFING {
+            self.items.remove(0);
+        }
+        self.items.push(BriefingItem {
+            app_name: app_name.to_string(),
+            description: description.to_string(),
+            wasm_bytes,
+            accepted: None,
+        });
+    }
+
+    /// True if at least one item is still awaiting a decision.
+    pub fn has_pending(&self) -> bool {
+        self.items.iter().any(|p| p.accepted.is_none())
+    }
+
+    /// How many items are awaiting a decision.
+    pub fn pending_count(&self) -> usize {
+        self.items.iter().filter(|p| p.accepted.is_none()).count()
+    }
+
+    /// Mark the item at `idx` as accepted. No-op if `idx` out of range.
+    pub fn accept(&mut self, idx: usize) {
+        if let Some(p) = self.items.get_mut(idx) {
+            p.accepted = Some(true);
+        }
+    }
+
+    /// Mark the item at `idx` as rejected. No-op if `idx` out of range.
+    pub fn reject(&mut self, idx: usize) {
+        if let Some(p) = self.items.get_mut(idx) {
+            p.accepted = Some(false);
+        }
+    }
+
+    /// Mark all undecided items as accepted.
+    pub fn accept_all(&mut self) {
+        for p in &mut self.items {
+            if p.accepted.is_none() {
+                p.accepted = Some(true);
+            }
+        }
+    }
+
+    /// Drain accepted items as `(app_name, wasm_bytes)` pairs and
+    /// remove all decided items (accepted *or* rejected) from the
+    /// queue. Pending items stay.
+    pub fn drain_accepted(&mut self) -> Vec<(String, Vec<u8>)> {
+        let mut result = Vec::new();
+        self.items.retain(|p| match p.accepted {
+            Some(true) => {
+                result.push((p.app_name.clone(), p.wasm_bytes.clone()));
+                false
+            }
+            Some(false) => false,
+            None => true,
+        });
+        result
+    }
+}
+
+impl Default for BriefingState {
+    fn default() -> Self { Self::new() }
+}

--- a/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
+++ b/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
@@ -668,8 +668,8 @@ pub(super) fn dispatch_legacy_command(
                     win.push_line("Example: revert ball 1");
                 }
             } else if cmd_str == "dream accept all" || cmd_str == "dream accept" {
-                ctx.draug.accept_all_creative();
-                let accepted = ctx.draug.drain_accepted();
+                ctx.briefing.accept_all();
+                let accepted = ctx.briefing.drain_accepted();
                 for (name, wasm_bytes) in &accepted {
                     ctx.wasm.cache.insert(name.clone(), wasm_bytes.clone());
                     win.push_line(&alloc::format!("[Dream] Accepted: {}", &name[..name.len().min(30)]));
@@ -678,16 +678,16 @@ pub(super) fn dispatch_legacy_command(
                     win.push_line("[Dream] No pending changes");
                 }
             } else if cmd_str == "dream reject all" || cmd_str == "dream reject" {
-                for i in 0..ctx.draug.pending_creative.len() {
-                    ctx.draug.reject_creative(i);
+                for i in 0..ctx.briefing.items.len() {
+                    ctx.briefing.reject(i);
                 }
-                ctx.draug.drain_accepted();
+                ctx.briefing.drain_accepted();
                 win.push_line("[Dream] All creative changes rejected");
             } else if cmd_str.starts_with("dream accept ") {
                 if let Ok(idx) = cmd_str[13..].trim().parse::<usize>() {
-                    if idx > 0 && idx <= ctx.draug.pending_creative.len() {
-                        ctx.draug.accept_creative(idx - 1);
-                        let accepted = ctx.draug.drain_accepted();
+                    if idx > 0 && idx <= ctx.briefing.items.len() {
+                        ctx.briefing.accept(idx - 1);
+                        let accepted = ctx.briefing.drain_accepted();
                         for (name, wasm_bytes) in &accepted {
                             ctx.wasm.cache.insert(name.clone(), wasm_bytes.clone());
                             win.push_line(&alloc::format!("[Dream] Accepted: {}", name));
@@ -698,9 +698,9 @@ pub(super) fn dispatch_legacy_command(
                 }
             } else if cmd_str.starts_with("dream reject ") {
                 if let Ok(idx) = cmd_str[13..].trim().parse::<usize>() {
-                    if idx > 0 && idx <= ctx.draug.pending_creative.len() {
-                        ctx.draug.reject_creative(idx - 1);
-                        ctx.draug.drain_accepted();
+                    if idx > 0 && idx <= ctx.briefing.items.len() {
+                        ctx.briefing.reject(idx - 1);
+                        ctx.briefing.drain_accepted();
                         win.push_line("[Dream] Rejected");
                     }
                 }

--- a/userspace/compositor/src/command_dispatch/mod.rs
+++ b/userspace/compositor/src/command_dispatch/mod.rs
@@ -63,6 +63,7 @@ pub struct DispatchContext<'a> {
     pub mcp: &'a mut McpState,
     pub stream: &'a mut StreamState,
     pub draug: &'a mut DraugDaemon,
+    pub briefing: &'a mut compositor::briefing::BriefingState,
     pub fb: &'a mut FramebufferView,
     pub damage: &'a mut DamageTracker,
     pub com3_queue: &'a mut Vec<String>,

--- a/userspace/compositor/src/lib.rs
+++ b/userspace/compositor/src/lib.rs
@@ -69,6 +69,7 @@ pub mod window_manager;
 pub mod agent;
 pub mod draug;
 pub mod refactor_types;
+pub mod briefing;
 
 extern crate alloc;
 

--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -628,6 +628,7 @@ fn main() -> ! {
     // tz_offset_minutes, tz_synced, tz_sync_pending now in mcp
     let mut active_agent: Option<compositor::agent::AgentSession> = None; // ReAct agentic loop
     let mut draug = compositor::draug::DraugDaemon::new();
+    let mut briefing = compositor::briefing::BriefingState::new();
 
     // Phase A.5 step 2.3: read draug state from the daemon's status
     // shmem instead of the local DraugDaemon for the fields the
@@ -863,7 +864,7 @@ fn main() -> ! {
         {
             let ai = mcp_handler::tick_ai_systems(
                 &mut mcp, &mut wasm, &mut wm, &mut stream,
-                &mut draug, &mut fb, &mut damage,
+                &mut draug, &mut briefing, &mut fb, &mut damage,
                 &mut active_agent, &mut drivers_seeded,
                 tsc_per_us,
             );
@@ -1032,6 +1033,7 @@ fn main() -> ! {
                 mcp: &mut mcp,
                 stream: &mut stream,
                 draug: &mut draug,
+                briefing: &mut briefing,
                 fb: &mut fb,
                 damage: &mut damage,
                 com3_queue: &mut com3_queue,

--- a/userspace/compositor/src/mcp_handler/agent_logic.rs
+++ b/userspace/compositor/src/mcp_handler/agent_logic.rs
@@ -12,6 +12,7 @@ use libfolk::sys::io::write_str;
 
 use compositor::agent::AgentSession;
 use compositor::damage::DamageTracker;
+use compositor::briefing::BriefingState;
 use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{McpState, StreamState, WasmState};
@@ -27,6 +28,7 @@ pub(super) fn tick(
     wm: &mut WindowManager,
     stream: &mut StreamState,
     draug: &mut DraugDaemon,
+    briefing: &mut BriefingState,
     fb: &mut FramebufferView,
     damage: &mut DamageTracker,
     active_agent: &mut Option<AgentSession>,
@@ -113,8 +115,8 @@ pub(super) fn tick(
     }
 
     // Morning Briefing
-    if did_work && draug.has_pending_creative() && mcp.current_dream.is_none() {
-        let count = draug.pending_count();
+    if did_work && briefing.has_pending() && mcp.current_dream.is_none() {
+        let count = briefing.pending_count();
         write_str("[Morning Briefing] Draug has ");
         let mut nb2 = [0u8; 16];
         write_str(format_usize(count, &mut nb2));
@@ -124,7 +126,7 @@ pub(super) fn tick(
         if let Some(win) = wm.get_window_mut(brief_win) {
             win.push_line("Good morning! Draug dreamt overnight:");
             win.push_line("");
-            for (i, p) in draug.pending_creative.iter().enumerate() {
+            for (i, p) in briefing.items.iter().enumerate() {
                 if p.accepted.is_none() {
                     let line = alloc::format!(
                         "  {}. '{}': {}",
@@ -175,7 +177,7 @@ pub(super) fn tick(
                 } => {
                     // Delegate WasmChunk handling to autodream module
                     let result = autodream::handle_wasm_chunk(
-                        total_chunks, &data[..], mcp, wasm, wm, draug, fb, damage,
+                        total_chunks, &data[..], mcp, wasm, wm, draug, briefing, fb, damage,
                         drivers_seeded, tsc_per_us, &mut need_redraw,
                     );
                     if result.early_return {

--- a/userspace/compositor/src/mcp_handler/autodream.rs
+++ b/userspace/compositor/src/mcp_handler/autodream.rs
@@ -276,6 +276,7 @@ pub(super) fn handle_wasm_chunk(
     wasm: &mut WasmState,
     wm: &mut WindowManager,
     draug: &mut DraugDaemon,
+    briefing: &mut compositor::briefing::BriefingState,
     fb: &mut FramebufferView,
     damage: &mut DamageTracker,
     _drivers_seeded: &mut bool,
@@ -519,7 +520,7 @@ pub(super) fn handle_wasm_chunk(
     // Phase A.5 step 2; the local `DraugDaemon::is_dreaming()` flag is
     // no longer consulted from this path.
     if mcp.current_dream.is_some() && !tool_prompt.is_empty() {
-        evaluate_dream_result(&wasm_bytes, &tool_prompt, mcp, wasm, draug, fb, tsc_per_us);
+        evaluate_dream_result(&wasm_bytes, &tool_prompt, mcp, wasm, draug, briefing, fb, tsc_per_us);
     }
     // ── Normal cache storage (non-dream) ──
     else if !tool_prompt.is_empty() {
@@ -611,6 +612,7 @@ fn evaluate_dream_result(
     mcp: &mut McpState,
     wasm: &mut WasmState,
     draug: &mut DraugDaemon,
+    briefing: &mut compositor::briefing::BriefingState,
     fb: &FramebufferView,
     tsc_per_us: u64,
 ) {
@@ -647,7 +649,7 @@ fn evaluate_dream_result(
             write_str("[AutoDream] New render: ");
             write_str(&summary[..summary.len().min(200)]);
             write_str("\n[AutoDream] VERDICT: QUEUED for user approval (Morning Briefing)\n");
-            draug.queue_creative(orig_key, &summary[..summary.len().min(100)],
+            briefing.queue(orig_key, &summary[..summary.len().min(100)],
                 alloc::vec::Vec::from(wasm_bytes));
         }
         compositor::draug::DreamMode::Nightmare => {

--- a/userspace/compositor/src/mcp_handler/mod.rs
+++ b/userspace/compositor/src/mcp_handler/mod.rs
@@ -93,6 +93,7 @@ pub fn tick_ai_systems(
     wm: &mut WindowManager,
     stream: &mut StreamState,
     draug: &mut DraugDaemon,
+    briefing: &mut compositor::briefing::BriefingState,
     fb: &mut FramebufferView,
     damage: &mut DamageTracker,
     active_agent: &mut Option<AgentSession>,
@@ -100,7 +101,7 @@ pub fn tick_ai_systems(
     tsc_per_us: u64,
 ) -> AiTickResult {
     agent_logic::tick(
-        mcp, wasm, wm, stream, draug, fb, damage, active_agent, drivers_seeded, tsc_per_us,
+        mcp, wasm, wm, stream, draug, briefing, fb, damage, active_agent, drivers_seeded, tsc_per_us,
     )
 }
 

--- a/userspace/draug-daemon/src/draug.rs
+++ b/userspace/draug-daemon/src/draug.rs
@@ -276,18 +276,6 @@ pub enum DreamMode {
     DriverNightmare,
 }
 
-/// Pending creative changes awaiting user approval ("Morning Briefing")
-pub struct PendingCreative {
-    pub app_name: alloc::string::String,
-    pub description: alloc::string::String, // what changed
-    pub wasm_bytes: alloc::vec::Vec<u8>,
-    pub accepted: Option<bool>, // None = pending, Some(true) = accepted, Some(false) = rejected
-}
-
-/// Maximum pending creative changes
-/// Cap pending creative items to limit heap use (~50KB WASM each).
-pub const MAX_PENDING_CREATIVE: usize = 3;
-
 /// System observation snapshot
 pub struct Observation {
     pub timestamp_ms: u64,
@@ -437,9 +425,6 @@ pub struct DraugDaemon {
 
     /// Dream journal: tracks which app was dreamt about most recently.
     dream_journal: [Option<(u32, u32)>; 16],
-
-    /// Morning Briefing: creative changes pending user approval
-    pub pending_creative: alloc::vec::Vec<PendingCreative>,
 
     /// Friction Sensor: tracks user frustration per app
     pub friction: FrictionTracker,
@@ -601,7 +586,6 @@ impl DraugDaemon {
             dream_mode: DreamMode::Refactor,
             strikes: [const { None }; 8],
             dream_journal: [const { None }; 16],
-            pending_creative: alloc::vec::Vec::new(),
             friction: FrictionTracker::new(),
             crash_hashes: [(0, 0); 8],
             last_pattern_mine_ms: 0,
@@ -1624,67 +1608,9 @@ impl DraugDaemon {
     pub fn is_waiting(&self) -> bool { self.waiting_for_llm }
     pub fn analysis_count(&self) -> u32 { self.analysis_count }
 
-    // ═══════ Morning Briefing: User Approval of Creative Changes ════════
-
-    /// Queue a creative change for user approval (NOT auto-accepted).
-    pub fn queue_creative(&mut self, app_name: &str, description: &str, wasm: alloc::vec::Vec<u8>) {
-        if self.pending_creative.len() >= MAX_PENDING_CREATIVE {
-            self.pending_creative.remove(0); // Drop oldest
-        }
-        self.pending_creative.push(PendingCreative {
-            app_name: String::from(app_name),
-            description: String::from(description),
-            wasm_bytes: wasm,
-            accepted: None,
-        });
-    }
-
-    /// Check if there are pending creative changes to show the user.
-    pub fn has_pending_creative(&self) -> bool {
-        self.pending_creative.iter().any(|p| p.accepted.is_none())
-    }
-
-    /// Get pending creative changes for the Morning Briefing.
-    pub fn pending_count(&self) -> usize {
-        self.pending_creative.iter().filter(|p| p.accepted.is_none()).count()
-    }
-
-    /// Accept a pending creative change by index.
-    pub fn accept_creative(&mut self, idx: usize) {
-        if idx < self.pending_creative.len() {
-            self.pending_creative[idx].accepted = Some(true);
-        }
-    }
-
-    /// Reject a pending creative change by index.
-    pub fn reject_creative(&mut self, idx: usize) {
-        if idx < self.pending_creative.len() {
-            self.pending_creative[idx].accepted = Some(false);
-        }
-    }
-
-    /// Accept all pending creative changes.
-    pub fn accept_all_creative(&mut self) {
-        for p in &mut self.pending_creative {
-            if p.accepted.is_none() { p.accepted = Some(true); }
-        }
-    }
-
-    /// Get accepted creative WASMs (to apply to cache) and clear them.
-    pub fn drain_accepted(&mut self) -> alloc::vec::Vec<(String, alloc::vec::Vec<u8>)> {
-        let mut result = alloc::vec::Vec::new();
-        self.pending_creative.retain(|p| {
-            if p.accepted == Some(true) {
-                result.push((p.app_name.clone(), p.wasm_bytes.clone()));
-                false // remove from pending
-            } else if p.accepted == Some(false) {
-                false // remove rejected too
-            } else {
-                true // keep pending
-            }
-        });
-        result
-    }
+    // Morning Briefing (`pending_creative` queue) was extracted into
+    // `compositor::briefing::BriefingState` in Phase A.5 step 3 — it
+    // was always compositor UI state, never agent state.
 
     // ═══════ Token Scheduler: Attention-Based LLM Priority ══════════
     //


### PR DESCRIPTION
## Summary
- The `pending_creative` queue (Morning Briefing) was always compositor UI state but lived on `DraugDaemon` for pre-isolation reasons. Extracted into a new `compositor::briefing::BriefingState` struct with `queue` / `has_pending` / `pending_count` / `accept` / `reject` / `accept_all` / `drain_accepted` methods.
- Plumbed through `DispatchContext`, `mcp_handler::tick_ai_systems`, `agent_logic::tick`, and `autodream::handle_wasm_chunk` / `evaluate_dream_result`.
- Removed from daemon's `DraugDaemon`: `pending_creative` field, the 6 creative-queue methods, the `PendingCreative` struct, and the `MAX_PENDING_CREATIVE` const — 80 LOC gone.

## Why now
- Closes the Morning Briefing portion of the Phase A.5 cleanup that started with #76 and #78. With briefing out of `DraugDaemon`, compositor's local instance is one step closer to being purely transitional.
- Avoids the alternative — shipping wasm_bytes (50 KiB+) over IPC for every queue/accept/reject operation, with shmem plumbing on both sides — which would have been pure overhead since nothing in the daemon's address space ever read `pending_creative` anyway.

## Out of scope (subsequent PRs)
- Local `DraugDaemon` is still consulted by compositor for `should_dream` / `should_yield_tokens` / `next_task_and_level` / `complex_task_idx` / `plan_mode_active` / `is_waiting`. Those reads migrate to the status shmem next; that's a separate self-contained PR.
- Local `friction.record_signal` and `on_user_input` calls in input handlers are now redundant with the IPC-forwarded versions; safe to drop, also a separate PR.

## Test plan
- [x] `cargo check` workspace clean
- [ ] On Proxmox VM 800: trigger an autodream Creative cycle; the result should hit the `[Morning Briefing]` window with the same description as before
- [ ] `dream accept 1` / `dream reject 1` / `dream accept all` / `dream reject all` all behave identically to before (cache.insert on accept, queue drains, no orphaned items)

## Save/restore compatibility
- Not affected — the 26-byte `save_state` never included `pending_creative`. No on-disk schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)