### PR TITLE
Issue #99: Draug-async TCP debug — diagnostics + build hygiene fix

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -7,6 +7,17 @@ fn main() {
     println!("cargo:rustc-link-arg=-Tlinker.ld");
     println!("cargo:rerun-if-changed=linker.ld");
 
+    // Re-evaluate `option_env!` constants when these toggle. Without
+    // these directives cargo's incremental cache silently keeps the
+    // last-baked PROXY_IP / GEMINI_PORT / etc., which previously cost
+    // four debug sessions on Issue #99 (daemon kept SYN'ing the SLIRP
+    // gateway because the env var changed but the old IP stayed in
+    // the binary). Same list lives in userspace/libfolk/build.rs and
+    // userspace/draug-streamer/build.rs — keep all three in sync.
+    println!("cargo:rerun-if-env-changed=FOLKERING_PROXY_IP");
+    println!("cargo:rerun-if-env-changed=FOLKERING_PROXY_PORT");
+    println!("cargo:rerun-if-env-changed=FOLKERING_GEMINI_PORT");
+
     // Resolve the shared HMAC key used by `kernel::jit` to sign CODE
     // frames sent to the Pi-side a64-stream-daemon. Same priority list
     // as tools/a64-streamer/build.rs so the two stay aligned.

--- a/kernel/src/drivers/virtio_net/tx.rs
+++ b/kernel/src/drivers/virtio_net/tx.rs
@@ -13,36 +13,71 @@ pub(super) fn transmit_packet_inner(dev: &mut VirtIONet, frame: &[u8]) -> Result
         return Err(NetError::DeviceFailed);
     }
 
