### PR TITLE
fix(virtio-net): free TX pages on completion (closes #54)

### DIFF
--- a/kernel/src/drivers/virtio_net/tx.rs
+++ b/kernel/src/drivers/virtio_net/tx.rs
@@ -13,9 +13,19 @@ pub(super) fn transmit_packet_inner(dev: &mut VirtIONet, frame: &[u8]) -> Result
         return Err(NetError::DeviceFailed);
     }
 
-    // Drain any completed TX descriptors first
+    // Drain any completed TX descriptors first.
+    // Each descriptor has a 4 KB physical page bound to its `addr`
+    // field — `free_desc` only releases the descriptor index back
+    // to the queue's free list. We must free the page too, otherwise
+    // every outbound packet leaks 4 KB. Under sustained TCP/UDP
+    // flood at 200 pps, the leak compounds to ~70 MB/min — see #54
+    // for the live-Proxmox repro that surfaced this.
     while let Some((done_idx, _)) = dev.tx_queue.pop_used() {
+        let desc_addr = unsafe { (*dev.tx_queue.desc(done_idx)).addr } as usize;
         dev.tx_queue.free_desc(done_idx);
+        if desc_addr != 0 {
+            crate::memory::physical::free_page(desc_addr);
+        }
     }
 
     // Allocate a descriptor

