### PR TITLE
chore(compositor): drop redundant local Draug record calls

### DIFF
--- a/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
+++ b/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
@@ -1200,7 +1200,6 @@ pub(super) fn dispatch_legacy_command(
                     win.push_line("  --force: skip WASM cache");
                     win.push_line("  --tweak \"change\": modify cached version");
                 } else {
-                    ctx.draug.record_command(prompt);
                     if !flags.force {
                         if let Some(cached_wasm) = ctx.wasm.cache.get(prompt) {
                             win.push_line(&alloc::format!("[Cache] Hit: {} bytes", cached_wasm.len()));

--- a/userspace/compositor/src/input_keyboard.rs
+++ b/userspace/compositor/src/input_keyboard.rs
@@ -6,7 +6,6 @@
 extern crate alloc;
 
 use compositor::damage::DamageTracker;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{InputState, RenderState, WasmState};
 use compositor::window_manager::WindowManager;
@@ -50,7 +49,6 @@ pub fn process_keyboard(
     render: &mut RenderState,
     fb: &mut FramebufferView,
     damage: &mut DamageTracker,
-    draug: &mut DraugDaemon,
     tsc_per_us: u64,
     layout: &KeyboardLayout,
 ) -> KeyboardResult {
@@ -76,13 +74,7 @@ pub fn process_keyboard(
         };
         did_work = true;
         let input_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { 0 };
-        // Phase A.5: forward to draug-daemon over IPC. Local update
-        // stays for the transition window so compositor-side HUD reads
-        // (which still target the in-process DraugDaemon) keep
-        // returning fresh values; the call goes away in step 2.4 once
-        // the local instance is dropped.
         libfolk::sys::draug::send_user_input(input_ms);
-        draug.on_user_input(input_ms);
 
         // Ctrl+G (0x07) or 'G'/'g': toggle RAM graph
         if key == 0x07 || (wasm.active_app.is_none() && (key == b'G' || key == b'g') && !input.omnibar_visible) {
@@ -108,15 +100,8 @@ pub fn process_keyboard(
                     if open_duration < 3000 {
                         if let Some(ref k) = wasm.active_app_key {
                             let h = compositor::draug::DraugDaemon::key_hash_pub(k);
-                            // Phase A.5 Path A.2: forward friction
-                            // signal to draug-daemon so its friction
-                            // map sees the same input pattern. Local
-                            // call stays for autodream's gating
-                            // (which still consults compositor's local
-                            // DraugDaemon) until autodream migrates.
                             libfolk::sys::draug::send_friction_signal(
                                 h, compositor::draug::FRICTION_QUICK_CLOSE);
-                            draug.friction.record_signal(h, compositor::draug::FRICTION_QUICK_CLOSE);
                             write_str("[Friction] quick_close for '");
                             write_str(&k[..k.len().min(30)]);
                             write_str("'\n");

--- a/userspace/compositor/src/input_mouse.rs
+++ b/userspace/compositor/src/input_mouse.rs
@@ -6,7 +6,6 @@
 extern crate alloc;
 
 use compositor::damage::DamageTracker;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{CursorState, InputState, RenderState, StreamState, WasmState, Category};
 use compositor::window_manager::{WindowManager, HitZone, BORDER_W, TITLE_BAR_H};
@@ -67,7 +66,6 @@ pub fn process_mouse(
     input: &mut InputState,
     render: &mut RenderState,
     stream: &mut StreamState,
-    draug: &mut DraugDaemon,
     fb: &mut FramebufferView,
     damage: &mut DamageTracker,
     cursor_drawn: &mut bool,
@@ -112,11 +110,7 @@ pub fn process_mouse(
     if had_mouse_events {
         // Tell Draug the user is actively interacting
         let input_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { 0 };
-        // Phase A.5: forward to draug-daemon over IPC. Local update
-        // stays for the transition window — see input_keyboard.rs for
-        // the full rationale.
         libfolk::sys::draug::send_user_input(input_ms);
-        draug.on_user_input(input_ms);
         // Hover detection for folder preview (home view)
         if render.open_folder < 0 && wasm.active_app.is_none() {
             let old_hover = render.hover_folder;
@@ -173,12 +167,8 @@ pub fn process_mouse(
                 if recent > 5 {
                     if let Some(ref k) = wasm.active_app_key {
                         let h = compositor::draug::DraugDaemon::key_hash_pub(k);
-                        // Phase A.5 Path A.2: forward to draug-daemon.
-                        // Local call kept for autodream gating until
-                        // autodream migrates.
                         libfolk::sys::draug::send_friction_signal(
                             h, compositor::draug::FRICTION_RAGE_CLICK);
-                        draug.friction.record_signal(h, compositor::draug::FRICTION_RAGE_CLICK);
                         write_str("[Friction] rage_click for '");
                         write_str(&k[..k.len().min(30)]);
                         write_str("'\n");

--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -914,7 +914,7 @@ fn main() -> ! {
             };
             let mr = input_mouse::process_mouse(
                 &mut cursor, &mut wm, &mut wasm, &mut input, &mut render,
-                &mut stream, &mut draug, &mut fb, &mut damage,
+                &mut stream, &mut fb, &mut damage,
                 &mut cursor_drawn, &mut last_buttons, &mut cursor_bg.0,
                 tsc_per_us, &categories[..], &mouse_layout,
             );
@@ -1013,7 +1013,7 @@ fn main() -> ! {
             };
             input_keyboard::process_keyboard(
                 &mut input, &mut wasm, &mut wm, &mut render,
-                &mut fb, &mut damage, &mut draug,
+                &mut fb, &mut damage,
                 tsc_per_us, &kb_layout,
             )
         };

--- a/userspace/compositor/src/rendering/wasm_layer.rs
+++ b/userspace/compositor/src/rendering/wasm_layer.rs
@@ -113,12 +113,8 @@ pub(super) fn render_fullscreen_app(ctx: &mut RenderContext) -> bool {
                             } else {
                                 write_str("[IMMUNE] Failed to send patch request\n");
                             }
-                            // Phase A.5: forward crash to draug-daemon.
-                            // Local record_crash stays for HUD coherence
-                            // until A.5 step 2.4 drops the local instance.
                             let h = compositor::draug::DraugDaemon::key_hash_pub(k);
                             libfolk::sys::draug::record_crash(h as u64);
-                            ctx.draug.record_crash(k);
                         }
                     } else if ctx.wasm.fuel_fail_count < 3 {
                         write_str("[WASM APP] Fuel exhausted (");
@@ -138,7 +134,6 @@ pub(super) fn render_fullscreen_app(ctx: &mut RenderContext) -> bool {
                     if let Some(ref k) = app_active_key {
                         let h = compositor::draug::DraugDaemon::key_hash_pub(k);
                         libfolk::sys::draug::record_crash(h as u64);
-                        ctx.draug.record_crash(k);
                     }
                 }
                 _ => {


### PR DESCRIPTION
## Summary
- Five local `draug.*` calls in compositor had been double-recording for several PRs already, with comments like \"Local call stays for the transition window.\" Their IPC equivalents (since #71, #76, etc.) reach the authoritative daemon-side state, and audit shows no live consumer of the local-side data.
- Net 33 lines removed; `process_mouse` and `process_keyboard` lose their `&mut DraugDaemon` parameter entirely.

## What was dropped & why it's safe

| Call | Reader of local state | Verdict |
|------|----------------------|---------|
| `draug.on_user_input(ms)` × 2 (input_mouse, input_keyboard) | Caret-blink fallback at main.rs:938 — already prefers status shmem when attached | Stale local just means caret stops blinking after perceived idle; harmless |
| `draug.friction.record_signal(h, …)` × 2 (input_mouse, input_keyboard) | Only `start_dream`, daemon-side since #76 | Daemon gets the same signal via `send_friction_signal` (#71) |
| `ctx.draug.record_crash(k)` × 2 (rendering/wasm_layer) | Only `start_dream`'s priority-2 (\"crashed apps → Nightmare\"), daemon-side | Daemon gets the crash via `record_crash` IPC |
| `ctx.draug.record_command(prompt)` × 1 (legacy_dispatch) | `predict_next()`, only referenced from an archived doc | Dead-code path on compositor side |

## Test plan
- [x] `cargo check` workspace clean
- [ ] On Proxmox VM 800: caret keeps blinking with the daemon attached (HUD reads status shmem); ESC-quick-close still triggers Creative dreams via daemon's friction sensor; WASM crash routes the app to Nightmare evaluation
- [ ] Daemon's `pending_count` (status shmem) keeps reflecting friction events fed exclusively over IPC

## Notes
- Several remaining transition-window items still consult local `DraugDaemon` (`should_dream`, `should_yield_tokens`, `next_task_and_level`, `complex_task_idx`, `plan_mode_active`, `is_waiting`). Those need status-shmem reads instead — separate self-contained PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)