### PR TITLE
refactor(compositor): drop local DraugDaemon instance entirely

### DIFF
--- a/userspace/compositor/src/command_dispatch/mod.rs
+++ b/userspace/compositor/src/command_dispatch/mod.rs
@@ -24,7 +24,6 @@ use alloc::vec::Vec;
 
 use compositor::agent::AgentSession;
 use compositor::damage::DamageTracker;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{CursorState, InputState, McpState, StreamState, WasmState};
 use compositor::window_manager::WindowManager;
@@ -62,7 +61,6 @@ pub struct DispatchContext<'a> {
     pub wm: &'a mut WindowManager,
     pub mcp: &'a mut McpState,
     pub stream: &'a mut StreamState,
-    pub draug: &'a mut DraugDaemon,
     pub briefing: &'a mut compositor::briefing::BriefingState,
     pub fb: &'a mut FramebufferView,
     pub damage: &'a mut DamageTracker,

--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -627,47 +627,26 @@ fn main() -> ! {
     // last_clock_second now in render (RenderState)
     // tz_offset_minutes, tz_synced, tz_sync_pending now in mcp
     let mut active_agent: Option<compositor::agent::AgentSession> = None; // ReAct agentic loop
-    let mut draug = compositor::draug::DraugDaemon::new();
     let mut briefing = compositor::briefing::BriefingState::new();
 
-    // Phase A.5 step 2.3: read draug state from the daemon's status
-    // shmem instead of the local DraugDaemon for the fields the
-    // daemon owns now (refactor counts, task_levels, last_input_ms,
-    // hibernation flags). Compositor's local DraugDaemon stays
-    // allocated until step 2.4 because the analysis-cycle path and
-    // a few HUD callsites still read from it.
-    //
-    // `attach_status()` returns `Err` if draug-daemon hasn't booted
-    // yet — that's expected during cold boot since compositor
-    // currently spawns before draug-daemon (Phase A.6 fixes the
-    // ordering). Treat as `None` and fall back to local reads.
+    // Phase A.5 step 6: compositor's local `DraugDaemon` instance is
+    // gone. All agent work ticks in `draug-daemon`; reads come over
+    // the status shmem. `attach_status()` returns `Err` if the daemon
+    // hasn't booted yet — boot-order race since compositor spawns
+    // first today (Phase A.6 fixes the ordering). Until shmem is
+    // available the autodream gate stays closed (safe default).
     let draug_status: Option<&'static libfolk::sys::draug::DraugStatus> =
         libfolk::sys::draug::attach_status().ok();
     if draug_status.is_some() {
         libfolk::sys::io::write_str("[Draug] status shmem attached — HUD reads from daemon\n");
     } else {
-        libfolk::sys::io::write_str("[Draug] status shmem not yet ready (daemon booting?) — HUD falls back to local\n");
+        libfolk::sys::io::write_str("[Draug] status shmem not yet ready (daemon booting?) — autodream gate closed until attach\n");
     }
 
-    // Stability Fix 1: restore state from previous session. Daemon
-    // also restores from the same Synapse file at its own boot — no
-    // contention because save_state writes only fire from the
-    // daemon's tick path now (compositor's local DraugDaemon is
-    // dormant on those code paths).
-    if draug.restore_state() {
-        libfolk::sys::io::write_str("[Draug] Restored state: iter=");
-        let mut nb = [0u8; 16];
-        libfolk::sys::io::write_str(crate::util::format_usize(draug.refactor_iter as usize, &mut nb));
-        libfolk::sys::io::write_str(" levels=[");
-        for i in 0..20 {
-            if i > 0 { libfolk::sys::io::write_str(","); }
-            libfolk::sys::io::write_str(crate::util::format_usize(draug.task_levels[i] as usize, &mut nb));
-        }
-        libfolk::sys::io::write_str("]\n");
-        // The kernel-bridge push that used to live here is now done
-        // by draug-daemon on every tick — the boot-time push was
-        // double-writing into the bridge atomics for no benefit.
-    }
+    // `restore_state` runs in the daemon now (`draug-daemon::main`
+    // calls it during boot from the same Synapse file we used to read
+    // here). The boot-time print of restored counters is gone because
+    // the daemon logs the same info — duplicating it served no purpose.
 
     // Phase 17 — seed the autonomous refactor task queue if it's
     // missing. Daemon picks up the same Synapse VFS file on its
@@ -864,7 +843,7 @@ fn main() -> ! {
         {
             let ai = mcp_handler::tick_ai_systems(
                 &mut mcp, &mut wasm, &mut wm, &mut stream,
-                &mut draug, &mut briefing, draug_status, &mut fb, &mut damage,
+                &mut briefing, draug_status, &mut fb, &mut damage,
                 &mut active_agent, &mut drivers_seeded,
                 tsc_per_us,
             );
@@ -930,13 +909,14 @@ fn main() -> ! {
         // Freeze caret when idle >10s — prevents infinite 150ms redraw loop
         {
             let caret_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { uptime() };
-            // Phase A.5 step 2.3: prefer the daemon's last_input_ms
-            // from shmem (cross-process source of truth). Fall back
-            // to compositor's local DraugDaemon if shmem isn't
-            // attached (boot-order race with draug-daemon).
+            // Read user-input timestamp from the daemon's status shmem.
+            // If shmem isn't attached yet (cold-boot race), default to
+            // 0 — the resulting "huge idle" reading just freezes the
+            // caret, which is the same observable behaviour as the
+            // 10-second idle freeze that already kicks in.
             let last_input_ms = draug_status
                 .map(|s| s.last_input_ms.load(core::sync::atomic::Ordering::Acquire))
-                .unwrap_or_else(|| draug.last_input_ms());
+                .unwrap_or(0);
             let idle_secs = caret_ms.saturating_sub(last_input_ms) / 1000;
             if idle_secs < 10 && caret_ms.saturating_sub(input.last_caret_flip_ms) >= CARET_BLINK_MS {
                 input.caret_visible = !input.caret_visible;
@@ -1032,7 +1012,6 @@ fn main() -> ! {
                 wm: &mut wm,
                 mcp: &mut mcp,
                 stream: &mut stream,
-                draug: &mut draug,
                 briefing: &mut briefing,
                 fb: &mut fb,
                 damage: &mut damage,
@@ -1113,7 +1092,6 @@ fn main() -> ! {
                     mcp: &mut mcp,
                     iqe: &iqe,
                     damage: &mut damage,
-                    draug: &mut draug,
                     categories: &categories[..],
                     layout: &rl,
                     cursor: &cursor,

--- a/userspace/compositor/src/mcp_handler/agent_logic.rs
+++ b/userspace/compositor/src/mcp_handler/agent_logic.rs
@@ -13,7 +13,6 @@ use libfolk::sys::io::write_str;
 use compositor::agent::AgentSession;
 use compositor::damage::DamageTracker;
 use compositor::briefing::BriefingState;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{McpState, StreamState, WasmState};
 use compositor::window_manager::WindowManager;
@@ -27,7 +26,6 @@ pub(super) fn tick(
     wasm: &mut WasmState,
     wm: &mut WindowManager,
     stream: &mut StreamState,
-    draug: &mut DraugDaemon,
     briefing: &mut BriefingState,
     draug_status: Option<&'static libfolk::sys::draug::DraugStatus>,
     fb: &mut FramebufferView,
@@ -95,16 +93,12 @@ pub(super) fn tick(
     // ticking).
 
     // ===== AutoDream cycle start (delegates to autodream module) =====
-    // Phase 14: don't dream if the skill tree still has work to do —
-    // the refactor loop takes priority over AutoDream.
     //
-    // Gate state lives in the daemon's status shmem (Phase A.5 step 4):
-    // `DRAUG_FLAG_DREAM_READY` collapses `should_dream` + `should_yield_tokens`,
-    // `DRAUG_FLAG_SKILL_TREE_HAS_WORK` and `DRAUG_FLAG_PLAN_MODE_ACTIVE`
-    // gate against the refactor / planner loops, and `complex_task_idx`
-    // gates the boot-time complex-task warmup. Compositor-local
-    // `DraugDaemon` is consulted only as a cold-boot fallback before the
-    // daemon's shmem region is attached.
+    // Gate is fully shmem-driven now (Phase A.5 step 6, the
+    // compositor-local `DraugDaemon` instance has been dropped). When
+    // the daemon's status shmem isn't attached yet (boot-order race),
+    // the gate stays closed — that defers a few autodream cycles
+    // until the daemon comes up, which is harmless.
     let dream_ms = if tsc_per_us > 0 { rdtsc() / tsc_per_us / 1000 } else { 0 };
     let dream_gate_open = if active_agent.is_some() || mcp.async_tool_gen.is_some() {
         false
@@ -117,16 +111,7 @@ pub(super) fn tick(
             >= compositor::draug::COMPLEX_TASK_COUNT as u32;
         dream_ready && !plan_active && !skill_has_work && complex_done
     } else {
-        // Fallback: shmem not attached yet (boot-order race with
-        // draug-daemon). Read from compositor-local DraugDaemon — its
-        // values can drift from the daemon's, but for this gate the
-        // cost of being wrong is one wasted DREAM_DECIDE IPC, which the
-        // daemon then short-circuits with SKIP. Acceptable.
-        draug.should_dream(dream_ms)
-            && !draug.should_yield_tokens(active_agent.is_some(), dream_ms)
-            && draug.next_task_and_level().is_none()
-            && !draug.plan_mode_active
-            && draug.complex_task_idx >= compositor::draug::COMPLEX_TASK_COUNT
+        false
     };
     if dream_gate_open {
         autodream::start_dream_cycle(mcp, wasm, fb, dream_ms);
@@ -172,12 +157,10 @@ pub(super) fn tick(
     }
 
     // ===== MCP: Poll for responses =====
-    let daemon_waiting = if let Some(s) = draug_status {
-        let flags = s.flags.load(core::sync::atomic::Ordering::Acquire);
-        flags & libfolk::sys::draug::DRAUG_FLAG_WAITING_FOR_LLM != 0
-    } else {
-        draug.is_waiting()
-    };
+    let daemon_waiting = draug_status
+        .map(|s| s.flags.load(core::sync::atomic::Ordering::Acquire)
+                  & libfolk::sys::draug::DRAUG_FLAG_WAITING_FOR_LLM != 0)
+        .unwrap_or(false);
     if mcp.tz_sync_pending || mcp.async_tool_gen.is_some() || active_agent.is_some()
         || daemon_waiting || mcp.pending_shell_jit.is_some()
     {

--- a/userspace/compositor/src/mcp_handler/mod.rs
+++ b/userspace/compositor/src/mcp_handler/mod.rs
@@ -19,7 +19,6 @@ extern crate alloc;
 use compositor::Compositor;
 use compositor::agent::AgentSession;
 use compositor::damage::DamageTracker;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{McpState, StreamState, WasmState};
 use compositor::window_manager::WindowManager;
@@ -92,7 +91,6 @@ pub fn tick_ai_systems(
     wasm: &mut WasmState,
     wm: &mut WindowManager,
     stream: &mut StreamState,
-    draug: &mut DraugDaemon,
     briefing: &mut compositor::briefing::BriefingState,
     draug_status: Option<&'static libfolk::sys::draug::DraugStatus>,
     fb: &mut FramebufferView,
@@ -102,7 +100,7 @@ pub fn tick_ai_systems(
     tsc_per_us: u64,
 ) -> AiTickResult {
     agent_logic::tick(
-        mcp, wasm, wm, stream, draug, briefing, draug_status, fb, damage, active_agent, drivers_seeded, tsc_per_us,
+        mcp, wasm, wm, stream, briefing, draug_status, fb, damage, active_agent, drivers_seeded, tsc_per_us,
     )
 }
 

--- a/userspace/compositor/src/rendering/mod.rs
+++ b/userspace/compositor/src/rendering/mod.rs
@@ -17,7 +17,6 @@
 extern crate alloc;
 
 use compositor::damage::DamageTracker;
-use compositor::draug::DraugDaemon;
 use compositor::framebuffer::FramebufferView;
 use compositor::state::{
     Category, CursorState, IqeState, InputState, McpState, RenderState, StreamState,
@@ -82,7 +81,6 @@ pub struct RenderContext<'a> {
     pub mcp: &'a mut McpState,
     pub iqe: &'a IqeState,
     pub damage: &'a mut DamageTracker,
-    pub draug: &'a mut DraugDaemon,
     pub categories: &'a [Category],
     pub layout: &'a RenderLayout,
     pub cursor: &'a CursorState,


### PR DESCRIPTION
## Summary
- Phase A.5 step 6 — completes the multi-PR migration that started with #76. Compositor no longer holds an in-process \`DraugDaemon\`; all agent state lives in the \`draug-daemon\` process and flows back via the status shmem (read) and IPC ops (write).
- 74 lines removed, 29 added. \`&mut DraugDaemon\` parameters dropped from \`tick_ai_systems\`, \`agent_logic::tick\`, \`DispatchContext\`, \`RenderContext\`.

## Stacked on #82
- Base branch is \`feat/draug-strike-ipc\` (#82). The strike state needed to migrate to IPC before the local instance could be dropped — without #82, this PR would fail to compile (\`evaluate_refactor\` still calls \`draug.add_strike\`).

## What was removed
- \`DraugDaemon::new()\` + \`restore_state()\` at boot — daemon owns restore at its own boot from the same Synapse file (\`draug-daemon::main\` line 103).
- Boot-time print of restored counters — daemon already logs the same.
- \`draug.last_input_ms()\` fallback in caret-blink. When status shmem isn't attached we default to 0; the resulting \"huge idle\" reading freezes the caret, which is the same observable behaviour as the existing 10-second idle freeze.
- Cold-boot fallback in the autodream gate — when shmem isn't attached the gate stays closed. Defers a few autodream cycles until the daemon comes up. Harmless.

## What stays
- \`compositor::draug\` re-export shim — \`DraugDaemon::key_hash_pub\` is still used as a stateless helper (compute key hash for the friction-signal and strike IPCs), and the \`DreamMode\` / \`COMPLEX_TASK_COUNT\` / \`DREAM_MAX_PER_SESSION\` / \`FRICTION_*\` constants still resolve through it.
- The HUD's status reads — those already went through the shmem in #81, no change here.

## Test plan
- [x] \`cargo check\` workspace clean (post-#82 base)
- [ ] On Proxmox VM 800: full daemon attach + autodream cycle + Morning Briefing + accept/reject all still work; daemon's serial logs the strike/friction/user-input IPC arrivals in lockstep with compositor activity
- [ ] Cold-boot path: compositor boots before daemon, logs \`autodream gate closed until attach\`, then the gate opens once \`attach_status\` succeeds on a later tick — autodream still fires after the daemon is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)