### PR TITLE
fix(draug): advance task level after repeated LLM parse failures

### DIFF
--- a/userspace/draug-daemon/src/draug.rs
+++ b/userspace/draug-daemon/src/draug.rs
@@ -467,6 +467,13 @@ pub struct DraugDaemon {
     pub consecutive_skips: u32,
     /// Fix 8: Hibernation mode — set after 30 consecutive skips.
     pub refactor_hibernating: bool,
+    /// Per-task consecutive parse-failure count, reset on PASS or
+    /// when the daemon switches to a different task. Used to force-
+    /// advance a task that keeps failing at LLM-parse stage (proxy
+    /// returned empty bytes, model dropped offline mid-stream, etc.)
+    /// instead of looping on it forever until the global 30-skip
+    /// hibernation kicks in. See `process_skill_llm` for the wiring.
+    pub task_parse_fails: [u32; TASK_COUNT],
     /// Cached proxy ping result (avoid 2s TCP per iteration).
     pub last_ping_ms: u64,
     pub last_ping_ok: bool,
@@ -594,6 +601,7 @@ impl DraugDaemon {
             task_errors: [const { None }; TASK_COUNT],
             consecutive_skips: 0,
             refactor_hibernating: false,
+            task_parse_fails: [0u32; TASK_COUNT],
             last_ping_ms: 0,
             last_ping_ok: false,
             async_phase: AsyncPhase::Idle,

--- a/userspace/draug-daemon/src/draug.rs
+++ b/userspace/draug-daemon/src/draug.rs
@@ -474,6 +474,12 @@ pub struct DraugDaemon {
     /// instead of looping on it forever until the global 30-skip
     /// hibernation kicks in. See `process_skill_llm` for the wiring.
     pub task_parse_fails: [u32; TASK_COUNT],
+    /// Cumulative count of force-advance events (parse-fail SKIPs +
+    /// cargo-fail SKIPs). Reported in the Skill: line so an operator
+    /// can tell at a glance how much of `tasks_at_level(N)` is real
+    /// PASS vs a level the daemon gave up on. Doesn't persist across
+    /// boots — diagnostic only.
+    pub force_advance_count: u32,
     /// Cached proxy ping result (avoid 2s TCP per iteration).
     pub last_ping_ms: u64,
     pub last_ping_ok: bool,
@@ -602,6 +608,7 @@ impl DraugDaemon {
             consecutive_skips: 0,
             refactor_hibernating: false,
             task_parse_fails: [0u32; TASK_COUNT],
+            force_advance_count: 0,
             last_ping_ms: 0,
             last_ping_ok: false,
             async_phase: AsyncPhase::Idle,

--- a/userspace/draug-daemon/src/draug_async.rs
+++ b/userspace/draug-daemon/src/draug_async.rs
@@ -804,6 +804,34 @@ fn process_skill_llm(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -> b
             write_str("[Draug-async] LLM parse failed\n");
             draug.async_phase = AsyncPhase::Idle;
             draug.record_skip();
+
+            // Force-advance the task level after repeated parse-stage
+            // failures on the same task. Without this, daemon keeps
+            // re-picking the same task every cycle (next_task_and_level
+            // looks at task_levels only, which the parse-fail path
+            // doesn't bump), wasting LLM round-trips and burning
+            // toward the 30-skip global hibernation. Threshold of 3
+            // is empirical: fewer is too aggressive (one transient
+            // proxy hiccup gives up), more is too patient (we saw
+            // ~13 same-task fails before this was wired in).
+            const PARSE_FAIL_LIMIT: u32 = 3;
+            let task_idx = draug.async_task_idx;
+            if task_idx < crate::draug::TASK_COUNT {
+                draug.task_parse_fails[task_idx] =
+                    draug.task_parse_fails[task_idx].saturating_add(1);
+                if draug.task_parse_fails[task_idx] >= PARSE_FAIL_LIMIT {
+                    write_str("[Draug-async] task ");
+                    write_str(crate::knowledge_hunt::REFACTOR_TASKS[task_idx].0);
+                    write_str(" advancing past L");
+                    write_dec(draug.async_level as u32);
+                    write_str(" after ");
+                    write_dec(draug.task_parse_fails[task_idx]);
+                    write_str(" parse failures\n");
+                    draug.advance_task_level(task_idx);
+                    draug.task_parse_fails[task_idx] = 0;
+                    draug.save_state();
+                }
+            }
             return true;
         }
     };
@@ -815,6 +843,12 @@ fn process_skill_llm(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -> b
     if draug.async_level == 1 {
         draug.store_task_code(draug.async_task_idx, code.clone());
         draug.save_task_code(draug.async_task_idx);
+    }
+
+    // Reset per-task parse-fail counter on a clean parse — the rest
+    // of the path (PATCH, cargo test) decides PASS/SKIP from there.
+    if draug.async_task_idx < crate::draug::TASK_COUNT {
+        draug.task_parse_fails[draug.async_task_idx] = 0;
     }
 
     draug.async_phase_started_ms = now_ms;

--- a/userspace/draug-daemon/src/draug_async.rs
+++ b/userspace/draug-daemon/src/draug_async.rs
@@ -829,6 +829,7 @@ fn process_skill_llm(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -> b
                     write_str(" parse failures\n");
                     draug.advance_task_level(task_idx);
                     draug.task_parse_fails[task_idx] = 0;
+                    draug.force_advance_count = draug.force_advance_count.saturating_add(1);
                     draug.save_state();
                 }
             }
@@ -925,7 +926,18 @@ fn process_patch_result(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -
             write_dec(at_l2 as u32);
             write_str("/20 L3=");
             write_dec(at_l3 as u32);
-            write_str("/20\n");
+            write_str("/20");
+            // Distinguish real PASSes from levels we force-advanced
+            // past after repeated failures. Skipped tasks count toward
+            // tasks_at_level (they had to, otherwise next_task_and_level
+            // re-picks them forever) — this suffix tells the operator
+            // how much of the headline number is genuine progress.
+            if draug.force_advance_count > 0 {
+                write_str(" (");
+                write_dec(draug.force_advance_count);
+                write_str(" force-advanced)");
+            }
+            write_str("\n");
         }
     } else {
         // FAIL — attempt error-driven retry (max 2)
@@ -1000,6 +1012,7 @@ fn process_patch_result(draug: &mut DraugDaemon, response: &[u8], now_ms: u64) -
 
             // Force-advance the level so next_task_and_level moves on
             draug.advance_task_level(task_idx);
+            draug.force_advance_count = draug.force_advance_count.saturating_add(1);
             draug.save_state();
         }
     }


### PR DESCRIPTION
## Summary

Closes a real progression bug observed in the autonomous loop running on Proxmox VM 800: daemon would burn ~13 retries on a single stuck task (\`reverse_u32\` in our trace) before the global 30-skip hibernation kicked in, and never advance past it.

Cause: \`process_skill_llm\`'s parse-fail branch only called \`record_skip()\`. That increments the global consecutive-skip counter but never bumps the per-task \`task_levels[i]\`, which is what \`next_task_and_level\` looks at when picking the next task. So daemon kept re-picking the same task every loop.

## Fix

Per-task parse-fail counter (\`task_parse_fails: [u32; TASK_COUNT]\`):

- Increments each time \`parse_llm_response\` returns None for the current task
- After 3 consecutive parse failures on one task, calls \`advance_task_level(idx)\` and resets the counter
- Reset to 0 on a clean parse (so an intermittent proxy hiccup doesn't get held against the task forever)

The skill counter still tells the truth — \`task_levels[i]\` advances even though the task wasn't successfully solved — but the loop makes forward progress.

## Threshold rationale

3 was tuned empirically:

- Too few (1): one transient \"max concurrent reached\" from the proxy gives up on a task forever
- Too many (10+): same long stuck cycles we already had
- 3: rides through single hiccups, gives up on tasks that consistently fail at parse stage

## Test plan

- [x] Userspace builds clean (\`cargo build --release\`)
- [x] No public-API changes
- [x] Touches only \`draug.rs\` (struct + initializer) and \`draug_async.rs\` (branch wiring)

Will validate end-to-end on Proxmox VM 800 once merged + redeployed: expect daemon to climb past \`reverse_u32\` (idx 4) and \`popcount\` (idx 5) cleanly into the latter 14 tasks, without burning the 30-skip hibernation budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)