### PR TITLE
feat(synapse): SYN_OP_DELETE_FILE — real btree cell removal (#100)

### DIFF
--- a/userspace/draug-daemon/src/project.rs
+++ b/userspace/draug-daemon/src/project.rs
@@ -62,8 +62,9 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use libfolk::sys::synapse::{
-    list_files, read_file_by_name, read_file_chunk, write_file, write_file_get_rowid,
-    SynapseError, SynapseResult, LIST_FILES_ENTRY_SIZE, LIST_FILES_NAME_BYTES,
+    delete_file, list_files, read_file_by_name, read_file_chunk, write_file,
+    write_file_get_rowid, SynapseError, SynapseResult, LIST_FILES_ENTRY_SIZE,
+    LIST_FILES_NAME_BYTES,
 };
 use libfolk::sys::{shmem_destroy, shmem_map, shmem_unmap};
 
@@ -147,19 +148,34 @@ impl Project {
         Ok(out)
     }
 
-    /// Soft-delete `file` by overwriting it with empty content. The
-    /// row stays in Synapse's `files` table (real eviction needs the
-    /// btree DELETE primitive tracked in Issue #100); enumeration
-    /// callers filter tombstones via `ProjectFile::is_deleted`.
+    /// Delete `file` from Synapse's `files` table.
     ///
-    /// Returns `Ok` even if the file did not exist — this matches
-    /// Draug's "make sure it's gone" intent better than an error
-    /// path callers would have to suppress anyway.
+    /// Tries the real btree DELETE primitive first (Issue #100); if
+    /// that fails (older Synapse build that doesn't recognise
+    /// SYN_OP_DELETE_FILE, or the row was already gone), falls back
+    /// to the original soft-delete-via-empty-content. Either way the
+    /// row stops being visible to `read_file_by_name` lookups.
+    ///
+    /// Returns `Ok` whether the file existed or not — Draug's
+    /// "make sure it's gone" intent is what callers want; an error
+    /// for "wasn't there to begin with" would just get suppressed.
     pub fn delete(&self, file: &str) -> SynapseResult<()> {
-        match write_file(&self.qualify(file), &[]) {
+        let qualified = self.qualify(file);
+        match delete_file(&qualified) {
             Ok(()) => Ok(()),
             Err(SynapseError::NotFound) => Ok(()),
-            Err(e) => Err(e),
+            Err(_) => {
+                // Fall back to soft-delete (overwrite with empty).
+                // Useful both when the synapse-service binary is
+                // older than this libfolk client AND when the btree
+                // delete reports a non-fatal failure (e.g. corrupt
+                // page in the leaf walk).
+                match write_file(&qualified, &[]) {
+                    Ok(()) => Ok(()),
+                    Err(SynapseError::NotFound) => Ok(()),
+                    Err(e) => Err(e),
+                }
+            }
         }
     }
 

--- a/userspace/libfolk/src/sys/synapse.rs
+++ b/userspace/libfolk/src/sys/synapse.rs
@@ -112,6 +112,19 @@ pub const SYN_OP_EMBEDDING_COUNT: u64 = 0x0022;
 /// Reply: 0 = success, SYN_STATUS_ERROR = failure
 pub const SYN_OP_WRITE_FILE: u64 = 0x0030;
 
+/// Phase C: delete a file row from Synapse's `files` table.
+/// Request: op | (name_hash << 16)
+/// Reply: 0 on success, SYN_STATUS_NOT_FOUND if no row matches the
+/// hash, SYN_STATUS_ERROR on btree corruption / IO failure.
+///
+/// Counterpart to write_file. The btree implementation removes the
+/// row's leaf-page cell pointer; the cell's payload bytes become
+/// dead space until the next page rewrite (page-level reclamation
+/// is the open follow-up). Overflow page chains attached to the
+/// row are NOT walked + freed yet — small cost given Synapse's
+/// 256 KB max-db cap, but issue #100 leaves it as the next step.
+pub const SYN_OP_DELETE_FILE: u64 = 0x0036;
+
 /// Write intent metadata for a file (Semantic VFS)
 /// Request: op | (shmem_handle << 16) | (total_size << 32)
 ///   shmem contains: [file_id: u32 LE][mime_len: u16 LE][mime: bytes][json: bytes]
@@ -360,6 +373,37 @@ pub fn hash_name(name: &str) -> u32 {
 pub struct FileInfo {
     pub file_id: u16,
     pub size: u32,
+}
+
+/// Phase C: delete a file from Synapse's `files` table by name.
+///
+/// Wire format: op | (name_hash << 16). The synapse-service handler
+/// finds the matching rowid via name_hash, then calls the btree
+/// `sqlite_delete_file_by_rowid` to remove the cell pointer.
+///
+/// Returns `Ok(())` on successful delete, `Err(SynapseError::NotFound)`
+/// if no row matches, `Err(SynapseError::IpcFailed)` on btree errors.
+/// Idempotent at the SynapseError::NotFound level — caller can treat
+/// "not found" as the same shape as "deleted" if that's what they
+/// need (Project::delete does this).
+pub fn delete_file(name: &str) -> SynapseResult<()> {
+    let name_hash = hash_name(name);
+    let request = SYN_OP_DELETE_FILE | ((name_hash as u64) << 16);
+
+    let ret = unsafe {
+        syscall3(SYS_IPC_SEND, SYNAPSE_TASK_ID as u64, request, 0)
+    };
+
+    if ret == u64::MAX {
+        return Err(SynapseError::ServiceUnavailable);
+    }
+    if ret == SYN_STATUS_NOT_FOUND {
+        return Err(SynapseError::NotFound);
+    }
+    if ret == SYN_STATUS_ERROR {
+        return Err(SynapseError::IpcFailed);
+    }
+    Ok(())
 }
 
 /// Look up a file by name and get its ID and size

--- a/userspace/synapse-service/src/btree.rs
+++ b/userspace/synapse-service/src/btree.rs
@@ -402,6 +402,201 @@ pub fn overwrite_blob_inplace(buf: &mut SafeSqliteBuffer, name: &str, new_data: 
     true
 }
 
+/// Walk every leaf page reachable from `root_page` and append page
+/// numbers into `out`. Used by the DELETE path to scan the tree
+/// without committing to a particular cell layout up front.
+///
+/// Bounded recursion (depth 10, branch fan-out per page) so a
+/// pathological / corrupted tree can't pin the kernel.
+fn collect_leaf_pages(
+    buf: &SafeSqliteBuffer,
+    root_page: u32,
+    page_size: usize,
+    out: &mut Vec<u32>,
+) {
+    let page_count = buf.page_count() as usize;
+    // Stack-based DFS, depth-bounded.
+    let mut stack: Vec<u32> = Vec::with_capacity(16);
+    stack.push(root_page);
+    let mut visited = 0usize;
+    while let Some(page) = stack.pop() {
+        visited += 1;
+        if visited > 256 {
+            println!("[SYNAPSE] delete: leaf walk hit visit cap (256), stopping");
+            return;
+        }
+        if page == 0 || (page as usize) > page_count {
+            continue;
+        }
+        let page_off = (page as usize - 1) * page_size;
+        let hdr_off = if page == 1 { 100 } else { 0 };
+        let ptype = match buf.read_byte(page_off + hdr_off) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        match ptype {
+            0x0d => out.push(page),
+            0x05 => {
+                // Interior: cell_count children + 1 right-pointer.
+                let cell_count = buf.read_be_u16(page_off + hdr_off + 3).unwrap_or(0) as usize;
+                let right_ptr = buf.read_be_u32(page_off + hdr_off + 8).unwrap_or(0);
+                if right_ptr != 0 {
+                    stack.push(right_ptr);
+                }
+                // Each interior cell is `[child_page: u32 BE][rowid: varint]`,
+                // pointed to by the cell-pointer array starting at hdr+12.
+                for i in 0..cell_count.min(64) {
+                    let ptr_off = page_off + hdr_off + 12 + i * 2;
+                    if let Ok(cell_offset) = buf.read_be_u16(ptr_off) {
+                        let cell_start = page_off + cell_offset as usize;
+                        if let Ok(child) = buf.read_be_u32(cell_start) {
+                            if child != 0 {
+                                stack.push(child);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {} // unknown page type; skip
+        }
+    }
+}
+
+/// Decode an SQLite varint. Returns (value, byte_count). Bounded to
+/// 9 bytes per the on-disk format.
+fn decode_varint(buf: &SafeSqliteBuffer, start: usize) -> (u64, usize) {
+    let mut value: u64 = 0;
+    for i in 0..9 {
+        let b = buf.read_byte(start + i).unwrap_or(0);
+        if i == 8 {
+            value = (value << 8) | b as u64;
+            return (value, 9);
+        }
+        value = (value << 7) | (b & 0x7f) as u64;
+        if b & 0x80 == 0 {
+            return (value, i + 1);
+        }
+    }
+    (value, 9)
+}
+
+/// Delete the cell with the given `rowid` from the `files` table.
+///
+/// Walks every leaf page, parses each cell's rowid varint, and on
+/// match removes the cell pointer from the page's pointer array
+/// (shifts subsequent pointers left by 2 bytes, decrements
+/// cell_count). The cell's payload bytes become dead space — SQLite's
+/// freeblock list isn't maintained here, so the space won't be
+/// reused by future inserts within the same page; it gets reclaimed
+/// on the next page rewrite. Acceptable for our small files.db
+/// (Issue #100 follow-up: page-level reclamation + overflow chain
+/// freeing on delete).
+///
+/// Returns `true` if a cell with the matching rowid was found and
+/// removed, `false` otherwise. Increments the SQLite change counter
+/// so other readers see the delete.
+pub fn sqlite_delete_file_by_rowid(buf: &mut SafeSqliteBuffer, rowid: i64) -> bool {
+    if !buf.is_valid() {
+        return false;
+    }
+
+    // Phase 1: get table root + page_size from a temporary view.
+    let (root_page, page_size) = {
+        let db = match SqliteDb::open(buf.loaded()) {
+            Ok(db) => db,
+            Err(_) => return false,
+        };
+        let root = match db.find_table_root("files") {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        (root, db.page_size() as usize)
+    };
+
+    // Phase 2: collect all leaf pages.
+    let mut leaves: Vec<u32> = Vec::with_capacity(8);
+    collect_leaf_pages(buf, root_page, page_size, &mut leaves);
+    if leaves.is_empty() {
+        return false;
+    }
+
+    // Phase 3: find the leaf that contains the matching rowid.
+    let target_rowid = rowid as u64;
+    for leaf_page in leaves {
+        let page_off = (leaf_page as usize - 1) * page_size;
+        let hdr_off = if leaf_page == 1 { 100 } else { 0 };
+        let hdr = page_off + hdr_off;
+
+        let cell_count = buf.read_be_u16(hdr + 3).unwrap_or(0) as usize;
+        let mut found_cell: Option<usize> = None;
+
+        for i in 0..cell_count {
+            let ptr_off = page_off + hdr_off + 8 + i * 2;
+            let cell_offset = buf.read_be_u16(ptr_off).unwrap_or(0) as usize;
+            if cell_offset == 0 {
+                continue;
+            }
+            let cell_start = page_off + cell_offset;
+            // Skip the payload_size varint; rowid varint follows.
+            let (_payload_size, ps_len) = decode_varint(buf, cell_start);
+            let (cell_rowid, _) = decode_varint(buf, cell_start + ps_len);
+            if cell_rowid == target_rowid {
+                found_cell = Some(i);
+                break;
+            }
+        }
+
+        if let Some(cell_idx) = found_cell {
+            return remove_cell_pointer(buf, leaf_page, page_size, cell_idx);
+        }
+    }
+
+    false
+}
+
+/// Remove the cell pointer at index `cell_idx` from the leaf page's
+/// pointer array. Shifts subsequent pointers left by 2 bytes and
+/// decrements `cell_count`. Does NOT compact cell content area —
+/// see `sqlite_delete_file_by_rowid` doc-comment.
+fn remove_cell_pointer(
+    buf: &mut SafeSqliteBuffer,
+    leaf_page: u32,
+    page_size: usize,
+    cell_idx: usize,
+) -> bool {
+    let page_off = (leaf_page as usize - 1) * page_size;
+    let hdr_off = if leaf_page == 1 { 100 } else { 0 };
+    let hdr = page_off + hdr_off;
+
+    let cell_count = buf.read_be_u16(hdr + 3).unwrap_or(0) as usize;
+    if cell_idx >= cell_count {
+        return false;
+    }
+
+    // Shift pointers at indices > cell_idx left by 2 bytes.
+    let ptr_array = page_off + hdr_off + 8;
+    for i in cell_idx..(cell_count - 1) {
+        let next_ptr = match buf.read_be_u16(ptr_array + (i + 1) * 2) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        if buf.write_be_u16(ptr_array + i * 2, next_ptr).is_err() {
+            return false;
+        }
+    }
+    // Zero out the now-unused last pointer slot for hygiene.
+    let _ = buf.write_be_u16(ptr_array + (cell_count - 1) * 2, 0);
+
+    // Decrement cell_count.
+    if buf.write_be_u16(hdr + 3, (cell_count - 1) as u16).is_err() {
+        return false;
+    }
+
+    buf.increment_change_counter();
+    buf.mark_page_dirty(leaf_page as usize - 1);
+    true
+}
+
 /// Insert a new row into the `files` table.
 ///
 /// Cell format for inline payloads:

--- a/userspace/synapse-service/src/handlers.rs
+++ b/userspace/synapse-service/src/handlers.rs
@@ -14,7 +14,8 @@ use libfolk::sys::synapse::{
     SYN_OP_FILE_INFO, SYN_OP_READ_FILE, SYN_OP_READ_FILE_BY_NAME, SYN_OP_READ_FILE_CHUNK,
     SYN_OP_READ_FILE_SHMEM, SYN_OP_SQL_QUERY,
     SYN_OP_VECTOR_SEARCH, SYN_OP_GET_EMBEDDING, SYN_OP_EMBEDDING_COUNT,
-    SYN_OP_WRITE_FILE, SYN_OP_WRITE_INTENT, SYN_OP_READ_INTENT, SYN_OP_QUERY_MIME,
+    SYN_OP_WRITE_FILE, SYN_OP_DELETE_FILE,
+    SYN_OP_WRITE_INTENT, SYN_OP_READ_INTENT, SYN_OP_QUERY_MIME,
     SYN_OP_QUERY_INTENT,
     SYN_OP_UPSERT_ENTITY, SYN_OP_UPSERT_EDGE, SYN_OP_GRAPH_WALK,
     SYN_STATUS_NOT_FOUND, SYN_STATUS_INVALID, SYN_STATUS_ERROR,
@@ -30,6 +31,7 @@ use libsqlite::vector::{
 use crate::btree::{
     overwrite_blob_inplace, sqlite_insert_file, sqlite_insert_intent, sqlite_read_intent,
     sqlite_insert_entity, sqlite_insert_edge, sqlite_expire_edge, sqlite_graph_walk,
+    sqlite_delete_file_by_rowid,
 };
 use crate::cache::{
     count_sqlite_files, find_max_rowid, get_file_size, open_db, refresh_fpk_cache,
@@ -77,6 +79,7 @@ pub fn handle_request<T: TokenSource>(
         SYN_OP_READ_FILE_SHMEM => handle_read_file_shmem(msg, src, sqlite, cache, backend),
         SYN_OP_SQL_QUERY => handle_sql_query(msg, src, sqlite, backend),
         SYN_OP_WRITE_FILE => handle_write_file(msg, src, sqlite, cache, backend),
+        SYN_OP_DELETE_FILE => handle_delete_file(msg, src, sqlite, cache, backend),
         SYN_OP_WRITE_INTENT => handle_write_intent(msg, src, sqlite, backend),
         SYN_OP_READ_INTENT => handle_read_intent(msg, src, sqlite),
         SYN_OP_QUERY_MIME => handle_query_mime(msg, src, sqlite),
@@ -495,6 +498,95 @@ fn handle_sql_query<T: TokenSource>(
         },
         Backend::Fpk => { let _ = reply(src, SYN_STATUS_INVALID, 0); }
     }
+}
+
+// ── Delete handler ────────────────────────────────────────────────────
+
+/// Phase C / Issue #100: delete a file row from the `files` table by
+/// name hash. Resolves the hash to a rowid via `table_scan` (same
+/// path `read_file_by_name` uses), then calls `sqlite_delete_file_by_rowid`
+/// to remove the leaf-page cell pointer + decrement cell_count.
+///
+/// Wire shape: `op | (name_hash << 16)`. Reply is one of:
+///   - 0          — success
+///   - NOT_FOUND  — no row with matching name hash
+///   - ERROR      — btree corruption or backend mismatch
+///
+/// After a successful delete the dir cache is invalidated so
+/// subsequent listings reflect the smaller set; refresh happens
+/// lazily on the next file-listing request.
+fn handle_delete_file<T: TokenSource>(
+    msg: AsyncIpcMessage,
+    src: &mut T,
+    sqlite: &mut SafeSqliteBuffer,
+    cache: &mut DirCacheState,
+    backend: Backend,
+) {
+    if backend != Backend::Sqlite {
+        let _ = reply(src, SYN_STATUS_ERROR, 0);
+        return;
+    }
+    let name_hash = ((msg.payload0 >> 16) & 0xFFFFFFFF) as u32;
+
+    // Phase 1: resolve name hash → rowid via a table_scan view.
+    // Hash collisions are technically possible (FNV-1a 32-bit) but the
+    // file count is small and the cost of a wrong delete is low (the
+    // operator can re-write the file). First match wins, same policy
+    // `read_file_by_name` already follows.
+    let rowid: i64 = {
+        let db = match open_db(sqlite) {
+            Some(db) => db,
+            None => {
+                let _ = reply(src, SYN_STATUS_ERROR, 0);
+                return;
+            }
+        };
+        let scanner = match db.table_scan("files") {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = reply(src, SYN_STATUS_ERROR, 0);
+                return;
+            }
+        };
+        let mut found: Option<i64> = None;
+        for result in scanner {
+            if let Ok(record) = result {
+                if let Some(Value::Text(rec_name)) = record.get(1) {
+                    if hash_name(rec_name) == name_hash {
+                        if let Some(id) = record.get(0).and_then(|v| v.as_int()) {
+                            found = Some(id);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        match found {
+            Some(id) => id,
+            None => {
+                let _ = reply(src, SYN_STATUS_NOT_FOUND, 0);
+                return;
+            }
+        }
+    };
+
+    // Phase 2: remove the cell. (sqlite_delete_file_by_rowid takes
+    // &mut SafeSqliteBuffer, so the table_scan borrow above had to
+    // drop before this call — hence the inner scope.)
+    if !sqlite_delete_file_by_rowid(sqlite, rowid) {
+        let _ = reply(src, SYN_STATUS_ERROR, 0);
+        return;
+    }
+
+    // Phase 3: invalidate the dir cache so the next listing picks
+    // up the smaller set. Lazy refresh happens on first list/scan.
+    cache.valid = false;
+
+    println!(
+        "[SYNAPSE] delete_file: removed rowid={} (name_hash=0x{:x})",
+        rowid, name_hash
+    );
+    let _ = reply(src, 0, 0);
 }
 
 // ── Write handler ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Implements real btree DELETE primitive in Synapse (closes #100). Previously `Project::delete` was soft-only — overwrite-with-empty leaving tombstones in `Project::list`. Now Draug can clean up its own work between cycles.
- Adds `SYN_OP_DELETE_FILE = 0x0036` wire op, server-side handler, and `libfolk::sys::synapse::delete_file` client wrapper.
- `Project::delete` tries real DELETE first, falls back to soft-delete on `Err(_)` so older Synapse builds still work during the transition.

## What's actually deleted
- The cell pointer is removed from the leaf page's pointer array (shift-left by 2 bytes from the deleted slot onward).
- `cell_count` at hdr+3 is decremented.
- `name_hash → rowid` lookup goes via existing `table_scan`, so the same code path Draug already uses for reads.

## What's deliberately NOT in this PR
- **Cell content area is not compacted.** Dead space remains on the page until the next page rewrite. SQLite handles this with VACUUM; we can add it as a follow-up when fragmentation actually bites.
- **Overflow chain freeing.** Files large enough to spill into overflow pages leak those pages on delete. Tracked as a follow-up — currently no caller deletes >page-size files.
- **Page-level reclamation.** A leaf page that goes empty stays in the b-tree.
- **`file_intents` cascade.** If a file was referenced by an intent row, that row now points to nothing.

## Test plan
- [ ] Boot Folkering on Proxmox VM 800
- [ ] Drive a Phase C cycle and confirm `Project::delete` no longer leaves tombstones in `Project::list`
- [ ] Manually `delete_file` an existing entry via tcp_shell and verify it disappears from `find` output
- [ ] Verify older clients (no `delete_file` import) still build — `Project::delete` fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)