-    // Issue #99 diagnostic: log the dst port for any TCP frame headed
-    // at the proxy. If smoltcp is producing the daemon's SYN we'll see
-    // dst=14711 here; absence in this log proves the SYN never reaches
-    // the virtio queue (i.e. iface.poll's TX path isn't running for
-    // task 4's socket). Filter cheap on the IPv4 + TCP shape so we
-    // don't drown the serial in ARP / IPv6 / ICMP noise.
-    if frame.len() >= 14 + 20 + 20 {
-        let ethertype = ((frame[12] as u16) << 8) | frame[13] as u16;
-        if ethertype == 0x0800 {
-            // IPv4 header — first byte is version+IHL, IHL is low 4 bits
-            // measured in 32-bit words.
-            let ihl = ((frame[14] & 0x0F) as usize) * 4;
-            let tcp_off = 14 + ihl;
-            // protocol == 6 (TCP)
-            if frame.len() >= tcp_off + 20 && frame[14 + 9] == 6 {
-                let dst_port = ((frame[tcp_off + 2] as u16) << 8)
-                    | frame[tcp_off + 3] as u16;
-                if dst_port == 14711 {
-                    let src_port = ((frame[tcp_off + 0] as u16) << 8)
-                        | frame[tcp_off + 1] as u16;
-                    let flags = frame[tcp_off + 13];
-                    crate::serial_str!("[VIRTIO_TX] sport=");
-                    crate::drivers::serial::write_dec(src_port as u32);
-                    crate::serial_str!(" dport=14711 flags=0x");
-                    crate::drivers::serial::write_hex(flags as u64);
-                    crate::serial_str!(" len=");
-                    crate::drivers::serial::write_dec(frame.len() as u32);
-                    crate::serial_strln!("");
+    // Issue #99 diagnostic: log every TX so we can see ARP / TCP / etc.
+    // If daemon's SYN isn't reaching here at all (no TCP dst=14711),
+    // we see what smoltcp DOES emit instead — could be ARP requests
+    // for .150, neighbor solicitations, or nothing. Throttle is via
+    // post-boot counter so the boot-time storm doesn't drown serial.
+    if frame.len() >= 14 {
+        static TX_LOG_COUNT: core::sync::atomic::AtomicU32 =
+            core::sync::atomic::AtomicU32::new(0);
+        let n = TX_LOG_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        // Log: first 50 packets after boot, then every 50th.
+        let should_log = n < 50 || (n % 50) == 0;
+        if should_log {
+            let ethertype = ((frame[12] as u16) << 8) | frame[13] as u16;
+            crate::serial_str!("[VIRTIO_TX] #");
+            crate::drivers::serial::write_dec(n);
+            crate::serial_str!(" eth=0x");
+            crate::drivers::serial::write_hex(ethertype as u64);
+            if ethertype == 0x0806 {
+                // ARP — print sender/target IP if frame is long enough
+                if frame.len() >= 42 {
+                    let op = ((frame[20] as u16) << 8) | frame[21] as u16;
+                    let tip = &frame[38..42];
+                    crate::serial_str!(" ARP op=");
+                    crate::drivers::serial::write_dec(op as u32);
+                    crate::serial_str!(" tip=");
+                    crate::drivers::serial::write_dec(tip[0] as u32);
+                    crate::serial_str!(".");
+                    crate::drivers::serial::write_dec(tip[1] as u32);
+                    crate::serial_str!(".");
+                    crate::drivers::serial::write_dec(tip[2] as u32);
+                    crate::serial_str!(".");
+                    crate::drivers::serial::write_dec(tip[3] as u32);
+                }
+            } else if ethertype == 0x0800 && frame.len() >= 34 {
+                let proto = frame[14 + 9];
+                let dip = &frame[30..34];
+                crate::serial_str!(" IPv4 proto=");
+                crate::drivers::serial::write_dec(proto as u32);
+                crate::serial_str!(" dip=");
+                crate::drivers::serial::write_dec(dip[0] as u32);
+                crate::serial_str!(".");
+                crate::drivers::serial::write_dec(dip[1] as u32);
+                crate::serial_str!(".");
+                crate::drivers::serial::write_dec(dip[2] as u32);
+                crate::serial_str!(".");
+                crate::drivers::serial::write_dec(dip[3] as u32);
+                if proto == 6 && frame.len() >= 14 + 20 + 20 {
+                    let ihl = ((frame[14] & 0x0F) as usize) * 4;
+                    let tcp_off = 14 + ihl;
+                    if frame.len() >= tcp_off + 20 {
+                        let src_port = ((frame[tcp_off] as u16) << 8)
+                            | frame[tcp_off + 1] as u16;
+                        let dst_port = ((frame[tcp_off + 2] as u16) << 8)
+                            | frame[tcp_off + 3] as u16;
+                        let flags = frame[tcp_off + 13];
+                        crate::serial_str!(" TCP ");
+                        crate::drivers::serial::write_dec(src_port as u32);
+                        crate::serial_str!("→");
+                        crate::drivers::serial::write_dec(dst_port as u32);
+                        crate::serial_str!(" flags=0x");
+                        crate::drivers::serial::write_hex(flags as u64);
+                    }
                 }
             }
+            crate::serial_strln!("");
         }
     }
 

--- a/kernel/src/drivers/virtio_net/tx.rs
+++ b/kernel/src/drivers/virtio_net/tx.rs
@@ -13,6 +13,39 @@ pub(super) fn transmit_packet_inner(dev: &mut VirtIONet, frame: &[u8]) -> Result
         return Err(NetError::DeviceFailed);
     }
 
+    // Issue #99 diagnostic: log the dst port for any TCP frame headed
+    // at the proxy. If smoltcp is producing the daemon's SYN we'll see
+    // dst=14711 here; absence in this log proves the SYN never reaches
+    // the virtio queue (i.e. iface.poll's TX path isn't running for
+    // task 4's socket). Filter cheap on the IPv4 + TCP shape so we
+    // don't drown the serial in ARP / IPv6 / ICMP noise.
+    if frame.len() >= 14 + 20 + 20 {
+        let ethertype = ((frame[12] as u16) << 8) | frame[13] as u16;
+        if ethertype == 0x0800 {
+            // IPv4 header — first byte is version+IHL, IHL is low 4 bits
+            // measured in 32-bit words.
+            let ihl = ((frame[14] & 0x0F) as usize) * 4;
+            let tcp_off = 14 + ihl;
+            // protocol == 6 (TCP)
+            if frame.len() >= tcp_off + 20 && frame[14 + 9] == 6 {
+                let dst_port = ((frame[tcp_off + 2] as u16) << 8)
+                    | frame[tcp_off + 3] as u16;
+                if dst_port == 14711 {
+                    let src_port = ((frame[tcp_off + 0] as u16) << 8)
+                        | frame[tcp_off + 1] as u16;
+                    let flags = frame[tcp_off + 13];
+                    crate::serial_str!("[VIRTIO_TX] sport=");
+                    crate::drivers::serial::write_dec(src_port as u32);
+                    crate::serial_str!(" dport=14711 flags=0x");
+                    crate::drivers::serial::write_hex(flags as u64);
+                    crate::serial_str!(" len=");
+                    crate::drivers::serial::write_dec(frame.len() as u32);
+                    crate::serial_strln!("");
+                }
+            }
+        }
+    }
+
     // Drain any completed TX descriptors first.
     // Each descriptor has a 4 KB physical page bound to its `addr`
     // field — `free_desc` only releases the descriptor index back

--- a/kernel/src/net/tcp_async.rs
+++ b/kernel/src/net/tcp_async.rs
@@ -276,8 +276,14 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
         }
     };
 
-    let tcp_rx = tcp::SocketBuffer::new(alloc::vec![0u8; 8192]);
-    let tcp_tx = tcp::SocketBuffer::new(alloc::vec![0u8; 4096]);
+    // Issue #99 fix candidate: match tcp_plain.rs's 65536/8192. The
+    // earlier 8192/4096 was the smallest of any TCP path in the
+    // codebase — and tcp_plain.rs (which works) goes 8x bigger on RX.
+    // Smoltcp's SYN handshake bookkeeping may need more headroom than
+    // the tiny SYN packet itself; bumping eliminates that as a source
+    // of the SynSent-forever symptom.
+    let tcp_rx = tcp::SocketBuffer::new(alloc::vec![0u8; 65536]);
+    let tcp_tx = tcp::SocketBuffer::new(alloc::vec![0u8; 8192]);
     let tcp_socket = tcp::Socket::new(tcp_rx, tcp_tx);
     let tcp_handle = state.sockets.add(tcp_socket);
 

--- a/kernel/src/net/tcp_async.rs
+++ b/kernel/src/net/tcp_async.rs
@@ -13,6 +13,8 @@
 //! The EAGAIN value is 0xFFFF_FFFE (distinct from 0xFFFF_FFFF = error).
 //! iface.poll() is called on every syscall to drive the TCP state machine.
 
+use core::sync::atomic::{AtomicU64, Ordering};
+
 use smoltcp::socket::tcp;
 use smoltcp::wire::{IpAddress, Ipv4Address};
 use smoltcp::time::Instant;
@@ -42,14 +44,92 @@ struct AsyncSlot {
     /// "unowned" (slot is Free or was allocated before ownership
     /// tracking landed — legacy path).
     owner: u32,
+    /// Wall-clock timestamp (ms via `tsc_ms`) when this slot last
+    /// transitioned into `Connecting`. Used by the stuck-handshake
+    /// diagnostic in `syscall_tcp_send` to throttle a one-line log
+    /// per slot per stuck-window — see Issue #99 for the symptom
+    /// (Draug-async TIMEOUT after 90s in Sending). `0` when the slot
+    /// is Free or has already been promoted past Connecting.
+    connecting_since_ms: u64,
 }
 
 static SLOTS: Mutex<[AsyncSlot; MAX_ASYNC_SLOTS]> = Mutex::new([
-    AsyncSlot { state: SlotState::Free, handle: None, owner: 0 },
-    AsyncSlot { state: SlotState::Free, handle: None, owner: 0 },
-    AsyncSlot { state: SlotState::Free, handle: None, owner: 0 },
-    AsyncSlot { state: SlotState::Free, handle: None, owner: 0 },
+    AsyncSlot { state: SlotState::Free, handle: None, owner: 0, connecting_since_ms: 0 },
+    AsyncSlot { state: SlotState::Free, handle: None, owner: 0, connecting_since_ms: 0 },
+    AsyncSlot { state: SlotState::Free, handle: None, owner: 0, connecting_since_ms: 0 },
+    AsyncSlot { state: SlotState::Free, handle: None, owner: 0, connecting_since_ms: 0 },
 ]);
+
+/// Issue #99 diagnostic: last wall-clock ms we logged a stuck slot,
+/// per slot. Throttle to one entry per 5 s so a 90 s timeout window
+/// produces ~18 lines on the serial — enough to see the pattern,
+/// not enough to drown anything else.
+static LAST_STUCK_LOG_MS: [AtomicU64; MAX_ASYNC_SLOTS] = [
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+];
+
+/// Print one line describing why slot `slot_id` is still Connecting,
+/// reading state straight off the smoltcp socket. Throttled to one
+/// log per slot per 5 s. Caller must already hold `state.sockets`
+/// borrows in a sane shape (we take a fresh `&` borrow here).
+fn log_stuck_connecting(
+    slot_id: usize,
+    slot: &AsyncSlot,
+    socket: &tcp::Socket,
+    now_ms: u64,
+) {
+    let last = LAST_STUCK_LOG_MS[slot_id].load(Ordering::Relaxed);
+    if now_ms.saturating_sub(last) < 5_000 {
+        return;
+    }
+    LAST_STUCK_LOG_MS[slot_id].store(now_ms, Ordering::Relaxed);
+
+    let elapsed = now_ms.saturating_sub(slot.connecting_since_ms);
+
+    crate::serial_str!("[TCP_ASYNC] slot ");
+    crate::drivers::serial::write_dec(slot_id as u32);
+    crate::serial_str!(" stuck Connecting for ");
+    crate::drivers::serial::write_dec((elapsed / 1000) as u32);
+    crate::serial_str!("s (owner=");
+    crate::drivers::serial::write_dec(slot.owner);
+    crate::serial_str!(", state=");
+    crate::serial_str!(state_name(socket.state()));
+    crate::serial_str!(", may_send=");
+    crate::serial_str!(if socket.may_send() { "1" } else { "0" });
+    crate::serial_str!(", can_send=");
+    crate::serial_str!(if socket.can_send() { "1" } else { "0" });
+    crate::serial_str!(", is_active=");
+    crate::serial_str!(if socket.is_active() { "1" } else { "0" });
+    if let Some(remote) = socket.remote_endpoint() {
+        crate::serial_str!(", remote=");
+        crate::drivers::serial::write_dec(remote.port as u32);
+    }
+    if let Some(local) = socket.local_endpoint() {
+        crate::serial_str!(", local_port=");
+        crate::drivers::serial::write_dec(local.port as u32);
+    }
+    crate::serial_strln!(")");
+}
+
+fn state_name(s: tcp::State) -> &'static str {
+    use smoltcp::socket::tcp::State;
+    match s {
+        State::Closed => "Closed",
+        State::Listen => "Listen",
+        State::SynSent => "SynSent",
+        State::SynReceived => "SynReceived",
+        State::Established => "Established",
+        State::FinWait1 => "FinWait1",
+        State::FinWait2 => "FinWait2",
+        State::CloseWait => "CloseWait",
+        State::Closing => "Closing",
+        State::LastAck => "LastAck",
+        State::TimeWait => "TimeWait",
+    }
+}
 
 /// Create — or re-poll — a non-blocking TCP connection.
 ///
