### PR TITLE
feat(net): build-time configurable proxy IP/port (Phase 17 cleanup)

### DIFF
--- a/kernel/src/arch/x86_64/syscall/handlers/net.rs
+++ b/kernel/src/arch/x86_64/syscall/handlers/net.rs
@@ -1,5 +1,13 @@
 //! Network syscalls: ICMP ping, DNS, HTTPS/HTTP fetch, GitHub helpers,
 //! UDP send/recv, NTP query.
+//!
+//! All host-bound TCP calls (NAVIGATE, PATCH, LLM relay, etc.) target
+//! `crate::net::proxy_config::{PROXY_IP, PROXY_PORT}` — configurable
+//! at build time via `FOLKERING_PROXY_IP` / `FOLKERING_PROXY_PORT`,
+//! defaulting to the SLIRP `10.0.2.2:14711` so local QEMU runs work
+//! out of the box.
+
+use crate::net::proxy_config::{PROXY_IP, PROXY_PORT};
 
 pub fn syscall_ping(ip_packed: u64) -> u64 {
     let a = (ip_packed & 0xFF) as u8;
@@ -410,8 +418,6 @@ pub fn syscall_fbp_request(
     buf_ptr: u64,
     buf_max: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
     const MAX_REQUEST: usize = 1024;
 
     if url_len == 0 || url_len > 512 || buf_max == 0 || buf_max > 262144 {
@@ -521,8 +527,6 @@ pub fn syscall_fbp_interact(
     buf_max: u64,
     action_and_node: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     if url_len == 0 || url_len > 512 || buf_max == 0 || buf_max > 262144 {
         return u64::MAX;
@@ -662,8 +666,6 @@ pub fn syscall_fbp_patch(
     result_ptr: u64,
     packed_lens: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     // Unpack: 21 bits each for filename_len / content_len / result_max.
     // See `libfolk::sys::fbp_patch` for the matching pack step.
@@ -806,8 +808,6 @@ pub fn syscall_llm_generate(
     result_ptr: u64,
     packed_lens: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     let model_len = (packed_lens & 0x1F_FFFF) as usize;
     let prompt_len = ((packed_lens >> 21) & 0x1F_FFFF) as usize;
@@ -933,8 +933,6 @@ pub fn syscall_llm_generate(
 /// Returns Some((status, bytes_written)) on a successful proxy
 /// round-trip (any status code), None on TCP failure.
 pub fn graph_callers_inner(name: &str, result: &mut [u8]) -> Option<(u32, usize)> {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     crate::serial_str!("[GRAPH] callers of ");
     crate::serial_strln!(name);
@@ -1053,8 +1051,6 @@ pub fn syscall_graph_callers(
 /// Returns 1 if proxy responds with PONG, 0 otherwise.
 /// Used before expensive LLM calls to fail fast when proxy is down.
 pub fn syscall_proxy_ping() -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     // Issue #58 instrumentation: log every ping attempt + outcome so we
     // can see whether hibernation's wakeup path is itself broken under
@@ -1100,8 +1096,6 @@ pub fn syscall_proxy_ping() -> u64 {
 /// (status = 0xDEADBEEF, output_len = 0) which we surface as
 /// `u64::MAX` so the userspace branch is unambiguous.
 pub fn syscall_proxy_last_verdict(buf_ptr: u64, buf_max: u64) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     if buf_max == 0 || buf_max > 65_536 {
         return u64::MAX;
@@ -1181,8 +1175,6 @@ pub fn syscall_proxy_patch_dedup(
     hash_ptr: u64, hash_len: u64,
     buf_ptr: u64, buf_max: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
     const MISS_SENTINEL: u32 = 0xCACE_D15D;
 
     // Pointer + length sanity. Hash is fixed at 64 hex chars; reject
@@ -1298,8 +1290,6 @@ pub fn syscall_proxy_patch_dedup(
 /// Returns 1 on successful ACK (proxy acknowledged or cache was
 /// already empty), 0 on transport failure.
 pub fn syscall_proxy_ack_verdict() -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     crate::serial_strln!("[ACK_VERDICT] sending to proxy");
 
@@ -1346,8 +1336,6 @@ pub fn syscall_proxy_ack_verdict() -> u64 {
 ///
 /// Returns 1 on PONG received, 0 otherwise.
 pub fn syscall_proxy_ping_udp() -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     crate::serial_strln!("[PROXY_PING_UDP] requesting");
 
@@ -1385,8 +1373,6 @@ pub fn syscall_proxy_ping_udp() -> u64 {
 ///
 /// Returns `(status << 32) | wasm_bytes_written` or `u64::MAX` on failure.
 pub fn syscall_wasm_compile(buf_ptr: u64, buf_max: u64) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     if buf_max == 0 || buf_max > 262_144 {
         return u64::MAX;
@@ -1545,8 +1531,6 @@ pub fn syscall_cargo_check(
     result_ptr: u64,
     packed_lens: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     let target_len = (packed_lens & 0x1F_FFFF) as usize;
     let content_len = ((packed_lens >> 21) & 0x1F_FFFF) as usize;
@@ -1687,8 +1671,6 @@ pub fn syscall_fetch_source(
     _unused: u64,
     packed_lens: u64,
 ) -> u64 {
-    const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-    const PROXY_PORT: u16 = 14711;
 
     let target_len = (packed_lens & 0x1F_FFFF) as usize;
     let result_max = ((packed_lens >> 21) & 0x1F_FFFF) as usize;

--- a/kernel/src/net/gemini.rs
+++ b/kernel/src/net/gemini.rs
@@ -35,9 +35,7 @@ fn libfolk_yield() {
     for _ in 0..5000 { core::hint::spin_loop(); }
 }
 
-/// Host proxy IP: Proxmox host on LAN (bridge networking, not SLIRP)
-const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-const PROXY_PORT: u16 = 8080;
+use super::proxy_config::{PROXY_IP, GEMINI_PORT as PROXY_PORT};
 
 pub fn ask_gemini(prompt: &str) -> Result<Vec<u8>, &'static str> {
     // Build the request payload (same format for both TCP and COM2)

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -14,6 +14,7 @@ pub mod firewall;
 pub mod gemini;
 pub mod github;
 pub mod json;
+pub mod proxy_config;
 pub mod tls;
 pub mod tls_verify;
 pub mod tcp_plain;

--- a/kernel/src/net/proxy_config.rs
+++ b/kernel/src/net/proxy_config.rs
@@ -1,0 +1,79 @@
+//! Build-time configurable proxy address.
+//!
+//! Phase 17 hardcoded `[192, 168, 68, 150]` (the demo Proxmox host's
+//! LAN address) at every TCP-to-host call site — kernel syscall
+//! handlers, the Gemini relay, the WebSocket bring-up in compositor,
+//! and the daemon's async TCP path. That made local QEMU runs (which
+//! use SLIRP / `[10, 0, 2, 2]`) impossible without source patches.
+//!
+//! This module exposes a single `PROXY_IP` resolved at compile time:
+//! `FOLKERING_PROXY_IP` env var if set (e.g. `cargo build` with
+//! `FOLKERING_PROXY_IP=192.168.68.150`), otherwise the SLIRP default.
+//! `PROXY_PORT` follows the same pattern with a 14711 default.
+
+/// Address of the host-side `folkering-proxy` listener.
+pub const PROXY_IP: [u8; 4] = match option_env!("FOLKERING_PROXY_IP") {
+    Some(s) => parse_ipv4(s),
+    None => [10, 0, 2, 2],
+};
+
+/// TCP port the host-side proxy listens on.
+pub const PROXY_PORT: u16 = match option_env!("FOLKERING_PROXY_PORT") {
+    Some(s) => parse_u16(s),
+    None => 14711,
+};
+
+/// TCP port the host-side Gemini relay listens on. Separate from the
+/// main proxy because it's historically a different service
+/// (`mcp/server.py` exposes both on different ports).
+pub const GEMINI_PORT: u16 = match option_env!("FOLKERING_GEMINI_PORT") {
+    Some(s) => parse_u16(s),
+    None => 8080,
+};
+
+/// Compile-time IPv4 dotted-quad parser. Accepts strings like
+/// `"10.0.2.2"` or `"192.168.68.150"`. Non-digit / non-dot bytes are
+/// silently treated as zero — bad input panics later through normal
+/// `[u8; 4]` use, which is fine for a build-time misconfiguration
+/// signal. Each octet must fit in `u8`; values > 255 wrap (which is
+/// also a misconfiguration the user will notice on first packet).
+const fn parse_ipv4(s: &str) -> [u8; 4] {
+    let bytes = s.as_bytes();
+    let mut out = [0u8; 4];
+    let mut octet: usize = 0;
+    let mut acc: u32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'.' {
+            if octet < 4 {
+                out[octet] = acc as u8;
+            }
+            octet += 1;
+            acc = 0;
+        } else if b >= b'0' && b <= b'9' {
+            acc = acc * 10 + (b - b'0') as u32;
+        }
+        i += 1;
+    }
+    if octet < 4 {
+        out[octet] = acc as u8;
+    }
+    out
+}
+
+/// Compile-time decimal `u16` parser. Same lenient rules as
+/// `parse_ipv4`.
+const fn parse_u16(s: &str) -> u16 {
+    let bytes = s.as_bytes();
+    let mut acc: u32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b >= b'0' && b <= b'9' {
+            acc = acc * 10 + (b - b'0') as u32;
+        }
+        i += 1;
+    }
+    acc as u16
+}

--- a/userspace/compositor/src/host_api/network.rs
+++ b/userspace/compositor/src/host_api/network.rs
@@ -261,10 +261,11 @@ pub fn register(linker: &mut Linker<HostState>) {
                         parts[3].parse().unwrap_or(2),
                     ]
                 } else {
-                    // Phase 17 demo on Proxmox/KVM. 10.0.2.2 was the
-                    // QEMU SLIRP default; on a bridge to the LAN we
-                    // talk to the proxy host directly.
-                    [192, 168, 68, 150]
+                    // Non-IP hostname (DNS not yet resolved here):
+                    // fall back to the build-configured proxy IP.
+                    // Default = SLIRP `[10, 0, 2, 2]`; override with
+                    // `FOLKERING_PROXY_IP=<ip>` at compile time.
+                    libfolk::proxy_config::PROXY_IP
                 }
             };
 

--- a/userspace/draug-daemon/src/draug_async.rs
+++ b/userspace/draug-daemon/src/draug_async.rs
@@ -12,12 +12,10 @@ use crate::draug::{AsyncPhase, AsyncOp, DraugDaemon, PlanStep};
 use crate::knowledge_hunt::{write_dec, extract_rust_code_block, push_decimal, REFACTOR_TASKS};
 use crate::agent_planner::COMPLEX_TASKS;
 
-// Phase 17 demo on Proxmox/KVM: VM 800 talks to the proxy on the
-// Proxmox host directly via the LAN bridge, not the QEMU SLIRP
-// gateway. Set this to your proxy's LAN IP. 10.0.2.2 is the
-// historical default for `qemu -netdev user`.
-const PROXY_IP: [u8; 4] = [192, 168, 68, 150];
-const PROXY_PORT: u16 = 14711;
+// Build-time configurable proxy target — set `FOLKERING_PROXY_IP=<ip>`
+// at compile time for the Proxmox / bridged-LAN demo. Defaults to the
+// SLIRP `10.0.2.2:14711` so local QEMU runs work out of the box.
+use libfolk::proxy_config::{PROXY_IP, PROXY_PORT};
 
 /// Non-blocking Draug tick. Called every compositor frame (~60Hz).
 pub fn tick_async(draug: &mut DraugDaemon, now_ms: u64) -> bool {

--- a/userspace/libfolk/src/lib.rs
+++ b/userspace/libfolk/src/lib.rs
@@ -45,6 +45,7 @@ pub mod ui;
 pub mod mcp;
 pub mod json;
 pub mod crypto;
+pub mod proxy_config;
 
 // Re-export print macros at crate root
 pub use fmt::_print;

--- a/userspace/libfolk/src/proxy_config.rs
+++ b/userspace/libfolk/src/proxy_config.rs
@@ -1,0 +1,64 @@
+//! Build-time configurable proxy address — userspace mirror of
+//! `kernel::net::proxy_config`.
+//!
+//! Userspace tasks that connect to the host-side `folkering-proxy` /
+//! Gemini relay (compositor's host_api WebSocket bring-up,
+//! draug-daemon's PATCH/LLM TCP path) read these constants instead
+//! of hardcoding the demo address. Same `FOLKERING_PROXY_IP` /
+//! `FOLKERING_PROXY_PORT` env vars compile into both crates so kernel
+//! and userspace agree.
+//!
+//! Default is the SLIRP `[10, 0, 2, 2]:14711` so local QEMU runs work
+//! out of the box; set `FOLKERING_PROXY_IP=192.168.68.150` for the
+//! Proxmox / bridged-LAN demo.
+
+/// Address of the host-side `folkering-proxy` listener.
+pub const PROXY_IP: [u8; 4] = match option_env!("FOLKERING_PROXY_IP") {
+    Some(s) => parse_ipv4(s),
+    None => [10, 0, 2, 2],
+};
+
+/// TCP port the host-side proxy listens on.
+pub const PROXY_PORT: u16 = match option_env!("FOLKERING_PROXY_PORT") {
+    Some(s) => parse_u16(s),
+    None => 14711,
+};
+
+const fn parse_ipv4(s: &str) -> [u8; 4] {
+    let bytes = s.as_bytes();
+    let mut out = [0u8; 4];
+    let mut octet: usize = 0;
+    let mut acc: u32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'.' {
+            if octet < 4 {
+                out[octet] = acc as u8;
+            }
+            octet += 1;
+            acc = 0;
+        } else if b >= b'0' && b <= b'9' {
+            acc = acc * 10 + (b - b'0') as u32;
+        }
+        i += 1;
+    }
+    if octet < 4 {
+        out[octet] = acc as u8;
+    }
+    out
+}
+
+const fn parse_u16(s: &str) -> u16 {
+    let bytes = s.as_bytes();
+    let mut acc: u32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b >= b'0' && b <= b'9' {
+            acc = acc * 10 + (b - b'0') as u32;
+        }
+        i += 1;
+    }
+    acc as u16
+}


### PR DESCRIPTION
## Summary
- Replaces 17 hardcoded `[192, 168, 68, 150]` sites — the Phase 17 (#51) demo Proxmox address — with a single build-time configurable constant.
- Default flips to the SLIRP `[10, 0, 2, 2]:14711` so local QEMU runs work out of the box again. Override with `FOLKERING_PROXY_IP=192.168.68.150 cargo build ...` to keep the Proxmox demo target.

## New modules
- `kernel::net::proxy_config` — `PROXY_IP`, `PROXY_PORT`, `GEMINI_PORT` (separate because the relay's on a different port), all `option_env!`-resolved at compile time via a `const fn` IPv4 / `u16` parser. No build.rs dependency.
- `libfolk::proxy_config` — userspace mirror of the same env vars so kernel and userspace agree.

## Sites cleaned up
- `kernel/src/arch/x86_64/syscall/handlers/net.rs` — 13 paired `const PROXY_IP` / `const PROXY_PORT` declarations replaced with a module-level `use crate::net::proxy_config::{PROXY_IP, PROXY_PORT}`
- `kernel/src/net/gemini.rs` — relay const replaced; uses `GEMINI_PORT` for the port
- `userspace/draug-daemon/src/draug_async.rs` — pulls from `libfolk::proxy_config`
- `userspace/compositor/src/host_api/network.rs` — DNS-fallback path uses the configured PROXY_IP instead of the hardcoded constant

## Build-time configuration
```
# Local QEMU (default)
cargo build ...

# Proxmox demo / bridged LAN
FOLKERING_PROXY_IP=192.168.68.150 cargo build ...

# Custom ports
FOLKERING_PROXY_IP=10.10.0.50 FOLKERING_PROXY_PORT=8080 cargo build ...
```

## Test plan
- [x] `cargo check` kernel + userspace clean (default config)
- [x] No remaining literal `[192, 168, 68, 150]` outside of doc comments
- [ ] Local QEMU run: outbound TCP from Phase 17 path reaches `10.0.2.2:14711` (SLIRP forward)
- [ ] Proxmox VM 800: `FOLKERING_PROXY_IP=192.168.68.150 ./deploy.py` produces a build that reaches the host proxy on the LAN bridge — Phase 17 L1 PASSes still appear in serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)