### PR TITLE
fix(boot): COMPOSITOR_TASK_ID = 5 + attach_status retry

### DIFF
--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -632,17 +632,35 @@ fn main() -> ! {
     // Phase A.5 step 6: compositor's local `DraugDaemon` is gone.
     // All agent state lives in the daemon process; reads come over
     // the status shmem. Phase A.6 (#84) pinned daemon to task 4 so
-    // it boots before compositor — `attach_status` should succeed
-    // on the first try in normal flow. The `None` branch below is
-    // a defensive fallback for the IPC path being broken altogether
-    // (e.g. daemon ELF missing from the ramdisk).
+    // it boots before compositor — but "spawn order" doesn't
+    // guarantee "init order", and on a cold boot the scheduler can
+    // hand compositor a time slice before daemon has finished
+    // `boot_status_shmem`. Use the retry variant so the IPC path
+    // gets up to ~50 yields to settle before we give up.
     let draug_status: Option<&'static libfolk::sys::draug::DraugStatus> =
-        libfolk::sys::draug::attach_status().ok();
-    if draug_status.is_some() {
-        libfolk::sys::io::write_str("[Draug] status shmem attached — HUD reads from daemon\n");
-    } else {
-        libfolk::sys::io::write_str("[Draug] WARNING: status shmem unavailable — autodream gate stays closed\n");
-    }
+        match libfolk::sys::draug::attach_status_with_retry(50) {
+            Ok(s) => {
+                libfolk::sys::io::write_str("[Draug] status shmem attached — HUD reads from daemon\n");
+                Some(s)
+            }
+            Err(libfolk::sys::draug::AttachError::Daemon(_)) => {
+                libfolk::sys::io::write_str("[Draug] WARNING: daemon IPC unreachable after retries\n");
+                None
+            }
+            Err(libfolk::sys::draug::AttachError::Map(_)) => {
+                libfolk::sys::io::write_str("[Draug] WARNING: shmem_map failed\n");
+                None
+            }
+            Err(libfolk::sys::draug::AttachError::LayoutMismatch { expected, found }) => {
+                libfolk::sys::io::write_str("[Draug] WARNING: layout mismatch (expected v");
+                let mut nb = [0u8; 16];
+                libfolk::sys::io::write_str(crate::util::format_usize(expected as usize, &mut nb));
+                libfolk::sys::io::write_str(", found v");
+                libfolk::sys::io::write_str(crate::util::format_usize(found as usize, &mut nb));
+                libfolk::sys::io::write_str(")\n");
+                None
+            }
+        };
 
     // `restore_state` runs in the daemon (`draug-daemon::main`)
     // against the same Synapse file. The boot-time print of restored

--- a/userspace/inference-server/src/consts.rs
+++ b/userspace/inference-server/src/consts.rs
@@ -4,7 +4,12 @@ use libfolk::sys::block::SECTOR_SIZE;
 
 // ── IPC opcodes (must match libfolk::sys::inference) ───────────────────
 
-pub const INFERENCE_TASK_ID: u32 = 6;
+// Phase A.6 (#84) shifted task slots: draug-daemon now occupies 4
+// (explicit kernel spawn), so the generic-loop entries start at 5.
+// In Phase 5 Hybrid AI mode the kernel skips inference entirely, so
+// this const is mostly a fallback. If the skip is removed, inference
+// would land at 7 (after compositor=5, intent-service=6).
+pub const INFERENCE_TASK_ID: u32 = 7;
 
 pub const INFER_OP_PING: u64 = 0;
 pub const INFER_OP_GENERATE: u64 = 1;

--- a/userspace/libfolk/src/sys/compositor.rs
+++ b/userspace/libfolk/src/sys/compositor.rs
@@ -25,12 +25,19 @@ use crate::syscall::{syscall3, SYS_IPC_SEND};
 
 /// Compositor service task ID (spawned at boot as Task 4)
 ///
-/// Task layout:
+/// Task layout (post Phase A.6, PR #84):
 /// - Task 1: Idle/kernel
 /// - Task 2: Synapse (Data Kernel)
 /// - Task 3: Shell
-/// - Task 4: Compositor (Semantic Mirror)
-pub const COMPOSITOR_TASK_ID: u32 = 4;
+/// - Task 4: draug-daemon (explicit kernel spawn from ramdisk)
+/// - Task 5: Compositor (first entry in the generic ramdisk loop)
+///
+/// Pre-A.6 compositor was task 4. Without bumping this const after
+/// #84, daemon's `shmem_grant(handle, COMPOSITOR_TASK_ID)` granted
+/// to itself, and compositor's later `shmem_map` returned `Unknown`.
+/// The retry path in `attach_status_with_retry` couldn't help — the
+/// grant target was wrong, not just slow.
+pub const COMPOSITOR_TASK_ID: u32 = 5;
 
 // ============================================================================
 // Operation Codes (must match compositor/src/main.rs)

--- a/userspace/libfolk/src/sys/draug.rs
+++ b/userspace/libfolk/src/sys/draug.rs
@@ -660,3 +660,38 @@ pub fn attach_status() -> Result<&'static DraugStatus, AttachError> {
     }
     Ok(status)
 }
