### PR TITLE
chore(draug-daemon): drop dead command-prediction code + fix warnings

### DIFF
--- a/userspace/draug-daemon/src/agent_planner.rs
+++ b/userspace/draug-daemon/src/agent_planner.rs
@@ -537,17 +537,3 @@ fn deploy_wasm(task_id: &str) {
     }
 }
 
-fn push_dec(out: &mut String, mut v: u32) {
-    if v == 0 { out.push('0'); return; }
-    let mut buf = [0u8; 10];
-    let mut i = 0;
-    while v > 0 {
-        buf[i] = b'0' + (v % 10) as u8;
-        v /= 10;
-        i += 1;
-    }
-    while i > 0 {
-        i -= 1;
-        out.push(buf[i] as char);
-    }
-}

--- a/userspace/draug-daemon/src/draug.rs
+++ b/userspace/draug-daemon/src/draug.rs
@@ -300,9 +300,6 @@ pub enum ObservationEvent {
     BootComplete,
 }
 
-/// Maximum command history entries for prediction
-pub const MAX_CMD_HISTORY: usize = 16;
-
 // ── Friction Sensor: Frustration-Driven Evolution ──────────────────────
 
 /// Signal weights for friction tracking
@@ -406,11 +403,6 @@ pub struct DraugDaemon {
     waiting_for_llm: bool,
     analysis_count: u32,
     last_analysis_ms: u64,
-
-    /// Command history for prediction (Pillar 4)
-    cmd_history: [Option<alloc::string::String>; MAX_CMD_HISTORY],
-    cmd_head: usize,
-    cmd_count: usize,
 
     /// AutoDream state
     dream_count: u32,
@@ -576,9 +568,6 @@ impl DraugDaemon {
             waiting_for_llm: false,
             analysis_count: 0,
             last_analysis_ms: 0,
-            cmd_history: [const { None }; MAX_CMD_HISTORY],
-            cmd_head: 0,
-            cmd_count: 0,
             dream_count: 0,
             last_dream_ms: 0,
             dreaming: false,
@@ -960,60 +949,7 @@ impl DraugDaemon {
         self.knowledge_hunted = true;
     }
 
-    /// Record a user command for prediction history.
-    pub fn record_command(&mut self, cmd: &str) {
-        self.cmd_history[self.cmd_head] = Some(String::from(cmd));
-        self.cmd_head = (self.cmd_head + 1) % MAX_CMD_HISTORY;
-        if self.cmd_count < MAX_CMD_HISTORY { self.cmd_count += 1; }
-    }
 
-    /// Predict what the user might ask next based on command history.
-    /// Simple frequency analysis: returns the most common command that
-    /// followed the last command, if pattern is strong enough (>50% match).
-    pub fn predict_next(&self) -> Option<&str> {
-        if self.cmd_count < 4 { return None; } // Need enough history
-
-        // Get the last command
-        let last_idx = (self.cmd_head + MAX_CMD_HISTORY - 1) % MAX_CMD_HISTORY;
-        let last_cmd = self.cmd_history[last_idx].as_deref()?;
-
-        // Count what follows `last_cmd` in history
-        let mut best: Option<&str> = None;
-        let mut best_count = 0u32;
-        let mut total_follows = 0u32;
-
-        for i in 0..self.cmd_count.saturating_sub(1) {
-            let idx = (self.cmd_head + MAX_CMD_HISTORY - self.cmd_count + i) % MAX_CMD_HISTORY;
-            let next_idx = (idx + 1) % MAX_CMD_HISTORY;
-            if let (Some(cmd), Some(next)) = (&self.cmd_history[idx], &self.cmd_history[next_idx]) {
-                if cmd.as_str() == last_cmd {
-                    total_follows += 1;
-                    // Count this "next" command
-                    let mut count = 0u32;
-                    for j in 0..self.cmd_count.saturating_sub(1) {
-                        let ji = (self.cmd_head + MAX_CMD_HISTORY - self.cmd_count + j) % MAX_CMD_HISTORY;
-                        let jn = (ji + 1) % MAX_CMD_HISTORY;
-                        if let (Some(jc), Some(jnc)) = (&self.cmd_history[ji], &self.cmd_history[jn]) {
-                            if jc.as_str() == last_cmd && jnc.as_str() == next.as_str() {
-                                count += 1;
-                            }
-                        }
-                    }
-                    if count > best_count {
-                        best_count = count;
-                        best = Some(next.as_str());
-                    }
-                }
-            }
-        }
-
-        // Only predict if >50% confidence
-        if total_follows >= 2 && best_count * 2 > total_follows {
-            best
-        } else {
-            None
-        }
-    }
 
     /// Record user input activity (resets idle timer)
     pub fn on_user_input(&mut self, now_ms: u64) {
@@ -1034,7 +970,7 @@ impl DraugDaemon {
         // Decay friction scores over time
         self.friction.decay(now_ms);
 
-        let (total_mb, used_mb, mem_pct) = libfolk::sys::memory_stats();
+        let (_total_mb, _used_mb, mem_pct) = libfolk::sys::memory_stats();
         let uptime_s = (now_ms / 1000) as u32;
 
         // Determine event type

--- a/userspace/draug-daemon/src/draug_async.rs
+++ b/userspace/draug-daemon/src/draug_async.rs
@@ -870,7 +870,7 @@ fn process_patch_result(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -
             }
         } else {
             // Skill tree PASS
-            let iter = draug.advance_refactor(now_ms);
+            draug.advance_refactor(now_ms);
             draug.record_refactor_pass();
             draug.advance_task_level(draug.async_task_idx);
             draug.reset_skips();

--- a/userspace/draug-daemon/src/knowledge_hunt.rs
+++ b/userspace/draug-daemon/src/knowledge_hunt.rs
@@ -28,7 +28,6 @@
 //! only runs while the user is idle anyway.
 
 use alloc::string::String;
-use alloc::vec::Vec;
 use libfolk::sys::io::write_str;
 
 use crate::draug::{
@@ -262,7 +261,6 @@ pub const REFACTOR_TASKS: &[(&str, &str)] = &[
 ///   L3: Optimize prior code with MemPalace context (cargo check)
 pub fn run_refactor_step(draug: &mut crate::draug::DraugDaemon, now_ms: u64) {
     use libfolk::sys::{fbp_patch, llm_generate};
-    use crate::agent_planner;
 
     // NOTE: advance_refactor() is called AFTER proxy check to avoid
     // counting skips toward REFACTOR_MAX_ITER. Without this, ~4-16

--- a/userspace/draug-daemon/src/refactor_loop.rs
+++ b/userspace/draug-daemon/src/refactor_loop.rs
@@ -31,7 +31,7 @@
 //! Both are deferred to the session that does the boot-verify, so
 //! we don't ship placebo-integration today.
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
 
 use crate::agent_planner::{codegraph_for_model, fetch_callers_summary};
 use crate::task_store::{RefactorTask, TaskStatus};


### PR DESCRIPTION
## Summary
- Drop the `cmd_history` ring buffer + `record_command` writer + `predict_next` reader (\"Pillar 4\" command-prediction feature) — never wired to live code. The only writer was `ctx.draug.record_command(prompt)` in compositor's `legacy_dispatch`, removed in #80. The only reader is mentioned in an archived doc.
- Drop `agent_planner::push_dec` (private fn, never called).
- Fix five lingering compiler warnings (unused imports + unused vars). Daemon now builds with zero warnings.

## What was dead
| Symbol | Location | Why |
|--------|----------|-----|
| `MAX_CMD_HISTORY` | draug.rs | const for the ring buffer below |
| `cmd_history` / `cmd_head` / `cmd_count` fields | draug.rs | nothing reads them after #80 |
| `DraugDaemon::record_command()` | draug.rs | only caller removed in #80 |
| `DraugDaemon::predict_next()` | draug.rs | only referenced from `userspace/docs/archive/TASK_27_COMPLETE.md` |
| `agent_planner::push_dec()` | agent_planner.rs | private fn, no callers |

Net 80 LOC removed.

## Warnings fixed
- `knowledge_hunt.rs:31` — drop `alloc::vec::Vec` import (no `Vec` left after earlier refactors)
- `knowledge_hunt.rs:264` — drop `use crate::agent_planner` from `run_refactor_step` (sibling fn at 536 still has its own)
- `refactor_loop.rs:34` — drop `ToString` from import group (only `String` is used)
- `draug.rs::tick` — `_total_mb` / `_used_mb` underscore-prefix (kept readable as future-telemetry hint, only `mem_pct` is consulted)
- `draug_async.rs:873` — drop unused `let iter =` binding around `advance_refactor` call

## Test plan
- [x] `cargo check -p draug-daemon` — zero warnings
- [x] `cargo check` workspace — same 80 baseline warnings (none new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)