--- a/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
+++ b/userspace/compositor/src/command_dispatch/legacy_dispatch.rs
@@ -492,6 +492,53 @@ pub(super) fn dispatch_legacy_command(
                 let mut buf = [0u8; 32];
                 let time_str = format_uptime(ms, &mut buf);
                 win.push_line(time_str);
+            } else if cmd_str == "heap" {
+                // Kernel-heap X-ray (PR #74). Syscall 0x85 fills a
+                // KernelHeapStats struct with both inner-allocator and
+                // requested-bytes views, plus high-water counter.
+                // Used to investigate Issue #54 (memory growth under
+                // flood). Mirrors `commands::basic::cmd_heap` in shell
+                // — duplicated here so COM3 god-mode injection from
+                // outside the VM can drive it without going through a
+                // shell IPC hop.
+                if let Some(stats) = libfolk::sys::heap_walk() {
+                    let mut nb = [0u8; 16];
+                    let total_kib = stats.total_bytes / 1024;
+                    let used_kib = stats.used_bytes / 1024;
+                    let free_kib = stats.free_bytes / 1024;
+                    let req_kib = stats.requested_bytes / 1024;
+                    let hw_kib = stats.high_water_bytes / 1024;
+                    let overhead_kib = stats.overhead_bytes() / 1024;
+                    let pmille = stats.used_per_mille();
+                    win.push_line(&alloc::format!(
+                        "Heap v{} | total {}K used {}K ({}.{}%) free {}K",
+                        stats.layout_version,
+                        total_kib, used_kib, pmille / 10, pmille % 10, free_kib,
+                    ));
+                    win.push_line(&alloc::format!(
+                        "  requested {}K | high-water {}K | overhead {}K",
+                        req_kib, hw_kib, overhead_kib,
+                    ));
+                    win.push_line(&alloc::format!(
+                        "  alloc={} dealloc={} live={}",
+                        stats.alloc_count, stats.dealloc_count, stats.live_allocs(),
+                    ));
+                    // Also write to serial so external scrapers can
+                    // grep [HEAP] tags from socat captures.
+                    libfolk::sys::io::write_str("[HEAP] ");
+                    libfolk::sys::io::write_str(crate::util::format_usize(used_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K used / ");
+                    libfolk::sys::io::write_str(crate::util::format_usize(total_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K total / hw=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(hw_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K req=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(req_kib as usize, &mut nb));
+                    libfolk::sys::io::write_str("K live=");
+                    libfolk::sys::io::write_str(crate::util::format_usize(stats.live_allocs() as usize, &mut nb));
+                    libfolk::sys::io::write_str("\n");
+                } else {
+                    win.push_line("[heap] syscall failed or layout mismatch");
+                }
             } else if cmd_str == "help" {
                 win.push_line("Commands: ls, cat, ps, uptime, mem");
                 win.push_line("lspci, drivers, generate driver [v:d]");

--- a/userspace/draug-daemon/src/main.rs
+++ b/userspace/draug-daemon/src/main.rs
@@ -179,6 +179,11 @@ fn main() -> ! {
 /// of kernel uptime. Surfaces the load-bearing decision flags so a
 /// reader can tell *why* the loop isn't producing work — instead of
 /// staring at silence.
+///
+/// Also emits a `[HEAP]` companion line per Issue #54 — kernel-heap
+/// stats over time without requiring a shell command injection from
+/// outside the VM. Lets us watch high-water vs requested vs live
+/// allocations across an idle session or a stress flood.
 fn log_alive_if_due(draug: &DraugDaemon, now_ms: u64) {
     let last = unsafe { LAST_ALIVE_LOG_MS };
     if now_ms.saturating_sub(last) < ALIVE_LOG_INTERVAL_MS {
@@ -197,6 +202,18 @@ fn log_alive_if_due(draug: &DraugDaemon, now_ms: u64) {
         draug.refactor_iter,
         draug.complex_task_idx,
     );
+    if let Some(stats) = libfolk::sys::heap_walk() {
+        println!(
+            "[HEAP] used={}K total={}K hw={}K req={}K live={} alloc={} dealloc={}",
+            stats.used_bytes / 1024,
+            stats.total_bytes / 1024,
+            stats.high_water_bytes / 1024,
+            stats.requested_bytes / 1024,
+            stats.live_allocs(),
+            stats.alloc_count,
+            stats.dealloc_count,
+        );
+    }
 }
 
 /// Allocate, map, initialise, and grant compositor read access to


### PR DESCRIPTION
## Summary
Closes #54. Every outbound packet was leaking 4 KB.

`tx.rs::transmit_packet_inner` allocates a fresh physical page per packet (`physical::alloc_page()`), submits to the TX queue, and on completion calls `free_desc(done_idx)`. That only returns the descriptor index to the queue's free list — **the page bound to the descriptor's `addr` field was never freed back to PMM**.

Result: every outbound TCP RST, ICMP unreachable, ARP reply leaks 4 KB. The 114 → 725 MB growth under sustained inbound flood is exactly this — every inbound SYN to a closed port forces an outbound RST, every UDP probe forces an ICMP unreachable, all of which allocate-and-leak a page.

## Live verification on Proxmox VM 800

Same workload (90 s of `nping --tcp -p 80,443,8080 --flags syn --rate 100 --delay 10ms` + matching UDP), captured `[PMM] used=NMB / total` from daemon's periodic alive log (PR #96):

| sample # | alloc count | PMM **pre-fix** | PMM **post-fix** |
|----------|-------------|-----------------|-------------------|
| 1 (baseline)  | 756    | 82 MB  | **81 MB** |
| 2 (baseline)  | 1.3 K  | 82 MB  | **81 MB** |
| 3 (during)    | 8.5 K  | 95 MB  | **81 MB** |
| 4 (during)    | 18 K   | 114 MB | **81 MB** |
| 5 (during)    | 28 K   | 132 MB | **81 MB** |
| 6 (during)    | 37 K   | 150 MB | **81 MB** |
| 7 (post)      | 38 K   | 154 MB | **81 MB** |

Pre-fix delta: **+72 MB** (and not recovering). Post-fix delta: **0 MB** through 38 270 packets.

## The fix

```rust
while let Some((done_idx, _)) = dev.tx_queue.pop_used() {
    let desc_addr = unsafe { (*dev.tx_queue.desc(done_idx)).addr } as usize;
    dev.tx_queue.free_desc(done_idx);
    if desc_addr != 0 {
        crate::memory::physical::free_page(desc_addr);
    }
}
```

11 LOC. Read the descriptor's `addr` before `free_desc` (descriptor fields are still valid until reused), then `physical::free_page`. The `addr != 0` guard avoids a double-free on reset.

## Test plan
- [x] `cargo build --release` clean
- [x] Baseline boot — heap counters live=52 stable, no growth
- [x] 90 s flood — alloc count goes 1.3 K → 38 K, **PMM stays at 81 MB**
- [x] Post-flood — PMM stays at 81 MB (vs pre-fix 154 MB plateau)
- [ ] Run the original #53 stress test for sanity — expect baseline → baseline once it lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
