### PR TITLE
feat(diag): periodic [HEAP] line + omnibar 'heap' command for #54

### DIFF
--- a/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
+++ b/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
@@ -492,6 +492,53 @@ pub(super) fn dispatch_legacy_command(
                 let mut buf = [0u8; 32];
                 let time_str = format_uptime(ms, &mut buf);
                 win.push_line(time_str);
+            } else if cmd_str == "heap" {
+                // Kernel-heap X-ray (PR #74). Syscall 0x85 fills a
+                // KernelHeapStats struct with both inner-allocator and
+                // requested-bytes views, plus high-water counter.
+                // Used to investigate Issue #54 (memory growth under
+                // flood). Mirrors `commands::basic::cmd_heap` in shell
+                // — duplicated here so COM3 god-mode injection from
+                // outside the VM can drive it without going through a
+                // shell IPC hop.
+                if let Some(stats) = libfolk::sys::heap_walk() {
+                    let mut nb = [0u8; 16];
+                    let total_kib = stats.total_bytes / 1024;
+                    let used_kib = stats.used_bytes / 1024;
+                    let free_kib = stats.free_bytes / 1024;
+                    let req_kib = stats.requested_bytes / 1024;
+                    let hw_kib = stats.high_water_bytes / 1024;
+                    let overhead_kib = stats.overhead_bytes() / 1024;
+                    let pmille = stats.used_per_mille();
+                    win.push_line(&alloc::format!(
+                        "Heap v{} | total {}K used {}K ({}.{}%) free {}K",
+                        stats.layout_version,
+                        total_kib, used_kib, pmille / 10, pmille % 10, free_kib,
+                    ));
+                    win.push_line(&alloc::format!(
+                        "  requested {}K | high-water {}K | overhead {}K",
+                        req_kib, hw_kib, overhead_kib,
+                    ));
+                    win.push_line(&alloc::format!(
+                        "  alloc={} dealloc={} live={}",
+                        stats.alloc_count, stats.dealloc_count, stats.live_allocs(),
+                    ));
+                    // Also write to serial so external scrapers can
+                    // grep [HEAP] tags from socat captures.
+                    libfolk::sys::io::write_str("[HEAP] ");
+                    libfolk::sys::io::write_str(crate::util::format_usize(used_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K used / ");
+                    libfolk::sys::io::write_str(crate::util::format_usize(total_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K total / hw=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(hw_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K req=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(req_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K live=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(stats.live_allocs() as usize, &mut nb));
+                    libfolk::sys::io::write_str("\n");
+                } else {
+                    win.push_line("[heap] syscall failed or layout mismatch");
+                }
             } else if cmd_str == "help" {
                 win.push_line("Commands: ls, cat, ps, uptime, mem");
                 win.push_line("lspci, drivers, generate driver [v:d]");

--- a/userspace/draug-daemon/src/main.rs
+++ b/userspace/draug-daemon/src/main.rs
@@ -179,6 +179,11 @@ fn main() -> ! {
 /// of kernel uptime. Surfaces the load-bearing decision flags so a
 /// reader can tell *why* the loop isn't producing work — instead of
 /// staring at silence.
+///
+/// Also emits a `[HEAP]` companion line per Issue #54 — kernel-heap
+/// stats over time without requiring a shell command injection from
+/// outside the VM. Lets us watch high-water vs requested vs live
+/// allocations across an idle session or a stress flood.
 fn log_alive_if_due(draug: &DraugDaemon, now_ms: u64) {
     let last = unsafe { LAST_ALIVE_LOG_MS };
     if now_ms.saturating_sub(last) < ALIVE_LOG_INTERVAL_MS {
@@ -197,6 +202,18 @@ fn log_alive_if_due(draug: &DraugDaemon, now_ms: u64) {
         draug.refactor_iter,
         draug.complex_task_idx,
     );
+    if let Some(stats) = libfolk::sys::heap_walk() {
+        println!(
+            "[HEAP] used={}K total={}K hw={}K req={}K live={} alloc={} dealloc={}",
+            stats.used_bytes / 1024,
+            stats.total_bytes / 1024,
+            stats.high_water_bytes / 1024,
+            stats.requested_bytes / 1024,
+            stats.live_allocs(),
+            stats.alloc_count,
+            stats.dealloc_count,
+        );
+    }
 }
 
 /// Allocate, map, initialise, and grant compositor read access to


### PR DESCRIPTION
## Summary

Two lightweight ways to drive `heap_walk()` for ongoing observation, tested live against #54 to gather an idle baseline.

### 1. Periodic `[HEAP]` line (preferred)
`draug-daemon`'s alive log (PR #95) already throttles to one line per 30 s of kernel uptime. Tag a heap snapshot onto the same throttle:

```
[DRAUG-DAEMON] alive uptime=60s ticks=6367 ...
[HEAP] used=140K total=32768K hw=200K req=140K live=52 alloc=793 dealloc=741
```

Zero command-injection plumbing needed — just `socat` the serial socket and grep `[HEAP]`. Works the same locally and on Proxmox.

### 2. Omnibar `heap` command (on-demand)
Added to compositor's legacy_dispatch so COM3 god-mode can `echo heap` to port 4568 and pull stats out of band. Mirrors the shell's existing `cmd_heap` formatting plus a `[HEAP] ...` serial line for scrapers.

## Live result (#54 idle baseline)

Built with `FOLKERING_PROXY_IP=192.168.68.150`, deployed to Proxmox VM 800, captured 6 samples over 180 s idle:

| t | used | hw | live | alloc | dealloc |
|---|------|----|------|-------|---------|
| 30s | 140 K | 200 K | 52 | 554 | 502 |
| 60s | 140 K | 200 K | 52 | 793 | 741 |
| 90s | 128 K | 200 K | 50 | 1020 | 970 |
| 120s | 128 K | 200 K | 50 | 1284 | 1234 |
| 150s | 128 K | 200 K | 50 | 1589 | 1539 |
| 180s | 128 K | 200 K | 50 | 1899 | 1849 |

**Findings:** Heap is rock-solid stable at idle. alloc/dealloc grow in lockstep (~10/s churn), live count flat at 50-52. **Hypothesis 2 of #54 is falsified** — the buffer-reclaim path in `tick_idle` is firing correctly. The 114→725 MB growth is a flood-specific issue, most likely smoltcp socket buffer accumulation under TCP retransmits.

Next session: synthesize a flood from the Proxmox host and capture the `[HEAP]` time-series during + after, to bisect socket-buffer-leak vs transient-spike.

## Test plan
- [x] `cargo check` workspace clean
- [x] Live boot on Proxmox VM 800 — `[HEAP]` lines emit every 30 s, values match expected idle ranges
- [ ] Compositor `heap` omnibar command — verifiable when serial input injection is wired (separate setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
