### PR TITLE
feat(diag): periodic [PMM] line for physical-page allocations

### DIFF
--- a/userspace/draug-daemon/src/main.rs
+++ b/userspace/draug-daemon/src/main.rs
@@ -214,6 +214,15 @@ fn log_alive_if_due(draug: &DraugDaemon, now_ms: u64) {
             stats.dealloc_count,
         );
     }
+    // PMM (physical-page) view — distinct from `heap_walk`, which only
+    // sees the 32 MB kernel LockedHeap pool. Phase A bug #54 was a
+    // virtio-net TX page leak that grew the VM's overall memory
+    // footprint without ever touching the LockedHeap; PR #97 fixed it,
+    // but only because this line surfaced "PMM grew 82 → 154 MB while
+    // HEAP stayed flat at 140 K". Keep the metric in the periodic log
+    // so the next allocator-but-not-heap leak shows up in plain sight.
+    let (total_mb, used_mb, pct) = libfolk::sys::memory_stats();
+    println!("[PMM] used={}MB / {}MB ({}%)", used_mb, total_mb, pct);
 }
 
 /// Allocate, map, initialise, and grant compositor read access to


### PR DESCRIPTION
## Summary

Companion to the `[HEAP]` line from #96. `heap_walk` only sees the kernel's 32 MB LockedHeap pool; physical pages allocated directly via `physical::alloc_page()` — virtio descriptor backings, userspace task frames, page tables — are invisible to it.

Adds a one-line PMM summary to the same 30 s throttle:

```
[PMM] used=82MB / 2038MB (4%)
```

## Why the metric matters (live evidence)

Issue #54's virtio-net TX leak was *invisible* in `[HEAP]` lines — heap stayed flat at 140 K while the host's view of guest memory climbed by 70 MB/min under flood. The leak was an `alloc_page` without a matching `free_page`, so it bypassed the LockedHeap entirely.

Adding this line during the live diagnosis on Proxmox VM 800 showed:

```
[PMM] used=82MB   ← baseline
[HEAP] used=140K
[PMM] used=95MB   ← flood started
[HEAP] used=140K
[PMM] used=132MB  ← 50 MB grown, heap totally flat
[HEAP] used=140K
```

That contrast is what made it obvious the leak was in the PMM-direct path, not the heap-allocator path. Fix landed in #97. Keeping the metric in main so the next allocator-but-not-heap leak shows up the moment an alive-log fires after it.

## Test plan
- [x] `cargo check` daemon clean
- [x] Live boot — `[PMM]` line emits every 30 s alongside `[HEAP]`
- [x] Pre-fix flood reproduces 82 → 154 MB delta (visible in #54's data table)
- [x] Post-fix flood (#97) shows 81 → 81 MB through 38 K packets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