+
+/// `attach_status` with retry. Phase A.6 (#84) made the kernel spawn
+/// draug-daemon before compositor, but "spawn order" doesn't
+/// guarantee "init order" — when the scheduler hands compositor a
+/// time slice before daemon has finished `boot_status_shmem`, the
+/// `GET_STATUS_HANDLE` IPC returns ERR (or `Unreachable` if the
+/// daemon's IPC loop hasn't started yet) and the gate stays closed
+/// for the rest of the session.
+///
+/// This wrapper retries with `yield_cpu()` between attempts, giving
+/// the daemon a chance to catch up. `max_attempts = 50` × 1 ms-ish
+/// scheduler ticks puts a ~50 ms cap on boot delay, which is well
+/// below human perception and well above any plausible boot-race
+/// window.
+pub fn attach_status_with_retry(
+    max_attempts: u32,
+) -> Result<&'static DraugStatus, AttachError> {
+    let mut last_err = AttachError::Daemon(DraugError::Unreachable);
+    for _ in 0..max_attempts {
+        match attach_status() {
+            Ok(status) => return Ok(status),
+            Err(e @ AttachError::LayoutMismatch { .. }) => return Err(e),
+            // For Daemon (IPC unreachable / status err) and Map
+            // errors: retry. The first happens during the boot race;
+            // the second can happen if the handle came back stale —
+            // either way, yielding lets the daemon drive its boot
+            // sequence forward.
+            Err(e) => {
+                last_err = e;
+                crate::sys::yield_cpu();
+            }
+        }
+    }
+    Err(last_err)
+}

--- a/userspace/libfolk/src/sys/inference.rs
+++ b/userspace/libfolk/src/sys/inference.rs
@@ -18,8 +18,14 @@ pub fn set_inference_task_id(new_id: u32) {
     INFERENCE_TASK.store(new_id, core::sync::atomic::Ordering::Relaxed);
 }
 
-/// Default task ID (backward compatibility for shmem_grant etc.)
-pub const INFERENCE_TASK_ID: u32 = 6;
+/// Default task ID — used by `shmem_grant` etc. before the runtime
+/// setter `set_inference_task_id` fires. Inference is skipped at
+/// boot in Phase 5 Hybrid AI mode (kernel `lib.rs` `if is_inference
+/// { continue }`), so the const is mostly a fallback for code paths
+/// that respawn the server dynamically. Phase A.6 (#84) shifted task
+/// 6 to intent-service; if inference were re-enabled today it'd land
+/// at task 7 (after draug-streamer which currently takes that slot).
+pub const INFERENCE_TASK_ID: u32 = 7;
 
 // ============================================================================
 // IPC Opcodes

--- a/userspace/libfolk/src/sys/intent.rs
+++ b/userspace/libfolk/src/sys/intent.rs
@@ -25,9 +25,17 @@ use crate::syscall::{syscall3, SYS_IPC_SEND};
 // Well-Known Task ID
 // ============================================================================
 
