### PR TITLE
feat(libfolk): SPSC display-list ring + opcode format (Del 1)

### DIFF
--- a/userspace/libfolk/src/gfx/display_list.rs
+++ b/userspace/libfolk/src/gfx/display_list.rs
@@ -1,0 +1,236 @@
+//! Display-list opcodes and packed wire structures.
+//!
+//! Each command is `[CommandHeader | payload]`. Header is fixed at 3 bytes
+//! (1B opcode + 2B payload length, little-endian implicit on x86_64). The
+//! payload is whatever `repr(C, packed)` struct corresponds to the opcode.
+//! `payload_len` is redundant for fixed-size opcodes but keeps the format
+//! self-framing — the consumer can skip an unknown opcode by jumping
+//! `header.payload_len` bytes ahead.
+//!
+//! All multi-byte fields are little-endian. We're x86_64-only, so this is
+//! free; the format becomes a problem if the OS is ever ported to a
+//! big-endian target, but that's deliberately out of scope.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOpCode {
+    /// End-of-frame marker. Tells the compositor "this list is complete,
+    /// commit it to the render graph and present". Zero-length payload.
+    Sync = 0x00,
+    /// Push a scissor rect onto the clip stack (or pop if width=0,height=0).
+    SetClipRect = 0x01,
+    /// Solid filled rectangle, optionally with rounded corners.
+    DrawRect = 0x02,
+    /// UTF-8 text run rendered against a pre-uploaded font atlas. Variable
+    /// payload — see `display_list.rs::DrawTextHeader` for the fixed prefix.
+    DrawText = 0x03,
+    /// Hardware blit from a texture resource (sprite atlas).
+    DrawTexture = 0x04,
+}
+
+impl CommandOpCode {
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            0x00 => Some(Self::Sync),
+            0x01 => Some(Self::SetClipRect),
+            0x02 => Some(Self::DrawRect),
+            0x03 => Some(Self::DrawText),
+            0x04 => Some(Self::DrawTexture),
+            _ => None,
+        }
+    }
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct CommandHeader {
+    pub opcode: u8,
+    pub payload_len: u16,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DrawRectCmd {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub color_rgba: u32,
+    pub corner_radius: u16,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DrawTextureCmd {
+    pub texture_id: u32,
+    pub dest_x: i32,
+    pub dest_y: i32,
+    pub dest_width: u32,
+    pub dest_height: u32,
+    pub src_x: u32,
+    pub src_y: u32,
+    pub opacity: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct SetClipRectCmd {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Fixed prefix of a `DrawText` payload. The variable tail is the UTF-8
+/// bytes; total length is `core::mem::size_of::<DrawTextHeader>() + bytes_len`,
+/// which is what `payload_len` in the outer `CommandHeader` reports.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DrawTextHeader {
+    pub x: i32,
+    pub y: i32,
+    pub color_rgba: u32,
+    pub font_size: u16,
+    pub bytes_len: u16,
+}
+
+// ── Builder ────────────────────────────────────────────────────────────
+
+/// Builder that accumulates display-list bytes into a heap buffer, ready to
+/// be `push`-ed onto an `IpcGraphicsRing` in one shot. Heap-backed because
+/// (1) we don't know the final size up front, and (2) keeping it heap-side
+/// means the producer doesn't have to interleave atomics into its render
+/// loop. One memcpy at the end is the price.
+pub struct DisplayListBuilder {
+    buf: Vec<u8>,
+}
+
+impl Default for DisplayListBuilder {
+    fn default() -> Self { Self::new() }
+}
+
+impl DisplayListBuilder {
+    pub fn new() -> Self {
+        // 2 KiB is enough for ~30 typical commands; grows if needed.
+        Self { buf: Vec::with_capacity(2048) }
+    }
+
+    pub fn with_capacity(n: usize) -> Self {
+        Self { buf: Vec::with_capacity(n) }
+    }
+
+    /// Bytes pending serialization.
+    pub fn len(&self) -> usize { self.buf.len() }
+    pub fn is_empty(&self) -> bool { self.buf.is_empty() }
+    pub fn as_slice(&self) -> &[u8] { &self.buf }
+
+    fn write_header(&mut self, opcode: CommandOpCode, payload_len: u16) {
+        self.buf.push(opcode as u8);
+        self.buf.extend_from_slice(&payload_len.to_le_bytes());
+    }
+
+    fn write_struct<T: Copy>(&mut self, value: &T) {
+        // SAFETY: `T: Copy` guarantees no destructor, and we treat the bytes
+        // as opaque. All consumers of the wire format must use the same
+        // `repr(C, packed)` structs.
+        let bytes = unsafe {
+            core::slice::from_raw_parts(
+                value as *const T as *const u8,
+                core::mem::size_of::<T>(),
+            )
+        };
+        self.buf.extend_from_slice(bytes);
+    }
+
+    pub fn draw_rect(&mut self, cmd: DrawRectCmd) -> &mut Self {
+        self.write_header(CommandOpCode::DrawRect, core::mem::size_of::<DrawRectCmd>() as u16);
+        self.write_struct(&cmd);
+        self
+    }
+
+    pub fn set_clip_rect(&mut self, cmd: SetClipRectCmd) -> &mut Self {
+        self.write_header(CommandOpCode::SetClipRect, core::mem::size_of::<SetClipRectCmd>() as u16);
+        self.write_struct(&cmd);
+        self
+    }
+
+    pub fn draw_texture(&mut self, cmd: DrawTextureCmd) -> &mut Self {
+        self.write_header(CommandOpCode::DrawTexture, core::mem::size_of::<DrawTextureCmd>() as u16);
+        self.write_struct(&cmd);
+        self
+    }
+
+    pub fn draw_text(&mut self, x: i32, y: i32, color_rgba: u32, font_size: u16, text: &str) -> &mut Self {
+        let header = DrawTextHeader {
+            x, y, color_rgba, font_size,
+            bytes_len: text.len() as u16,
+        };
+        let payload = core::mem::size_of::<DrawTextHeader>() + text.len();
+        self.write_header(CommandOpCode::DrawText, payload as u16);
+        self.write_struct(&header);
+        self.buf.extend_from_slice(text.as_bytes());
+        self
+    }
+
+    /// Finalize with a `Sync` marker. The compositor uses this as the
+    /// frame boundary — everything before it is in this frame, everything
+    /// after starts the next frame.
+    pub fn end_frame(&mut self) -> &mut Self {
+        self.write_header(CommandOpCode::Sync, 0);
+        self
+    }
+
+    /// Reset the builder to empty without freeing the backing buffer.
+    /// Useful when the same builder is reused frame-to-frame.
+    pub fn clear(&mut self) {
+        self.buf.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_size_is_three() {
+        // Important: the wire format encodes header as 3 bytes (1+2). If
+        // someone adds a field, the parser breaks silently. This is a
+        // tripwire.
+        assert_eq!(core::mem::size_of::<CommandHeader>(), 3);
+    }
+
+    #[test]
+    fn build_and_walk_one_rect() {
+        let mut b = DisplayListBuilder::new();
+        b.draw_rect(DrawRectCmd {
+            x: 10, y: 20, width: 100, height: 50,
+            color_rgba: 0xFF_AA_22_11,
+            corner_radius: 4,
+        });
+        b.end_frame();
+
+        let bytes = b.as_slice();
+        assert_eq!(bytes[0], CommandOpCode::DrawRect as u8);
+        let payload_len = u16::from_le_bytes([bytes[1], bytes[2]]);
+        assert_eq!(payload_len as usize, core::mem::size_of::<DrawRectCmd>());
+
+        // Last 3 bytes should be the Sync header.
+        let n = bytes.len();
+        assert_eq!(bytes[n - 3], CommandOpCode::Sync as u8);
+        assert_eq!(bytes[n - 2], 0);
+        assert_eq!(bytes[n - 1], 0);
+    }
+
+    #[test]
+    fn variable_text_payload() {
+        let mut b = DisplayListBuilder::new();
+        b.draw_text(0, 0, 0xFFFFFFFF, 14, "hi");
+        let bytes = b.as_slice();
+        assert_eq!(bytes[0], CommandOpCode::DrawText as u8);
+        let payload_len = u16::from_le_bytes([bytes[1], bytes[2]]) as usize;
+        assert_eq!(payload_len, core::mem::size_of::<DrawTextHeader>() + 2);
+    }
+}

--- a/userspace/libfolk/src/gfx/mod.rs
+++ b/userspace/libfolk/src/gfx/mod.rs
@@ -1,0 +1,24 @@
+//! Zero-copy graphics IPC: SPSC ring + display-list opcodes.
+//!
+//! This is the producer side of the rapport's Del 1 design — apps build a
+//! display list of `[CommandHeader | payload]` records and shove it into a
+//! shared-memory ring. The compositor is the consumer; it lives in
+//! `userspace/compositor/src/gfx_consumer.rs`.
+//!
+//! The ring is `Single-Producer Single-Consumer`. There's exactly one
+//! producer (the app) and one consumer (the compositor) per ring; serializing
+//! across producers is *not* supported and would require a different design.
+//!
+//! Memory ordering is the standard SPSC pattern: producer reads its own
+//! `head` Relaxed, reads `tail` Acquire, writes payload bytes, stores `head`
+//! Release. The consumer does the mirror image. No locks anywhere.
+
+pub mod ring;
+pub mod display_list;
+
+pub use ring::{IpcGraphicsRing, RING_CAPACITY_BYTES, PushError};
+pub use display_list::{
+    CommandOpCode, CommandHeader,
+    DrawRectCmd, DrawTextureCmd, SetClipRectCmd,
+    DisplayListBuilder,
+};

--- a/userspace/libfolk/src/gfx/ring.rs
+++ b/userspace/libfolk/src/gfx/ring.rs
@@ -1,0 +1,244 @@
+//! Lock-free SPSC byte ring for IPC display lists.
+//!
+//! Producer (app) and consumer (compositor) each see the same backing region
+//! mapped at different virtual addresses. Head/tail are atomic counters
+//! padded to separate cache lines so producer/consumer updates don't trigger
+//! false sharing on x86_64 (64-byte cache lines).
+//!
+//! ## Layout
+//!
+//! ```text
+//! offset   field
+//! ------   ----------------------------------------
+//! 0        head: AtomicUsize    (producer-owned)
+//! 8        _pad1: [u8; 56]      (cache-line padding)
+//! 64       tail: AtomicUsize    (consumer-owned)
+//! 72       _pad2: [u8; 56]      (cache-line padding)
+//! 128      buffer: [u8; CAPACITY]
+//! ```
+//!
+//! Both `head` and `tail` are byte indices into `buffer`, monotonically
+//! increasing. A reader/writer wraps with `idx % CAPACITY` when accessing
+//! the underlying buffer. CAPACITY must be a power of two so the wrap is a
+//! cheap mask, but we use `%` here for clarity — any reasonable optimizer
+//! turns it into the mask form for power-of-two constants.
+
+use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+/// Capacity in bytes. 64 KiB is enough for several frames worth of display
+/// lists at typical UI complexity (~1-2 KiB/frame). Power of two so the
+/// modulo turns into a mask. Must match what the compositor maps.
+pub const RING_CAPACITY_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushError {
+    /// Consumer hasn't drained enough room for this list. Caller should drop
+    /// the frame or retry next tick — never spin: that'd starve the consumer.
+    Full,
+    /// Display list exceeds total ring capacity. Caller bug.
+    TooLarge,
+}
+
+/// Backing layout for the shared ring. The producer constructs an
+/// `IpcGraphicsRing<RING_CAPACITY_BYTES>` over the shared region; the
+/// consumer constructs the same type over its mapping of the same pages.
+///
+/// `Send`/`Sync` are *not* derived because the type contains an
+/// `UnsafeCell`. Callers are responsible for ensuring exactly one producer
+/// and exactly one consumer touch the ring.
+#[repr(C, align(64))]
+pub struct IpcGraphicsRing<const N: usize> {
+    pub head: AtomicUsize,
+    _pad1: [u8; 56],
+    pub tail: AtomicUsize,
+    _pad2: [u8; 56],
+    buffer: UnsafeCell<[u8; N]>,
+}
+
+// SAFETY: the type is designed to be shared across producer/consumer
+// processes via shmem. The synchronization is the SPSC discipline, not Rust's
+// borrow checker — it's the caller's job to enforce single-producer
+// single-consumer.
+unsafe impl<const N: usize> Sync for IpcGraphicsRing<N> {}
+
+impl<const N: usize> IpcGraphicsRing<N> {
+    /// Initialize an empty ring in place. Called once by the kernel-side
+    /// allocator (or in tests) on freshly-zeroed memory.
+    pub const fn new() -> Self {
+        Self {
+            head: AtomicUsize::new(0),
+            _pad1: [0; 56],
+            tail: AtomicUsize::new(0),
+            _pad2: [0; 56],
+            buffer: UnsafeCell::new([0; N]),
+        }
+    }
+
+    /// Bytes currently in the ring (producer view).
+    #[inline]
+    pub fn occupied(&self) -> usize {
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Acquire);
+        head.wrapping_sub(tail)
+    }
+
+    /// Bytes the producer can push without blocking.
+    #[inline]
+    pub fn capacity_remaining(&self) -> usize {
+        N - self.occupied()
+    }
+
+    /// Producer: append `data` to the ring. Returns `Err(Full)` if the
+    /// consumer hasn't drained enough room. The write happens with two
+    /// `copy_nonoverlapping`s when the slice straddles the wrap point.
+    pub fn push(&self, data: &[u8]) -> Result<(), PushError> {
+        if data.len() > N {
+            return Err(PushError::TooLarge);
+        }
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Acquire);
+        let occupied = head.wrapping_sub(tail);
+        if occupied + data.len() > N {
+            return Err(PushError::Full);
+        }
+
+        let buf_ptr = self.buffer.get() as *mut u8;
+        let write_off = head % N;
+        let first = core::cmp::min(data.len(), N - write_off);
+
+        // SAFETY: `write_off + first <= N` and `data.len() - first <= write_off`.
+        // The wrap-second case writes at offset 0, well inside `buffer`.
+        unsafe {
+            core::ptr::copy_nonoverlapping(data.as_ptr(), buf_ptr.add(write_off), first);
+            if first < data.len() {
+                core::ptr::copy_nonoverlapping(
+                    data.as_ptr().add(first),
+                    buf_ptr,
+                    data.len() - first,
+                );
+            }
+        }
+
+        // Release: consumer's Acquire-load of `head` will see all the bytes
+        // we just wrote.
+        self.head.store(head.wrapping_add(data.len()), Ordering::Release);
+        Ok(())
+    }
+
+    /// Consumer: copy at most `out.len()` bytes from the ring into `out` and
+    /// advance `tail`. Returns the number of bytes consumed. This is
+    /// destructive — bytes are released back to the producer.
+    pub fn pop_into(&self, out: &mut [u8]) -> usize {
+        let tail = self.tail.load(Ordering::Relaxed);
+        let head = self.head.load(Ordering::Acquire);
+        let avail = head.wrapping_sub(tail);
+        let n = core::cmp::min(avail, out.len());
+        if n == 0 {
+            return 0;
+        }
+
+        let buf_ptr = self.buffer.get() as *const u8;
+        let read_off = tail % N;
+        let first = core::cmp::min(n, N - read_off);
+
+        // SAFETY: same bounds analysis as `push`. `read_off + first <= N`.
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf_ptr.add(read_off), out.as_mut_ptr(), first);
+            if first < n {
+                core::ptr::copy_nonoverlapping(buf_ptr, out.as_mut_ptr().add(first), n - first);
+            }
+        }
+
+        self.tail.store(tail.wrapping_add(n), Ordering::Release);
+        n
+    }
+
+    /// Consumer: peek the next `out.len()` bytes without advancing `tail`.
+    /// Useful for parsing variable-length records where we need to look at a
+    /// header to decide how many bytes to consume.
+    pub fn peek(&self, out: &mut [u8]) -> usize {
+        let tail = self.tail.load(Ordering::Relaxed);
+        let head = self.head.load(Ordering::Acquire);
+        let avail = head.wrapping_sub(tail);
+        let n = core::cmp::min(avail, out.len());
+        if n == 0 {
+            return 0;
+        }
+
+        let buf_ptr = self.buffer.get() as *const u8;
+        let read_off = tail % N;
+        let first = core::cmp::min(n, N - read_off);
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf_ptr.add(read_off), out.as_mut_ptr(), first);
+            if first < n {
+                core::ptr::copy_nonoverlapping(buf_ptr, out.as_mut_ptr().add(first), n - first);
+            }
+        }
+        n
+    }
+
+    /// Consumer: drop `n` bytes from the front of the ring. Pairs with
+    /// `peek` for the read-then-commit pattern.
+    pub fn drop_n(&self, n: usize) {
+        let tail = self.tail.load(Ordering::Relaxed);
+        self.tail.store(tail.wrapping_add(n), Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_then_pop_roundtrip() {
+        let ring: IpcGraphicsRing<128> = IpcGraphicsRing::new();
+        let data = [1u8, 2, 3, 4, 5];
+        ring.push(&data).unwrap();
+        let mut out = [0u8; 5];
+        assert_eq!(ring.pop_into(&mut out), 5);
+        assert_eq!(out, data);
+        assert_eq!(ring.occupied(), 0);
+    }
+
+    #[test]
+    fn push_full_returns_err() {
+        let ring: IpcGraphicsRing<8> = IpcGraphicsRing::new();
+        ring.push(&[0u8; 6]).unwrap();
+        assert_eq!(ring.push(&[7u8; 4]), Err(PushError::Full));
+    }
+
+    #[test]
+    fn wrap_works() {
+        let ring: IpcGraphicsRing<8> = IpcGraphicsRing::new();
+        ring.push(&[1, 2, 3, 4, 5, 6]).unwrap();
+        let mut out = [0u8; 5];
+        assert_eq!(ring.pop_into(&mut out), 5); // tail = 5
+        ring.push(&[7, 8, 9, 10, 11]).unwrap();   // wraps: 3 bytes after offset 6, then 2 at offset 0
+        let mut out2 = [0u8; 6];
+        assert_eq!(ring.pop_into(&mut out2), 6);
+        assert_eq!(&out2, &[6, 7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn peek_does_not_advance() {
+        let ring: IpcGraphicsRing<32> = IpcGraphicsRing::new();
+        ring.push(&[1, 2, 3, 4]).unwrap();
+        let mut p = [0u8; 2];
+        assert_eq!(ring.peek(&mut p), 2);
+        assert_eq!(&p, &[1, 2]);
+        assert_eq!(ring.occupied(), 4);
+        ring.drop_n(2);
+        let mut rest = [0u8; 2];
+        ring.pop_into(&mut rest);
+        assert_eq!(&rest, &[3, 4]);
+    }
+
+    #[test]
+    fn rejects_too_large() {
+        let ring: IpcGraphicsRing<8> = IpcGraphicsRing::new();
+        let big = [0u8; 9];
+        assert_eq!(ring.push(&big), Err(PushError::TooLarge));
+    }
+}

--- a/userspace/libfolk/src/lib.rs
+++ b/userspace/libfolk/src/lib.rs
@@ -37,6 +37,7 @@
 #![no_std]
 
 pub mod entry;
+pub mod gfx;
 pub mod syscall;
 pub mod fmt;
 pub mod sys;


### PR DESCRIPTION
## Summary
Second PR from the rapport — **Del 1: IPC Display Lists & Compositor Arkitektur**. Producer-side library: lock-free SPSC byte ring + binary display-list opcodes (\`Sync\`, \`SetClipRect\`, \`DrawRect\`, \`DrawText\`, \`DrawTexture\`).

## What's in
- \`libfolk::gfx::IpcGraphicsRing<N>\` — cache-line-padded \`head\`/\`tail\` (64-byte alignment, 56-byte padding between atomics) so producer and consumer don't false-share on x86_64.
- Acquire/Release ordering matches the rapport's described pattern.
- \`DisplayListBuilder\` — heap-backed builder that writes the packed wire format byte-for-byte, ready for one \`push()\` onto the ring.
- Tripwire test: \`size_of::<CommandHeader>() == 3\` (silent breakage if anyone adds a header field).

## What's NOT in (separate follow-ups)
- **Kernel-side shmem grant** — syscall to allocate the ring's pages and map them into both the app and the compositor. Needs a small API design first.
- **Compositor consumer** — parser + per-opcode dispatcher into the existing render path.
- **Migration** — no existing path is ported; current FKUI binary wire format keeps working.

## Why split this from the kernel work
The library half is fully usable in unit-test form (host-target build) and decouples wire-format review from the kernel API. Once this is in, the kernel/compositor halves can land independently without touching the format.

## Test notes
\`#[cfg(test)] mod tests\` consistent with the existing 141-test userspace pattern. They don't run under \`cargo test\` due to the custom no_std target (see memory note \`folkering-userspace-test-arch.md\`). \`cargo check\` passes; tests compile against the no_std target as a shape check.

## Test plan
- [ ] Round-trip a builder → ring → parse path locally
- [ ] Confirm no userspace builds break (libfolk is widely consumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)