### PR TITLE
Phase C: Project::list() + libfolk synapse::list_files() wrapper

### DIFF
--- a/userspace/draug-daemon/src/project.rs
+++ b/userspace/draug-daemon/src/project.rs
@@ -62,9 +62,10 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use libfolk::sys::synapse::{
-    read_file_by_name, read_file_chunk, write_file, write_file_get_rowid,
-    SynapseError, SynapseResult,
+    list_files, read_file_by_name, read_file_chunk, write_file, write_file_get_rowid,
+    SynapseError, SynapseResult, LIST_FILES_ENTRY_SIZE, LIST_FILES_NAME_BYTES,
 };
+use libfolk::sys::{shmem_destroy, shmem_map, shmem_unmap};
 
 /// One file entry inside a project. `size == 0` is the tombstone
 /// encoding (see module note + Issue #100).
@@ -182,6 +183,108 @@ impl Project {
     /// don't re-allocate just to read it back.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Enumerate the files Draug has authored under this project.
+    ///
+    /// Implementation: calls Synapse's `list_files` (returns a shmem
+    /// of every file in the data store), maps the buffer, and
+    /// filters the entries whose qualified name starts with this
+    /// project's prefix. The qualified names are stripped back to
+    /// project-local paths in the result.
+    ///
+    /// **Caveats**:
+    /// - Synapse's wire format truncates names at
+    ///   `LIST_FILES_NAME_BYTES` (24 bytes). Files whose qualified
+    ///   path exceeds 24 bytes appear truncated; callers should
+    ///   keep project+filename short until #100 lands a real
+    ///   `LIST_FILES_BY_PREFIX` op with a wider name field.
+    /// - Tombstone entries (size == 0, see `delete()`) are
+    ///   *included* — caller filters via `ProjectFile::is_deleted()`
+    ///   if they want only live files. This matches Draug's
+    ///   common case ("show me everything I've ever written under
+    ///   this project, dead or alive") better than silently hiding
+    ///   them.
+    pub fn list(&self) -> SynapseResult<Vec<ProjectFile>> {
+        let response = list_files()?;
+        if response.count == 0 || response.shmem_handle == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Map the shmem somewhere we know is unused. The same
+        // virtual address is used by other transient mappings
+        // (`read_file_shmem`, etc.) but since this entire function
+        // owns the mapping start-to-finish, there's no aliasing risk
+        // — the unmap at the end always pairs with this map.
+        const LIST_VADDR: usize = 0x21000000;
+        let total_size = response.count * LIST_FILES_ENTRY_SIZE;
+        if shmem_map(response.shmem_handle, LIST_VADDR).is_err() {
+            let _ = shmem_destroy(response.shmem_handle);
+            return Err(SynapseError::IpcFailed);
+        }
+
+        let prefix = self.prefix();
+        let prefix_bytes = prefix.as_bytes();
+        let mut out: Vec<ProjectFile> = Vec::new();
+
+        // SAFETY: shmem buffer is valid for `total_size` bytes for
+        // the duration of this scope (we own the mapping until the
+        // shmem_unmap call below). Synapse populated it in
+        // `handle_list_files`.
+        let buf = unsafe {
+            core::slice::from_raw_parts(LIST_VADDR as *const u8, total_size)
+        };
+
+        for i in 0..response.count {
+            let off = i * LIST_FILES_ENTRY_SIZE;
+            let name_field = &buf[off..off + LIST_FILES_NAME_BYTES];
+            // Find the zero terminator, or take the full 24 bytes.
+            let name_end = name_field.iter()
+                .position(|&b| b == 0)
+                .unwrap_or(LIST_FILES_NAME_BYTES);
+            // Skip non-UTF8 — defensive only; Synapse stores names
+            // as ASCII / UTF-8 paths.
+            let qualified = match core::str::from_utf8(&name_field[..name_end]) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            // Prefix-filter: belongs to this project iff it starts
+            // with `proj/<name>/`.
+            if !qualified.as_bytes().starts_with(prefix_bytes) {
+                continue;
+            }
+            let local_name = String::from(&qualified[prefix.len()..]);
+            // Skip the directory marker if Synapse ever introduces
+            // one — empty local_name = the project's "root", which
+            // the caller's mental model probably doesn't expect to
+            // see in `list()`.
+            if local_name.is_empty() {
+                continue;
+            }
+            let size = u32::from_le_bytes([
+                buf[off + LIST_FILES_NAME_BYTES],
+                buf[off + LIST_FILES_NAME_BYTES + 1],
+                buf[off + LIST_FILES_NAME_BYTES + 2],
+                buf[off + LIST_FILES_NAME_BYTES + 3],
+            ]);
+            // entry_type at off+28..32 is currently always 0 for
+            // data files; ignore for now. ProjectFile doesn't have
+            // a slot for it because the project abstraction treats
+            // every file uniformly.
+
+            out.push(ProjectFile {
+                name: local_name,
+                rowid: 0, // not exposed by list_files wire format
+                size,
+            });
+        }
+
+        // Always unmap + destroy, even on error in the loop above
+        // (the iterator is total — `?` doesn't escape).
+        let _ = shmem_unmap(response.shmem_handle, LIST_VADDR);
+        let _ = shmem_destroy(response.shmem_handle);
+
+        Ok(out)
     }
 }
 

