### PR TITLE
chore(tooling): host-side Proxmox config via env vars

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -598,9 +598,14 @@ TOOLS = [
 ]
 
 # ── Tool implementations ───────────────────────────────────────────────────────
+#
+# Override via FOLKERING_PROXMOX_HOST / FOLKERING_SERIAL_LOG. Defaults
+# match the historical demo target (Proxmox node at .68.150). Set
+# `FOLKERING_PROXMOX_HOST=10.0.0.50` to point the MCP tools at a
+# different Proxmox host without editing the file.
 
-PROXMOX_HOST = "192.168.68.150"
-SERIAL_LOG_REMOTE = "/tmp/folkering-serial.log"
+PROXMOX_HOST = os.environ.get("FOLKERING_PROXMOX_HOST", "192.168.68.150")
+SERIAL_LOG_REMOTE = os.environ.get("FOLKERING_SERIAL_LOG", "/tmp/folkering-serial.log")
 
 def _ssh_cmd(cmd: str, timeout: int = 10) -> str:
     """Run a command on Proxmox via SSH."""

--- a/tests/proxmox_e2e.py
+++ b/tests/proxmox_e2e.py
@@ -7,15 +7,19 @@ Tests: boot, DHCP, DNS, WASM gen, firewall, AutoDream, COM3 injection, stress.
 Usage: python tests/proxmox_e2e.py
 """
 
+import os
 import socket
 import time
 import sys
 import subprocess
 
-PROXMOX = "192.168.68.150"
-VM_ID = 900
-COM3_PORT = 4568
-SERIAL_LOG = "/tmp/folkering-serial.log"
+# Override via FOLKERING_PROXMOX_HOST / FOLKERING_VM_ID. Defaults match
+# the historical demo target so `python tests/proxmox_e2e.py` still
+# works on the original setup.
+PROXMOX = os.environ.get("FOLKERING_PROXMOX_HOST", "192.168.68.150")
+VM_ID = int(os.environ.get("FOLKERING_VM_ID", "900"))
+COM3_PORT = int(os.environ.get("FOLKERING_COM3_PORT", "4568"))
+SERIAL_LOG = os.environ.get("FOLKERING_SERIAL_LOG", "/tmp/folkering-serial.log")
 
 if sys.platform == "win32":
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")

--- a/tools/deploy_to_proxmox.py
+++ b/tools/deploy_to_proxmox.py
@@ -13,7 +13,8 @@ Usage:
 
 Prerequisites:
   - SSH key access to Proxmox (pi_key or password)
-  - Proxmox host: 192.168.68.150
+  - Proxmox host: configured via FOLKERING_PROXMOX_HOST env var
+    (default: 192.168.68.150 — the historical demo node)
   - VM ID 900 reserved for Folkering OS
 """
 
@@ -24,11 +25,17 @@ import time
 import argparse
 
 # ── Configuration ────────────────────────────────────────────────────────
+#
+# Defaults match the historical demo target (Proxmox node at .68.150,
+# VM 900). Override with env vars at invocation time, e.g.:
+#   FOLKERING_PROXMOX_HOST=10.0.0.50 python tools/deploy_to_proxmox.py deploy
 
-PROXMOX_HOST = "192.168.68.150"
-PROXMOX_USER = "root"  # Proxmox root access for qm commands
-PROXMOX_SSH_KEY = os.path.expanduser("~/.ssh/id_rsa")  # Try default key
-VM_ID = 900
+PROXMOX_HOST = os.environ.get("FOLKERING_PROXMOX_HOST", "192.168.68.150")
+PROXMOX_USER = os.environ.get("FOLKERING_PROXMOX_USER", "root")
+PROXMOX_SSH_KEY = os.path.expanduser(
+    os.environ.get("FOLKERING_PROXMOX_SSH_KEY", "~/.ssh/id_rsa")
+)
+VM_ID = int(os.environ.get("FOLKERING_VM_ID", "900"))
 VM_NAME = "folkering-os"
 VM_MEMORY = 512  # MB
 VM_CORES = 4

--- a/tools/nightly.sh
+++ b/tools/nightly.sh
@@ -7,8 +7,13 @@
 # Cron:  0 3 * * * cd /c/Users/merkn/folkering/folkering-os && bash tools/nightly.sh >> logs/nightly.log 2>&1
 
 set -e
-PROXMOX="root@192.168.68.150"
-VMID=900
+# Override via env: FOLKERING_PROXMOX_HOST / _USER / _VM_ID. Defaults
+# are the historical demo target so a bare `bash tools/nightly.sh`
+# still works on the original setup.
+PROXMOX_USER="${FOLKERING_PROXMOX_USER:-root}"
+PROXMOX_HOST="${FOLKERING_PROXMOX_HOST:-192.168.68.150}"
+PROXMOX="${PROXMOX_USER}@${PROXMOX_HOST}"
+VMID="${FOLKERING_VM_ID:-900}"
 PROJECT="/c/Users/merkn/folkering/folkering-os"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 


### PR DESCRIPTION
## Summary
- Companion to #86 (kernel + libfolk `PROXY_IP` cleanup). The four Python / bash tools that drive the Proxmox demo also hardcoded `192.168.68.150` / VM 900 / `/tmp/folkering-serial.log`. This PR makes them overridable via env vars so the same scripts work against a different Proxmox node without source patches.

## New env vars (all with sensible defaults)
| Env var | Default | Used by |
|---------|---------|---------|
| `FOLKERING_PROXMOX_HOST` | `192.168.68.150` | all four |
| `FOLKERING_PROXMOX_USER` | `root` | `deploy_to_proxmox.py`, `nightly.sh` |
| `FOLKERING_PROXMOX_SSH_KEY` | `~/.ssh/id_rsa` | `deploy_to_proxmox.py` |
| `FOLKERING_VM_ID` | `900` | `deploy_to_proxmox.py`, `proxmox_e2e.py`, `nightly.sh` |
| `FOLKERING_SERIAL_LOG` | `/tmp/folkering-serial.log` | `mcp/server.py`, `proxmox_e2e.py` |
| `FOLKERING_COM3_PORT` | `4568` | `proxmox_e2e.py` |

Defaults match today's behaviour, so a bare `bash tools/nightly.sh` or `python tests/proxmox_e2e.py` still hits the original demo node. To run the same flow against a different node:

```
FOLKERING_PROXMOX_HOST=10.0.0.50 bash tools/nightly.sh
```

## Files touched
- `mcp/server.py` — `PROXMOX_HOST` + `SERIAL_LOG_REMOTE`
- `tests/proxmox_e2e.py` — `PROXMOX` + `VM_ID` + `COM3_PORT` + `SERIAL_LOG`
- `tools/deploy_to_proxmox.py` — `PROXMOX_HOST` + `PROXMOX_USER` + `PROXMOX_SSH_KEY` + `VM_ID`
- `tools/nightly.sh` — composes `PROXMOX="${USER}@${HOST}"` from parts

## Left alone
- Sandbox copies under `tools/draug-eval-runner/sandbox/...` — those are deliberate point-in-time snapshots used by the eval runner and shouldn't drift from their captured baseline.

## Test plan
- [x] All three Python files parse cleanly with `ast.parse`
- [x] `bash -n tools/nightly.sh` clean
- [ ] `bash tools/nightly.sh` against the historical node still works (default path)
- [ ] `FOLKERING_PROXMOX_HOST=<alt> bash tools/nightly.sh` reaches the alt node

🤖 Generated with [Claude Code](https://claude.com/claude-code)