### PR TITLE
Phase C: autonomous multi-file project authoring (live-validated)

### DIFF
--- a/userspace/draug-daemon/src/draug.rs
+++ b/userspace/draug-daemon/src/draug.rs
@@ -113,6 +113,13 @@ pub enum AsyncOp {
     /// the proxy so it can run in the daemon process without
     /// touching compositor's COM2 frame queue.
     AnalysisLlm,
+    /// Phase C: ask the LLM for a multi-file Rust project (lib.rs +
+    /// tests.rs + Cargo.toml etc.) split by `// === FILE: <path>`
+    /// markers, parse the response into separate files, and write
+    /// each into Synapse via `Project::write` under a
+    /// `proj/<project>/` namespace. First demo of Draug authoring
+    /// beyond a single function.
+    PhaseCMultiFile,
 }
 
 /// Which kind of work Draug is doing right now. Lets `tick_idle`
@@ -480,6 +487,13 @@ pub struct DraugDaemon {
     /// PASS vs a level the daemon gave up on. Doesn't persist across
     /// boots — diagnostic only.
     pub force_advance_count: u32,
+    /// Phase C: index of the next multi-file project Draug should
+    /// attempt from `phase_c::MULTI_FILE_PROJECTS`. Once this hits
+    /// the list length, the autonomous loop stops trying new
+    /// projects (one-shot per project, success or fail). In-memory
+    /// only — Phase C resets each boot, which is fine for the
+    /// initial demo since proj/<id>/ persistence is up to Synapse.
+    pub phase_c_idx: u8,
     /// Cached proxy ping result (avoid 2s TCP per iteration).
     pub last_ping_ms: u64,
     pub last_ping_ok: bool,
@@ -609,6 +623,7 @@ impl DraugDaemon {
             refactor_hibernating: false,
             task_parse_fails: [0u32; TASK_COUNT],
             force_advance_count: 0,
+            phase_c_idx: 0,
             last_ping_ms: 0,
             last_ping_ok: false,
             async_phase: AsyncPhase::Idle,

--- a/userspace/draug-daemon/src/draug_async.rs
+++ b/userspace/draug-daemon/src/draug_async.rs
@@ -105,6 +105,19 @@ fn tick_idle(draug: &mut DraugDaemon, now_ms: u64) -> bool {
     if !draug.should_run_refactor_step(now_ms) { return false; }
     draug.last_refactor_ms = now_ms;
 
+    // Phase C — one-shot multi-file project authoring. Fires once
+    // per project from `phase_c::MULTI_FILE_PROJECTS` after the
+    // daemon has at least one L1 PASS (so we know LLM round-trips
+    // work) but before falling through to the skill-tree picker.
+    // Doesn't block subsequent skill-tree work — sets phase_c_idx
+    // forward on success or unconditional advance on parse fail
+    // so the demo never wedges the loop.
+    if (draug.phase_c_idx as usize) < crate::phase_c::MULTI_FILE_PROJECTS.len()
+        && draug.tasks_at_level(1) > 0
+    {
+        return start_phase_c_project(draug, now_ms);
+    }
+
     match draug.next_task_and_level() {
         Some((task_idx, level)) => start_skill_tree(draug, task_idx, level, now_ms),
         None => {
@@ -567,8 +580,74 @@ fn tick_processing(draug: &mut DraugDaemon, now_ms: u64) -> bool {
         // existing `on_analysis_response` so the alert / no-action
         // routing stays identical to the old MCP path.
         AsyncOp::AnalysisLlm => process_analysis_response(draug, &response),
+        AsyncOp::PhaseCMultiFile => process_phase_c_response(draug, &response, now_ms),
         _ => { draug.async_phase = AsyncPhase::Idle; true }
     }
+}
+
+/// Phase C — kick off a multi-file project authoring cycle.
+/// Picks the next entry from `phase_c::MULTI_FILE_PROJECTS`, builds
+/// the marker-format prompt, fires the LLM round-trip. Response is
+/// handled by `process_phase_c_response`.
+fn start_phase_c_project(draug: &mut DraugDaemon, now_ms: u64) -> bool {
+    let idx = draug.phase_c_idx as usize;
+    let (project_id, body) = crate::phase_c::MULTI_FILE_PROJECTS[idx];
+
+    write_str("\n[Phase-C] starting project: ");
+    write_str(project_id);
+    write_str("\n");
+
+    let prompt = crate::phase_c::build_multi_file_prompt(project_id, body);
+
+    draug.async_operation = AsyncOp::PhaseCMultiFile;
+    draug.async_phase_started_ms = now_ms;
+    // Use the same model the skill-tree L1 path uses — qwen2.5-coder
+    // is the only one we've validated for instruction-following on
+    // the Proxmox demo loop.
+    start_llm_request(draug, crate::draug::model_for_level(1), &prompt)
+}
+
+/// Phase C — handle the LLM response: parse, persist, advance the
+/// project index regardless of success so the demo never wedges
+/// the autonomous loop.
+fn process_phase_c_response(draug: &mut DraugDaemon, response: &[u8], _now_ms: u64) -> bool {
+    let raw_text = match parse_llm_response(response) {
+        Some(t) => t,
+        None => {
+            write_str("[Phase-C] LLM parse failed — skipping project\n");
+            // Advance the project index so we don't loop on the same
+            // project forever; matches the skill-tree force-advance
+            // contract from #106.
+            draug.phase_c_idx = draug.phase_c_idx.saturating_add(1);
+            draug.async_phase = AsyncPhase::Idle;
+            draug.async_operation = AsyncOp::None;
+            return true;
+        }
+    };
+
+    let idx = draug.phase_c_idx as usize;
+    let (project_id, _) = crate::phase_c::MULTI_FILE_PROJECTS[idx];
+
+    let files = crate::phase_c::parse_multi_file_response(&raw_text);
+    if files.is_empty() {
+        write_str("[Phase-C] no FILE markers in response — model didn't follow format\n");
+        // Same advance contract — model couldn't shape its output,
+        // we don't keep retrying the same project blind.
+        draug.phase_c_idx = draug.phase_c_idx.saturating_add(1);
+        draug.async_phase = AsyncPhase::Idle;
+        draug.async_operation = AsyncOp::None;
+        return true;
+    }
+
+    let written = crate::phase_c::persist_multi_file_project(project_id, &files);
+    let summary = crate::phase_c::summary_line(project_id, written, files.len());
+    write_str(&summary);
+    write_str("\n");
+
+    draug.phase_c_idx = draug.phase_c_idx.saturating_add(1);
+    draug.async_phase = AsyncPhase::Idle;
+    draug.async_operation = AsyncOp::None;
+    true
 }
 
 /// Phase A.5 (Path A): kick off a Draug self-analysis cycle over

--- a/userspace/draug-daemon/src/lib.rs
+++ b/userspace/draug-daemon/src/lib.rs
@@ -28,3 +28,4 @@ pub mod refactor_loop;
 pub mod draug_async;
 pub mod prevalidate;
 pub mod project;
+pub mod phase_c;

--- a/userspace/draug-daemon/src/phase_c.rs
+++ b/userspace/draug-daemon/src/phase_c.rs
@@ -1,0 +1,264 @@
+//! Phase C — autonomous multi-file project authoring.
+//!
+//! The skill-tree path (L1-L3) is single-file: each task is a
+//! standalone `fn`, the LLM writes one fenced ```rust block, the
+//! proxy stores it as `draug_latest.rs`. That ceiling is real — the
+//! demo "Draug builds apps overnight" needs more than one file at a
+//! time. This module wires the FIRST step toward that:
+//!
+//! 1. Pick a multi-file project from `MULTI_FILE_PROJECTS` (one entry
+//!    for now — a tiny calculator crate).
+//! 2. Build a prompt that asks the LLM for a Rust crate split into
+//!    multiple files using `// === FILE: <path>` markers.
+//! 3. Parse the response, extracting each `(path, content)` pair.
+//! 4. Write each file via `Project::write` under
+//!    `proj/<project_name>/`.
+//! 5. Log the resulting project listing via `Project::list` so the
+//!    operator can see "Draug authored these files autonomously".
+//!
+//! What's deliberately NOT here yet:
+//! - **Compilation / cargo test.** The proxy's PATCH command writes
+//!   one file (`draug_latest.rs`); a multi-file CARGO_CHECK is the
+//!   next PR's worth of work. For now this is store-only — Draug
+//!   produces the layout, we eyeball it.
+//! - **Iterative refinement.** Single-shot generation. A failed
+//!   parse just resets and tries again on the next cycle.
+//! - **Per-file deletion.** Project's `delete()` is soft (overwrite-
+//!   with-empty); real cleanup waits on Issue #100.
+
+extern crate alloc;
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use libfolk::sys::io::write_str;
+
+use crate::knowledge_hunt::write_dec;
+use crate::project::Project;
+
+/// Library of multi-file project specs. Each entry is
+/// `(project_id, prompt_body)` — the prompt body is interpolated
+/// into the LLM template; the project_id becomes the prefix under
+/// `proj/<id>/`. Keep names short and ASCII — Synapse's wire format
+/// truncates at 24 bytes (combined with the `proj/<id>/` prefix and
+/// the per-file path, names get tight fast).
+pub const MULTI_FILE_PROJECTS: &[(&str, &str)] = &[
+    (
+        "demo-calc",
+        "a tiny no_std calculator library. Two files: \
+         `src/lib.rs` defines `pub fn add(a: i32, b: i32) -> i32` \
+         and `pub fn sub(a: i32, b: i32) -> i32`; \
+         `src/tests.rs` is a `#[cfg(test)] mod` with three tests \
+         that verify add and sub via assert_eq! including a negative \
+         case. Both files compile as parts of a no_std `lib.rs` crate.",
+    ),
+];
+
+/// Build the LLM prompt for a multi-file project request.
+///
+/// Asks for a single response with `// === FILE: <path>` markers
+/// separating each file. The marker shape is unique enough that
+/// regex-free parsing (line-prefix match) is reliable on the kinds
+/// of output qwen2.5-coder produces — model-conditional templating
+/// can come later if needed.
+pub fn build_multi_file_prompt(_project_id: &str, body: &str) -> String {
+    let mut p = String::with_capacity(1024);
+    p.push_str("Write ");
+    p.push_str(body);
+    p.push_str("\n\n");
+    p.push_str("Format your response as a single Rust source listing ");
+    p.push_str("with each file separated by a marker line of the exact form:\n");
+    p.push_str("    // === FILE: <relative-path>\n");
+    p.push_str("Example:\n");
+    p.push_str("    // === FILE: src/lib.rs\n");
+    p.push_str("    pub fn foo() {}\n");
+    p.push_str("    // === FILE: src/tests.rs\n");
+    p.push_str("    #[cfg(test)]\n");
+    p.push_str("    mod tests { /* ... */ }\n\n");
+    p.push_str("Rules: include only file content between markers, ");
+    p.push_str("no explanation outside, no Cargo.toml (we'll generate one), ");
+    p.push_str("no top-level `fn main`. Wrap the whole thing in one ");
+    p.push_str("```rust fenced block.");
+    p
+}
+
+/// Parsed file from a multi-file LLM response.
+#[derive(Debug, Clone)]
+pub struct MultiFileEntry {
+    pub path: String,
+    pub content: String,
+}
+
+/// Split an LLM response into individual files using the
+/// `// === FILE: <path>` marker convention. Returns an empty Vec
+/// if no markers are present (caller treats that as a parse failure).
+///
+/// Trims leading/trailing whitespace from each file's content. The
+/// path is taken verbatim after `// === FILE:` up to the end of the
+/// line, then trimmed.
+pub fn parse_multi_file_response(raw: &str) -> Vec<MultiFileEntry> {
+    // Strip any outer ```rust fence first — the prompt asks for it
+    // wrapped, but we shouldn't trip on the closing ``` showing up
+    // inside a file's content (Rust comments wouldn't, but defensive).
+    let body = match raw.find("```rust") {
+        Some(start) => {
+            let after = &raw[start + "```rust".len()..];
+            let body_start = after.find('\n').map(|i| i + 1).unwrap_or(0);
+            let inner = &after[body_start..];
+            match inner.rfind("```") {
+                Some(end) => &inner[..end],
+                None => inner,
+            }
+        }
+        None => raw,
+    };
+
+    const MARKER: &str = "// === FILE:";
+    let mut out: Vec<MultiFileEntry> = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_content = String::new();
+
+    for line in body.lines() {
+        if let Some(after) = line.trim_start().strip_prefix(MARKER) {
+            // Flush previous entry
+            if let Some(path) = current_path.take() {
+                out.push(MultiFileEntry {
+                    path,
+                    content: core::mem::take(&mut current_content)
+                        .trim()
+                        .into(),
+                });
+            }
+            current_path = Some(after.trim().into());
+            continue;
+        }
+        if current_path.is_some() {
+            current_content.push_str(line);
+            current_content.push('\n');
+        }
+    }
+    if let Some(path) = current_path.take() {
+        out.push(MultiFileEntry {
+            path,
+            content: current_content.trim().into(),
+        });
+    }
+    out
+}
+
+/// Persist a parsed multi-file project to Synapse via `Project::write`,
+/// then log the resulting `Project::list` for operator visibility.
+///
+/// Returns the count of files actually written. Soft-fails on any
+/// individual write error (logs and continues) — the daemon's
+/// autonomous loop is best-effort, not transactional.
+pub fn persist_multi_file_project(project_id: &str, files: &[MultiFileEntry]) -> usize {
+    let proj = Project::new(project_id);
+
+    write_str("[Phase-C] persisting ");
+    write_dec(files.len() as u32);
+    write_str(" file(s) under proj/");
+    write_str(project_id);
+    write_str("/\n");
+
+    let mut written = 0usize;
+    for f in files {
+        match proj.write(&f.path, f.content.as_bytes()) {
+            Ok(_) => {
+                written += 1;
+                write_str("[Phase-C]   ✓ ");
+                write_str(&f.path);
+                write_str(" (");
+                write_dec(f.content.len() as u32);
+                write_str(" bytes)\n");
+            }
+            Err(_) => {
+                write_str("[Phase-C]   ✗ ");
+                write_str(&f.path);
+                write_str(" — Synapse write failed\n");
+            }
+        }
+    }
+
+    // Log the final state via Project::list — same code path the
+    // daemon would use to walk a project later (e.g. to read its own
+    // earlier work on the next iteration).
+    match proj.list() {
+        Ok(listing) => {
+            write_str("[Phase-C] project state after write: ");
+            write_dec(listing.len() as u32);
+            write_str(" entr");
+            if listing.len() == 1 { write_str("y"); } else { write_str("ies"); }
+            write_str("\n");
+            for entry in &listing {
+                write_str("[Phase-C]   • ");
+                write_str(&entry.name);
+                write_str(" (");
+                write_dec(entry.size);
+                if entry.is_deleted() {
+                    write_str(" bytes, tombstone)\n");
+                } else {
+                    write_str(" bytes)\n");
+                }
+            }
+        }
+        Err(_) => {
+            write_str("[Phase-C] project listing failed (Synapse unavailable?)\n");
+        }
+    }
+
+    written
+}
+
+/// Format a one-line summary suitable for the autonomous loop's
+/// status print after a Phase C cycle completes.
+pub fn summary_line(project_id: &str, written: usize, parsed: usize) -> String {
+    format!(
+        "[Phase-C] {} done: {} of {} file(s) persisted",
+        project_id, written, parsed
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn parser_extracts_two_files() {
+        let raw = "```rust\n\
+                   // === FILE: src/lib.rs\n\
+                   pub fn add(a: i32, b: i32) -> i32 { a + b }\n\
+                   // === FILE: src/tests.rs\n\
+                   #[cfg(test)]\n\
+                   mod tests {\n\
+                       use super::*;\n\
+                       #[test]\n\
+                       fn it_adds() { assert_eq!(add(2, 3), 5); }\n\
+                   }\n\
+                   ```";
+        let files = parse_multi_file_response(raw);
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].path, "src/lib.rs".to_string());
+        assert!(files[0].content.contains("pub fn add"));
+        assert_eq!(files[1].path, "src/tests.rs".to_string());
+        assert!(files[1].content.contains("it_adds"));
+    }
+
+    #[test]
+    fn parser_handles_no_outer_fence() {
+        let raw = "// === FILE: a.rs\nA\n// === FILE: b.rs\nB";
+        let files = parse_multi_file_response(raw);
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].content, "A".to_string());
+        assert_eq!(files[1].content, "B".to_string());
+    }
+
+    #[test]
+    fn parser_returns_empty_when_no_markers() {
+        let raw = "```rust\nfn main() {}\n```";
+        let files = parse_multi_file_response(raw);
+        assert_eq!(files.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Live-validated milestone — Draug autonomously emitted her first multi-file Rust crate on Proxmox VM 800. Serial output from the boot that produced this PR:

\`\`\`
[Phase-C] starting project: demo-calc
[Phase-C] persisting 2 file(s) under proj/demo-calc/
[Phase-C]   ✓ src/lib.rs (96 bytes)
[Phase-C]   ✓ src/tests.rs (329 bytes)
[Phase-C] project state after write: 2 entries
[Phase-C]   • src/lib.r (96 bytes)
[Phase-C]   • src/tests (329 bytes)
[Phase-C] demo-calc done: 2 of 2 file(s) persisted
\`\`\`

The autonomous loop now:
1. Picks a multi-file project from \`MULTI_FILE_PROJECTS\`
2. Asks qwen2.5-coder:7b for output split by \`// === FILE: <path>\` markers
3. Parses each file out of the response
4. Writes each via \`Project::write\` under \`proj/<id>/\`
5. Logs the resulting \`Project::list\` state

## What lands

- **\`phase_c\` module** with \`MULTI_FILE_PROJECTS\`, \`build_multi_file_prompt\`, \`parse_multi_file_response\`, \`persist_multi_file_project\`, \`summary_line\`. 3 unit tests on the parser.
- **\`AsyncOp::PhaseCMultiFile\`** + tick_processing dispatch.
- **\`phase_c_idx: u8\`** state on \`DraugDaemon\` (one-shot per project, no retry-loop wedge risk).
- **\`tick_idle\` trigger**: fires before the skill-tree picker, gated on \`tasks_at_level(1) > 0\` so we know the LLM round-trip works before trusting a multi-file ask.

## Out of scope (next PR)

- **Multi-file CARGO_CHECK on the proxy.** Currently store-only — daemon authors the layout, no compile pass yet. Proxy's PATCH writes one file; multi-file is its own piece of work.
- **Iterative refinement.** Single-shot generation; failed parse unconditionally advances \`phase_c_idx\` so the demo can never wedge the autonomous loop.
- **Listing truncation.** Synapse's wire format trims names at 24 bytes — full file contents are stored correctly (96 / 329 bytes), only the listing display gets clipped. Tracked under #100 for the eventual \`LIST_FILES_BY_PREFIX\` op with a wider name field.

## Test plan

- [x] Unit tests pass on the parser (3/3)
- [x] Userspace builds clean
- [x] Live-deployed on Proxmox VM 800 — daemon emitted 2-file crate autonomously, both files persisted to Synapse, listing confirms presence
- [x] No regressions in existing skill-tree path — Phase C trigger is gated, doesn't run before \`tasks_at_level(1) > 0\`, runs once per project (one-shot), then daemon falls through to skill-tree as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)