--- a/userspace/libfolk/src/sys/synapse.rs
+++ b/userspace/libfolk/src/sys/synapse.rs
@@ -264,6 +264,54 @@ pub fn file_count() -> SynapseResult<usize> {
     Ok(ret as usize)
 }
 
+/// Reply struct for `list_files` — mirrors Synapse's wire shape.
+/// Caller is responsible for `shmem_destroy(shmem_handle)` once done.
+///
+/// Each entry in the shmem buffer is 32 bytes:
+///   [name(24) zero-padded][size: u32 LE][entry_type: u32 LE]
+///
+/// **Name truncation**: Synapse's directory cache stores names in a
+/// 32-byte field but only the first 24 bytes are copied into shmem.
+/// Names longer than 24 bytes are silently truncated. Phase C
+/// callers (e.g. `Project::list`) should keep project + filename
+/// combinations within that budget for now.
+#[derive(Debug, Clone)]
+pub struct ListFilesResponse {
+    pub count: usize,
+    pub shmem_handle: u32,
+}
+
+/// Layout of one entry inside the `list_files` shmem buffer.
+pub const LIST_FILES_ENTRY_SIZE: usize = 32;
+/// How many bytes of the entry are name (zero-padded).
+pub const LIST_FILES_NAME_BYTES: usize = 24;
+
+/// Enumerate every file Synapse knows about.
+///
+/// Returns the count and a shmem handle to a buffer of
+/// `count × LIST_FILES_ENTRY_SIZE` bytes. The caller maps the shmem
+/// (e.g. via `shmem_map`), walks the entries, then destroys the shmem.
+///
+/// Higher-level wrappers (`Project::list`) should be preferred for
+/// most callers; this is the raw IPC primitive.
+pub fn list_files() -> SynapseResult<ListFilesResponse> {
+    let ret = unsafe {
+        syscall3(SYS_IPC_SEND, SYNAPSE_TASK_ID as u64, SYN_OP_LIST_FILES, 0)
+    };
+
+    if ret == u64::MAX {
+        return Err(SynapseError::ServiceUnavailable);
+    }
+
+    // Wire format: ((count << 32) | shmem_handle). Empty cache or
+    // shmem_create failure both return 0 in the low 32 bits — caller
+    // should treat that as "no files" rather than an error.
+    let count = ((ret >> 32) & 0xFFFF_FFFF) as usize;
+    let shmem_handle = (ret & 0xFFFF_FFFF) as u32;
+
+    Ok(ListFilesResponse { count, shmem_handle })
+}
+
 /// Get file entry by index
 pub fn file_by_index(index: usize) -> SynapseResult<FileEntry> {
     let ret = unsafe {


### PR DESCRIPTION
## Summary

Continuation of Phase C foundation. The \`Project\` abstraction landed in #101 had write / read / delete / exists / qualify / prefix / name — but no way to enumerate. Without \`list()\`, Draug couldn't walk her project's files, find tombstones to clean up, or even print contents for diagnostics.

This PR plugs the gap with a pair of additions:

### libfolk: \`synapse::list_files()\`

The first libfolk client binding for \`SYN_OP_LIST_FILES\` (the constant has existed since the original Synapse landing but the wrapper never did). Returns \`ListFilesResponse { count, shmem_handle }\`; caller maps the shmem, walks 32-byte entries (\`[name(24)][size(4)][type(4)]\`), destroys when done. Constants \`LIST_FILES_ENTRY_SIZE = 32\` and \`LIST_FILES_NAME_BYTES = 24\` exported for parsing.

### draug-daemon: \`Project::list()\`

Enumerates every entry, prefix-filters on \`proj/<name>/\`, strips the prefix back to project-local paths, returns \`Vec<ProjectFile>\`. Maps shmem at \`0x21000000\` (known unused), unmaps + destroys before returning. Tombstones are included — callers filter via \`ProjectFile::is_deleted()\` when they want only live files. That matches Draug's likely use case (\"what have I ever written here?\") better than silent hiding.

## Caveat (documented in both layers)

Synapse truncates names at 24 bytes in the wire format. Project paths longer than 24 bytes appear cut off; #100's eventual \`LIST_FILES_BY_PREFIX\` op should widen this. For now Draug's project + filename combos must stay short — the daemon's task IDs are well under the budget.

## What this is NOT

Still doesn't add a real DELETE primitive (#100 remains open). Soft-delete via empty content from #101 is unchanged; this just lets Draug see what she's accumulated.

## Test plan

- [x] Userspace workspace builds clean (\`cargo build --release\`)
- [x] No new dependencies, no API breakage on existing libfolk consumers
- [x] Synapse-side handler unchanged (already worked for the shell's \`list_files\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)