-/// Intent Service task ID (spawned after compositor)
-/// Task layout: 1=Idle, 2=Synapse, 3=Shell, 4=Compositor, 5=IntentService
-pub const INTENT_TASK_ID: u32 = 5;
+/// Intent Service task ID. Phase A.6 (#84) inserted draug-daemon at
+/// task 4, shifting everything in the generic ramdisk loop by one.
+/// Task layout (post-A.6):
+///   1 = Idle / kernel
+///   2 = Synapse
+///   3 = Shell
+///   4 = draug-daemon  (explicit kernel spawn)
+///   5 = Compositor    (first generic-loop entry)
+///   6 = Intent Service (next generic-loop entry)
+///   7 = draug-streamer
+pub const INTENT_TASK_ID: u32 = 6;
 
 // ============================================================================
 // Operation Codes


### PR DESCRIPTION
## Summary
Three regressions from Phase A.6 (#84) surfaced when I booted the OS in QEMU/WHPX to verify the day's work end-to-end. All three are silent at compile time but break runtime IPC routing. Fixed in this PR.

Tracking: closes #91, validates fix for #92.

### 1. \`COMPOSITOR_TASK_ID\` was stuck at 4
Phase A.6 (#84) inserted draug-daemon at task 4 via explicit kernel spawn. Compositor moved to **task 5** (first generic-loop entry), but the const stayed at 4.

Symptom: daemon's \`shmem_grant(handle, COMPOSITOR_TASK_ID)\` was granting access to **itself**. Compositor's later \`shmem_map\` returned \`Unknown\`. Autodream gate stayed closed for the entire session.

Fix: \`COMPOSITOR_TASK_ID = 5\`.

### 2. \`INTENT_TASK_ID\` collided with new compositor slot
Same shift: \`INTENT_TASK_ID\` was 5 but intent-service is now task 6. Six call sites in \`legacy_dispatch.rs\` + \`intent.rs\` were sending IPC to compositor instead of intent-service.

Fix: \`INTENT_TASK_ID = 6\`.

### 3. \`INFERENCE_TASK_ID\` stale (less critical)
\`INFERENCE_TASK_ID = 6\` collided with intent-service. Inference is skipped at boot (Phase 5 hybrid AI mode), so this const is mostly a fallback for the runtime \`set_inference_task_id\` setter, but still wrong.

Fix: bumped to 7 in both \`libfolk/sys/inference.rs\` and \`inference-server/src/consts.rs\`.

### Bonus: \`attach_status_with_retry\`
Even with the right task ID, compositor can be scheduled before daemon finishes \`boot_status_shmem\`. The very first IPC then returns \`DRAUG_STATUS_ERR\`. Pre-#85 compositor had a local \`DraugDaemon\` fallback that absorbed this; post-#85 the gate just stayed closed.

New \`attach_status_with_retry(50)\` helper that yields up to N times before giving up. Compositor now uses it. Replaces the silent first-try-only path.

Compositor's WARNING also distinguishes the three failure modes (\`Daemon\` / \`Map\` / \`LayoutMismatch\`) instead of one generic message, so the next race-style bug surfaces concretely.

## Live verification (QEMU/WHPX, post-fix)

```
[BOOT] Task 1 (idle) spawned, id=1
[BOOT] Synapse spawned, id=2
[BOOT] Shell spawned, id=3
[BOOT] draug-daemon spawned, id=4
[BOOT] Spawned "compositor", id=5
[BOOT] Spawned "intent-service", id=6
[BOOT] Spawned "draug-streamer", id=7
[DRAUG-DAEMON] starting (PID: 4)
[DRAUG-DAEMON] status shmem ready (handle=1, size=256)
[INTENT] Intent Service starting (PID: 6)
[INTENT] Shell (task 3) auto-registered as default handler
[Draug] status shmem attached — HUD reads from daemon   ← was the WARNING line before
[Draug] Refactor queue: 5 tasks persisted for daemon
```

Plus a screenshot showing the GUI rendered correctly: status bar with date/clock, FOLKERING OS title, Boot Test window, omnibar.

## Test plan
- [x] Local QEMU/WHPX boot — daemon attaches, gate opens, intent-service handlers register correctly
- [x] All four CI checks SUCCESS
- [x] GUI screenshot via QMP confirms compositor rendering
- [ ] Proxmox VM 800 — same trace expected on cold boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)