### PR TITLE
feat(boot): Phase A.6 — spawn draug-daemon before compositor

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -516,7 +516,49 @@ pub fn kernel_main_with_boot_info(boot_info: &boot::BootInfo) -> ! {
                 serial_strln!("[BOOT] WARNING: Shell not found in ramdisk!");
             }
 
-            // Spawn any additional ELF entries (skip synapse and shell)
+            // Spawn Draug daemon (Task 4) — Phase A.6 boot ordering.
+            // Compositor's `attach_status()` reads from the daemon's
+            // status shmem on its first tick; spawning the daemon
+            // before compositor means the shmem region is allocated
+            // and the read-grant is in place by the time compositor
+            // gets its first time slice. Without this explicit step,
+            // ramdisk entry order decided spawn order — compositor
+            // fell through the cold-boot fallback path until the
+            // daemon caught up.
+            if let Some(entry) = rd.find("draug-daemon") {
+                serial_strln!("[BOOT] Spawning Task 4 (draug-daemon)...");
+                let daemon_elf = rd.read(entry);
+                serial_str!("[BOOT] draug-daemon ELF size: ");
+                drivers::serial::write_dec(daemon_elf.len() as u32);
+                serial_strln!(" bytes");
+                match task::spawn(daemon_elf, &[]) {
+                    Ok(task_id) => {
+                        if let Some(task_arc) = task::task::get_task(task_id) {
+                            task_arc.lock().set_name("draug-daemon");
+                        }
+                        serial_str!("[BOOT] draug-daemon spawned, id=");
+                        drivers::serial::write_dec(task_id);
+                        serial_strln!("");
+                        // Daemon talks IPC to compositor (status shmem
+                        // grant), Synapse (state restore), and the
+                        // proxy-bound TCP path via libfolk syscalls.
+                        let _ = capability::grant_ipc_send_any(task_id);
+                    }
+                    Err(e) => {
+                        serial_str!("[BOOT] draug-daemon spawn FAILED: ");
+                        match e {
+                            task::SpawnError::InvalidElf(_) => { serial_strln!("InvalidElf"); }
+                            task::SpawnError::OutOfMemory => { serial_strln!("OutOfMemory"); }
+                            task::SpawnError::PermissionDenied => { serial_strln!("PermissionDenied"); }
+                            task::SpawnError::NotFound => { serial_strln!("NotFound"); }
+                        }
+                    }
+                }
+            } else {
+                serial_strln!("[BOOT] WARNING: draug-daemon not found in ramdisk!");
+            }
+
+            // Spawn any additional ELF entries (skip synapse, shell, draug-daemon)
             for entry in rd.entries() {
                 let name = entry.name_str();
                 // Use byte comparison to avoid potential str comparison issues
@@ -525,7 +567,8 @@ pub fn kernel_main_with_boot_info(boot_info: &boot::BootInfo) -> ! {
                 let is_compositor = name.as_bytes() == b"compositor";
                 let is_inference = name.as_bytes() == b"inference";
                 let is_draug_streamer = name.as_bytes() == b"draug-streamer";
-                if is_shell || is_synapse {
+                let is_draug_daemon = name.as_bytes() == b"draug-daemon";
+                if is_shell || is_synapse || is_draug_daemon {
                     continue;
                 }
                 // Phase 5 Hybrid AI: skip built-in inference server to save ~400MB RAM.

--- a/userspace/libfolk/src/sys/draug.rs
+++ b/userspace/libfolk/src/sys/draug.rs
@@ -54,15 +54,13 @@ use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 // Well-Known Task ID
 // ============================================================================
 
-/// Default expected draug-daemon task ID. Phase A.6 originally
-/// proposed pinning this with a kernel-side special-case spawn (the
-/// way Synapse=2 and Shell=3 are pinned), but that would have forced
-/// shifting compositor's well-known ID. Instead we ship a fallback
-/// const here and discover the actual ID at runtime via
-/// `daemon_task_id()`, which scans `task_list_detailed` for a task
-/// named `"draug-daemon"`. The const stays as the cache seed value
-/// and as the documented "if you want to pin this, pin to 7" target.
-pub const DRAUG_TASK_ID: u32 = 7;
+/// Pinned draug-daemon task ID. Phase A.6 added an explicit
+/// kernel-side spawn between shell (task 3) and the generic ramdisk
+/// loop, so the daemon now lands on task 4 deterministically. The
+/// `daemon_task_id()` discovery helper still scans `task_list_detailed`
+/// as a fallback in case spawn order changes again, but the seed
+/// here matches the actual ID on a fresh boot.
+pub const DRAUG_TASK_ID: u32 = 4;
 
 /// Cached daemon task ID. Seeded with `DRAUG_TASK_ID`; if the first
 /// IPC fails (`Err(IpcError::Unknown)` from `send`), the next


### PR DESCRIPTION
## Summary
- Pre-A.6, daemon spawn order was determined by ramdisk entry layout in the generic ELF loop, so compositor and draug-daemon raced on first tick: compositor's `attach_status()` ran before the daemon had created its status shmem region, falling through to the cold-boot fallback on every boot.
- Add an explicit kernel-side spawn for draug-daemon between shell (task 3) and the generic loop, mirroring the synapse / shell pattern. The daemon lands on task 4 deterministically; by the time compositor (task 5) reaches its main loop, the status shmem is allocated and granted, so `attach_status()` succeeds on the first try.

## Wired
- `kernel/src/lib.rs` — explicit `if let Some(entry) = rd.find("draug-daemon")` block + IPC send-any grant
- `kernel/src/lib.rs` — `is_draug_daemon` added to the generic-loop skip set so we don't double-spawn
- `libfolk/src/sys/draug.rs` — `DRAUG_TASK_ID` bumped 7 → 4 to match the new pinned ID; doc updated. The `daemon_task_id()` runtime scan still works as a defensive fallback if spawn order changes again.

## Test plan
- [x] `cargo check` kernel + userspace clean
- [ ] On Proxmox VM 800: boot serial shows `[BOOT] Spawning Task 4 (draug-daemon)` followed by `[BOOT] draug-daemon spawned, id=4`, then compositor's `[Draug] status shmem attached — HUD reads from daemon` (instead of the `not yet ready` warning)
- [ ] First-tick autodream gate goes through the shmem path on cold boot, not the cold-boot fallback (verifiable by daemon serial seeing DREAM_DECIDE IPCs from the very first idle window)

## Notes
- This is independent of #82 / #83 (they touch userspace; this touches kernel + a const). All three should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)