@@ -132,6 +212,7 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
         let socket = state.sockets.get_mut::<tcp::Socket>(h);
         if socket.may_send() {
             slots[i].state = SlotState::Connected;
+            slots[i].connecting_since_ms = 0;
             return i as u64;
         }
         if !socket.is_active() {
@@ -141,6 +222,7 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
             state.sockets.remove(h);
             slots[i].state = SlotState::Free;
             slots[i].handle = None;
+            slots[i].connecting_since_ms = 0;
             return u64::MAX;
         }
         return EAGAIN;
@@ -211,6 +293,8 @@ pub fn syscall_tcp_connect(ip_packed: u64, port: u64) -> u64 {
     slots[slot_idx].state = SlotState::Connecting;
     slots[slot_idx].handle = Some(tcp_handle);
     slots[slot_idx].owner = current_task;
+    slots[slot_idx].connecting_since_ms = tsc_ms() as u64;
+    LAST_STUCK_LOG_MS[slot_idx].store(0, Ordering::Relaxed);
 
     // Return slot_id immediately. Connection completes asynchronously.
     // Subsequent polls on the same (ip, port) will return this slot
@@ -258,12 +342,18 @@ pub fn syscall_tcp_send(slot_id: u64, data_ptr: u64, data_len: u64) -> u64 {
         let socket = state.sockets.get_mut::<tcp::Socket>(h);
         if socket.may_send() {
             slot.state = SlotState::Connected;
+            slot.connecting_since_ms = 0;
         } else if !socket.is_active() {
             state.sockets.remove(h);
             slot.state = SlotState::Free;
             slot.handle = None;
+            slot.connecting_since_ms = 0;
             return u64::MAX;
         } else {
+            // Issue #99 diagnostic: surface the stuck handshake on
+            // serial so we can tell SynSent vs CloseWait vs other
+            // without re-running with a debug build.
+            log_stuck_connecting(slot_id as usize, slot, &*socket, tsc_ms() as u64);
             return EAGAIN; // still connecting
         }
     }

--- a/tools/rebuild_current_img.py
+++ b/tools/rebuild_current_img.py
@@ -1,0 +1,35 @@
+"""One-shot helper: rebuild boot/current.img from base + fresh kernel/initrd
+via WSL mcopy. Used when we want to deploy without starting QEMU."""
+from pathlib import Path
+import shutil
+import subprocess
+
+BOOT_DIR = Path('C:/Users/merkn/folkering/folkering-os/boot')
+SRC = BOOT_DIR / 'folkering-deploy.img'
+DST = BOOT_DIR / 'current.img'
+KERNEL = BOOT_DIR / 'iso_root' / 'boot' / 'kernel.elf'
+INITRD = BOOT_DIR / 'iso_root' / 'boot' / 'initrd.fpk'
+FAT_OFFSET = 1048576
+
+def win_to_wsl(p):
+    s = str(p).replace('\\', '/')
+    if len(s) >= 2 and s[1] == ':':
+        s = '/mnt/' + s[0].lower() + s[2:]
+    return s
+
+shutil.copy2(SRC, DST)
+wsl_dst = win_to_wsl(DST)
+
+for src_file, fat_paths in [
+    (KERNEL, ['::/boot/kernel.elf']),
+    (INITRD, ['::/boot/initrd.fpk', '::/initrd.fpk']),
+]:
+    wsl_src = win_to_wsl(src_file)
+    for fat_path in fat_paths:
+        cmd = ['wsl', '-d', 'Ubuntu-22.04', '--', 'bash', '-c',
+               f"export MTOOLS_SKIP_CHECK=1; mcopy -o -i '{wsl_dst}@@{FAT_OFFSET}' '{wsl_src}' '{fat_path}' 2>&1"]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        kb = src_file.stat().st_size // 1024
+        print(f"  {fat_path}({kb}KB): rc={r.returncode} {r.stdout.strip() or 'OK'}")
+
+print(f"current.img: {DST.stat().st_size // (1024*1024)} MB")

--- a/userspace/draug-streamer/build.rs
+++ b/userspace/draug-streamer/build.rs
@@ -12,6 +12,13 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
+    // Re-evaluate `option_env!` constants when these toggle (#99).
+    // draug-streamer hard-codes the SLIRP target unless overridden;
+    // without these directives cargo silently kept the old value
+    // baked in across rebuilds.
+    println!("cargo:rerun-if-env-changed=FOLKERING_STREAMER_IP");
+    println!("cargo:rerun-if-env-changed=FOLKERING_STREAMER_PORT");
+
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let dest = out_dir.join("secret.key");
 

--- a/userspace/libfolk/build.rs
+++ b/userspace/libfolk/build.rs
@@ -1,0 +1,14 @@
+//! Tells cargo to invalidate libfolk's compilation cache when
+//! FOLKERING_PROXY_IP / FOLKERING_PROXY_PORT change between builds.
+//!
+//! Without this, `option_env!` in `proxy_config.rs` silently keeps
+//! the IP / port baked at the time of last source-change rebuild —
+//! which is how Issue #99 (daemon SYN'ing the SLIRP gateway forever)
+//! survived four debug sessions before the actual cause was spotted.
+//! Same list lives in `kernel/build.rs` and
+//! `userspace/draug-streamer/build.rs`; keep all three in sync.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=FOLKERING_PROXY_IP");
+    println!("cargo:rerun-if-env-changed=FOLKERING_PROXY_PORT");
+}


### PR DESCRIPTION
## Summary

Closes Issue #99 (Draug-async hung in SynSent forever, never reached proxy) and adds the kernel-side diagnostic infrastructure that made the root cause findable.

**Root cause was a build hygiene bug, not a kernel bug.** Userspace was being rebuilt without \`FOLKERING_PROXY_IP=192.168.68.150\`, so libfolk's \`option_env!\` fell back to the SLIRP default \`[10, 0, 2, 2]\`. Daemon dutifully SYN'd the SLIRP gateway, which doesn't exist on Proxmox bridged networking — kernel got \`ICMP host 10.0.2.2 unreachable\`, smoltcp kept retransmitting SYNs forever, daemon's userspace 90 s timer fired, repeat. Compositor's \`tcp_plain\` path was OK because that build had been done with the env var set in an earlier session, masking the daemon failure as \"new async path is buggy\".

The proper fix is the **build.rs additions** that ensure cargo invalidates the cache when the FOLKERING_* env vars toggle. Without these, cargo's incremental cache silently kept the old constants baked in across rebuilds — which is how this stayed open for four debug sessions.

## Commits

1. \`diag(tcp-async): per-slot stuck-Connecting log\` — surfaces smoltcp socket state (SynSent / Established / CloseWait / etc.) when an async slot stays in Connecting > 5 s. Throttled, ~18 lines per timeout window. Includes \`tools/rebuild_current_img.py\` which deploys without booting QEMU locally.
2. \`diag(virtio-net): TX-side dport=14711 trace + larger tcp_async buffers\` — first TX-side print, filtered to proxy traffic. Bumped tcp_async sockets to 65536/8192 (matched tcp_plain) — didn't fix #99 but the parity is correct anyway.
3. \`diag(virtio-net): expanded TX trace — ARP + IPv4/TCP w/ src/dst\` — widens the filter to log every TX (throttled). \*\*This is what found #99\*\*: the wider filter showed daemon's SYN was going to \`dip=10.0.2.2\` instead of \`dip=192.168.68.150\`, in one line. The narrow filter would have hidden it forever.
4. \`fix(build): cargo:rerun-if-env-changed for FOLKERING_* option_env vars\` — the actual fix. Adds rerun-if-env-changed directives to kernel/build.rs, userspace/libfolk/build.rs (new), and userspace/draug-streamer/build.rs.

## Test plan

- [x] Kernel builds clean: \`cargo build --release\` with FOLKERING_PROXY_IP env var
- [x] Userspace workspace builds clean
- [x] Deployed to Proxmox VM 800. Daemon spawns at task 4, [DRAUG-DAEMON] alive uptime=89s
- [x] First-ever \`[Draug-async] fib_iter L1 PASS\` observed; skill tree advanced to L1=1/20
- [x] Second L1 PASS (\`factorial\`) → L1=2/20 — autonomous loop working as intended
- [x] HEAP/PMM stable through the test (live=50, no leak)
- [x] Compositor's tcp_plain Phase 17 pipeline still works concurrently (cargo test on proxy archives 0009_draug_latest.rs)

## Notes for reviewer

- The diagnostic instrumentation stays in tree as ongoing observability. It's cheap (throttled, no allocs in hot path) and proved its keep on the second debug it surfaced.
- The build.rs additions are the load-bearing fix; the diagnostics just made the root cause visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)