### PR TITLE
feat(compositor): MinimalRenderGraph + front-to-back occlusion (Del 2)

### DIFF
--- a/userspace/compositor/src/lib.rs
+++ b/userspace/compositor/src/lib.rs
@@ -53,6 +53,7 @@
 // Graphics modules (Phase 6.2)
 pub mod blend;
 pub mod damage;
+pub mod render_graph;
 pub mod framebuffer;
 pub mod font;
 pub mod intent;

--- a/userspace/compositor/src/render_graph/graph.rs
+++ b/userspace/compositor/src/render_graph/graph.rs
@@ -1,0 +1,246 @@
+//! Core Render Graph data types.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// Signed rectangle so a node can sit (partially) off-screen without
+/// distorting bounding-box math.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Rect {
+    pub const fn new(x: i32, y: i32, w: u32, h: u32) -> Self {
+        Self { x, y, w, h }
+    }
+
+    /// Right edge (exclusive) as i64 to avoid overflow at INT_MAX edges.
+    #[inline]
+    pub fn right(&self) -> i64 { self.x as i64 + self.w as i64 }
+    #[inline]
+    pub fn bottom(&self) -> i64 { self.y as i64 + self.h as i64 }
+
+    /// AABB intersection.
+    #[inline]
+    pub fn overlaps(&self, other: &Rect) -> bool {
+        (self.x as i64) < other.right()
+            && self.right() > other.x as i64
+            && (self.y as i64) < other.bottom()
+            && self.bottom() > other.y as i64
+    }
+
+    /// `self` fully covers `inner` (boundary inclusive).
+    #[inline]
+    pub fn contains(&self, inner: &Rect) -> bool {
+        self.x as i64 <= inner.x as i64
+            && self.y as i64 <= inner.y as i64
+            && self.right() >= inner.right()
+            && self.bottom() >= inner.bottom()
+    }
+
+    /// Geometric union — smallest rect that covers both.
+    pub fn union(&self, other: &Rect) -> Rect {
+        let x = core::cmp::min(self.x, other.x);
+        let y = core::cmp::min(self.y, other.y);
+        let r = core::cmp::max(self.right(), other.right());
+        let b = core::cmp::max(self.bottom(), other.bottom());
+        Rect {
+            x, y,
+            w: (r - x as i64) as u32,
+            h: (b - y as i64) as u32,
+        }
+    }
+
+    /// Geometric intersection. `None` if disjoint.
+    pub fn intersection(&self, other: &Rect) -> Option<Rect> {
+        if !self.overlaps(other) { return None; }
+        let x = core::cmp::max(self.x, other.x);
+        let y = core::cmp::max(self.y, other.y);
+        let r = core::cmp::min(self.right(), other.right());
+        let b = core::cmp::min(self.bottom(), other.bottom());
+        Some(Rect {
+            x, y,
+            w: (r - x as i64) as u32,
+            h: (b - y as i64) as u32,
+        })
+    }
+
+    #[inline]
+    pub fn area(&self) -> u64 {
+        self.w as u64 * self.h as u64
+    }
+}
+
+/// Stable, lightweight handle for a node inside one graph. Becomes
+/// invalid as soon as the graph is rebuilt for the next frame — that's
+/// fine, we don't store these across frames.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeId(pub u32);
+
+/// One window / overlay / fullscreen-app surface.
+///
+/// `display_list` is intentionally `Vec<u8>` rather than parsed into
+/// commands here — the consumer side of `libfolk::gfx` walks it lazily.
+/// Keeping it bytes means `RenderNode` is `Clone` and cheap to move
+/// between graph-build and graph-consume passes.
+#[derive(Clone, Debug)]
+pub struct RenderNode {
+    /// Identifier of the producing process. Diagnostic only — graph
+    /// logic doesn't depend on it.
+    pub process_id: u32,
+    /// Higher z is closer to the user. Topo sort is stable on equal z.
+    pub z_index: i32,
+    /// World-space bounds. Used for occlusion + damage.
+    pub global_bounds: Rect,
+    /// Display-list bytes (the rapport's Del 1 wire format).
+    pub display_list: Vec<u8>,
+    /// `true` if `display_list` changed since last frame. Drives damage.
+    pub is_dirty: bool,
+    /// Whether the surface is opaque. Only opaque nodes count toward
+    /// occluding lower z's.
+    pub is_opaque: bool,
+    /// Set by `compute_occlusion` when something fully on top. The
+    /// renderer skips fully occluded nodes' display lists outright.
+    pub is_occluded: bool,
+    /// Clip rects injected by partial-occlusion handling. Renderer
+    /// must scissor every command in `display_list` against this list.
+    /// Empty means "no clip" (full bounds visible).
+    pub clip_regions: Vec<Rect>,
+}
+
+impl RenderNode {
+    pub fn new_opaque(process_id: u32, z_index: i32, bounds: Rect, display_list: Vec<u8>) -> Self {
+        Self {
+            process_id, z_index, global_bounds: bounds, display_list,
+            is_dirty: true, is_opaque: true, is_occluded: false,
+            clip_regions: Vec::new(),
+        }
+    }
+
+    pub fn new_translucent(process_id: u32, z_index: i32, bounds: Rect, display_list: Vec<u8>) -> Self {
+        Self {
+            process_id, z_index, global_bounds: bounds, display_list,
+            is_dirty: true, is_opaque: false, is_occluded: false,
+            clip_regions: Vec::new(),
+        }
+    }
+}
+
+/// Per-frame graph. Rebuilt from scratch each frame; the heap
+/// allocations happen once, the contents churn, the `Vec` capacity
+/// stays warm so repeated frames are alloc-light.
+pub struct MinimalRenderGraph {
+    pub nodes: Vec<RenderNode>,
+    /// Damage rects accumulated by the most recent occlusion + dirty
+    /// pass. In screen-clipped coords.
+    pub damage_regions: Vec<Rect>,
+    pub screen_width: u32,
+    pub screen_height: u32,
+}
+
+impl MinimalRenderGraph {
+    pub fn new(screen_width: u32, screen_height: u32) -> Self {
+        Self {
+            nodes: Vec::with_capacity(16),
+            damage_regions: Vec::with_capacity(16),
+            screen_width, screen_height,
+        }
+    }
+
+    /// Reset for a new frame without dropping the backing Vecs.
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+        self.damage_regions.clear();
+    }
+
+    pub fn add_node(&mut self, node: RenderNode) -> NodeId {
+        let id = NodeId(self.nodes.len() as u32);
+        self.nodes.push(node);
+        id
+    }
+
+    /// Stable topological sort by z_index ascending (back-to-front, the
+    /// painter's algorithm order). For occlusion we iterate the reverse.
+    pub fn sort_by_z(&mut self) {
+        // `sort_by_key` is a stable sort — equal z_index keeps insertion
+        // order, which the renderer relies on for sub-stages of the same
+        // window stack.
+        self.nodes.sort_by_key(|n| n.z_index);
+    }
+
+    /// Whole screen as a damage rect — useful when a global state change
+    /// (e.g. wallpaper swap) invalidates everything.
+    pub fn screen_rect(&self) -> Rect {
+        Rect::new(0, 0, self.screen_width, self.screen_height)
+    }
+
+    /// Clip a node-space rect to the visible screen. Returns `None` if
+    /// the rect is entirely off-screen.
+    pub fn clip_to_screen(&self, r: Rect) -> Option<Rect> {
+        let screen = self.screen_rect();
+        r.intersection(&screen)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rect_overlap_and_contains() {
+        let outer = Rect::new(0, 0, 100, 100);
+        let inside = Rect::new(10, 10, 50, 50);
+        let crossing = Rect::new(50, 50, 100, 100);
+        let outside = Rect::new(200, 200, 10, 10);
+
+        assert!(outer.overlaps(&inside));
+        assert!(outer.contains(&inside));
+
+        assert!(outer.overlaps(&crossing));
+        assert!(!outer.contains(&crossing));
+
+        assert!(!outer.overlaps(&outside));
+    }
+
+    #[test]
+    fn rect_intersection_basic() {
+        let a = Rect::new(0, 0, 100, 100);
+        let b = Rect::new(50, 50, 100, 100);
+        let i = a.intersection(&b).unwrap();
+        assert_eq!(i, Rect::new(50, 50, 50, 50));
+    }
+
+    #[test]
+    fn rect_intersection_disjoint() {
+        let a = Rect::new(0, 0, 10, 10);
+        let b = Rect::new(20, 20, 10, 10);
+        assert_eq!(a.intersection(&b), None);
+    }
+
+    #[test]
+    fn rect_with_negative_origin() {
+        // Window dragged partly off the left edge.
+        let off_left = Rect::new(-50, 0, 100, 100);
+        let screen = Rect::new(0, 0, 1024, 768);
+        let clipped = screen.intersection(&off_left).unwrap();
+        assert_eq!(clipped, Rect::new(0, 0, 50, 100));
+    }
+
+    #[test]
+    fn graph_topo_sort_is_stable() {
+        let mut g = MinimalRenderGraph::new(800, 600);
+        let dl = alloc::vec::Vec::new();
+        g.add_node(RenderNode::new_opaque(1, 5, Rect::new(0,0,10,10), dl.clone()));
+        g.add_node(RenderNode::new_opaque(2, 5, Rect::new(0,0,10,10), dl.clone()));
+        g.add_node(RenderNode::new_opaque(3, 1, Rect::new(0,0,10,10), dl));
+        g.sort_by_z();
+        // process 3 (z=1) first; then 1 and 2 in original order (stable).
+        assert_eq!(g.nodes[0].process_id, 3);
+        assert_eq!(g.nodes[1].process_id, 1);
+        assert_eq!(g.nodes[2].process_id, 2);
+    }
+}

--- a/userspace/compositor/src/render_graph/mod.rs
+++ b/userspace/compositor/src/render_graph/mod.rs
@@ -1,0 +1,35 @@
+//! Render Graph (Del 2 of the architecture rapport).
+//!
+//! Today the compositor is "immediate-mode": each stage of `render_frame()`
+//! draws straight into the shadow buffer in a fixed sequence. That works,
+//! but it can't make global decisions like "Node B is fully covered by
+//! Node A, skip drawing it" or "these two damaged regions are close enough
+//! that one larger flush is cheaper than two".
+//!
+//! This module is the *data layer* for moving toward a Render Graph: a
+//! lightweight DAG of `RenderNode`s with z-indexed sorting, front-to-back
+//! occlusion culling, partial-occlusion clip-rect injection, and
+//! coalesced damage extraction. It deliberately doesn't touch the active
+//! render pipeline — it's added as a peer of `damage.rs` so callers can
+//! adopt it incrementally. Once render stages emit nodes instead of
+//! drawing directly, this becomes the orchestration core.
+//!
+//! Design notes:
+//! - `Vec<RenderNode>` is the storage. Cache-friendly, predictable,
+//!   freed in one shot per frame (arena-style without bringing in an
+//!   actual arena allocator yet).
+//! - All geometry is `i32` for coords and `u32` for sizes — no floating
+//!   point in the kernel-side path.
+//! - Bounding-box arithmetic is exposed via `Rect` here even though
+//!   `damage::Rect` already exists; we use a slightly different shape
+//!   (`i32` x/y) to handle nodes that conceptually sit at negative
+//!   coordinates (e.g. partially off-screen windows). Conversion to
+//!   `damage::Rect` happens at the screen boundary.
+
+extern crate alloc;
+
+pub mod graph;
+pub mod occlusion;
+
+pub use graph::{Rect, RenderNode, MinimalRenderGraph, NodeId};
+pub use occlusion::{compute_occlusion, OcclusionStats};

--- a/userspace/compositor/src/render_graph/occlusion.rs
+++ b/userspace/compositor/src/render_graph/occlusion.rs
@@ -1,0 +1,250 @@
+//! Front-to-back occlusion culling + damage extraction.
+//!
+//! After the graph is z-sorted, `compute_occlusion` walks nodes from
+//! highest z to lowest and decides:
+//!   * whether each lower-z opaque rect *fully covers* a candidate node
+//!     (then the candidate is `is_occluded = true` — its display list is
+//!     skipped entirely);
+//!   * whether the candidate is *partially* covered (then a clip-rect is
+//!     injected on top of `clip_regions` so the renderer scissors out the
+//!     hidden portion);
+//!   * which screen regions are dirty enough to need a flush this frame.
+//!
+//! The fully-covers test uses `Rect::contains`. Partial-coverage is more
+//! subtle: subtracting an axis-aligned rect from another can produce up
+//! to four output rects. We do the simple "intersection rect goes into
+//! `clip_regions`" form here and let the renderer handle the rest with
+//! the existing `damage::DamageTracker` — that keeps the algorithm
+//! simple while still producing correct visuals.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use super::graph::{MinimalRenderGraph, Rect, RenderNode};
+
+/// Simple counter struct so callers can report how many nodes the pass
+/// shaved off this frame. Useful for serial logs / TIMING output.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct OcclusionStats {
+    pub fully_occluded: u32,
+    pub partially_occluded: u32,
+    pub visible: u32,
+}
+
+/// Compute occlusion + accumulate damage for a graph that's already been
+/// `sort_by_z()`-ed. Idempotent — running it twice produces the same
+/// result.
+pub fn compute_occlusion(graph: &mut MinimalRenderGraph) -> OcclusionStats {
+    // Reset per-node occlusion state from any previous pass.
+    for n in graph.nodes.iter_mut() {
+        n.is_occluded = false;
+        n.clip_regions.clear();
+    }
+    graph.damage_regions.clear();
+
+    // Front-to-back walk: index the highest z first.
+    //
+    // For each node we look at every opaque node *above* it (higher z,
+    // i.e. later in the sorted Vec since sort is ascending) and check
+    // coverage. If any single one fully contains us → fully occluded.
+    // Otherwise we accumulate clip rects from each partial coverer.
+    let n_nodes = graph.nodes.len();
+    let mut stats = OcclusionStats::default();
+
+    for i in 0..n_nodes {
+        let bounds_i = graph.nodes[i].global_bounds;
+
+        // Skip nodes entirely off-screen — they contribute no damage and
+        // can't be occluded by anything visible.
+        let on_screen = match graph.clip_to_screen(bounds_i) {
+            Some(r) => r,
+            None => {
+                graph.nodes[i].is_occluded = true;
+                stats.fully_occluded += 1;
+                continue;
+            }
+        };
+
+        let mut fully_covered = false;
+        let mut partial_clips: Vec<Rect> = Vec::new();
+
+        for j in (i + 1)..n_nodes {
+            let above = &graph.nodes[j];
+            if !above.is_opaque { continue; }
+            let above_b = above.global_bounds;
+
+            if above_b.contains(&on_screen) {
+                fully_covered = true;
+                break;
+            }
+            // Partial: intersection rect is "what gets blocked", so we
+            // store it so the renderer can scissor it out. Equivalent
+            // formulations exist (subtract → up-to-4 visible rects); we
+            // pick the simpler "block list" representation for now.
+            if let Some(blocked) = on_screen.intersection(&above_b) {
+                partial_clips.push(blocked);
+            }
+        }
+
+        if fully_covered {
+            graph.nodes[i].is_occluded = true;
+            stats.fully_occluded += 1;
+            continue;
+        }
+
+        if !partial_clips.is_empty() {
+            graph.nodes[i].clip_regions = partial_clips;
+            stats.partially_occluded += 1;
+        } else {
+            stats.visible += 1;
+        }
+
+        // Every visible-or-partially-occluded *dirty* node contributes a
+        // damage rect. We use the on-screen-clipped bounds; the
+        // `DamageTracker` peer module will coalesce overlapping rects.
+        if graph.nodes[i].is_dirty {
+            graph.damage_regions.push(on_screen);
+        }
+    }
+
+    stats
+}
+
+/// Coalesce overlapping damage rects in place. Mirrors the shape of
+/// `damage::DamageTracker::add_damage` but operates on the graph's
+/// internal damage list. After this, callers can iterate
+/// `graph.damage_regions` to produce VirtIO-GPU flush commands.
+pub fn coalesce_damage(graph: &mut MinimalRenderGraph, max_rects: usize) {
+    if graph.damage_regions.len() <= 1 { return; }
+
+    // Repeatedly merge the first overlapping pair we find, until none
+    // overlap. O(n²) worst case but n is small (≤ MAX_RECTS in
+    // practice, otherwise we collapse).
+    'outer: loop {
+        for i in 0..graph.damage_regions.len() {
+            for j in (i + 1)..graph.damage_regions.len() {
+                let a = graph.damage_regions[i];
+                let b = graph.damage_regions[j];
+                if a.overlaps(&b) {
+                    let merged = a.union(&b);
+                    graph.damage_regions.swap_remove(j);
+                    graph.damage_regions[i] = merged;
+                    continue 'outer;
+                }
+            }
+        }
+        break;
+    }
+
+    // Safety clamp: if we still have too many disjoint rects, collapse
+    // to one bounding box. The heuristic mirrors `damage.rs`.
+    if graph.damage_regions.len() > max_rects {
+        let mut bb = graph.damage_regions[0];
+        for r in &graph.damage_regions[1..] {
+            bb = bb.union(r);
+        }
+        graph.damage_regions.clear();
+        graph.damage_regions.push(bb);
+    }
+}
+
+// Helpers for tests — kept in this module since `super::graph` declares
+// the test module privately.
+#[cfg(test)]
+fn make_node(z: i32, bounds: Rect, opaque: bool, dirty: bool) -> RenderNode {
+    let dl = Vec::new();
+    let mut n = if opaque {
+        RenderNode::new_opaque(0, z, bounds, dl)
+    } else {
+        RenderNode::new_translucent(0, z, bounds, dl)
+    };
+    n.is_dirty = dirty;
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::graph::MinimalRenderGraph;
+
+    #[test]
+    fn fully_covered_window_is_occluded() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        // Big background opaque, small foreground opaque covering it.
+        g.add_node(make_node(1, Rect::new(0, 0, 100, 100), true, true));
+        g.add_node(make_node(10, Rect::new(0, 0, 200, 200), true, true));
+        g.sort_by_z();
+        let stats = compute_occlusion(&mut g);
+        assert_eq!(stats.fully_occluded, 1);
+        assert!(g.nodes[0].is_occluded);
+        assert!(!g.nodes[1].is_occluded);
+    }
+
+    #[test]
+    fn partial_overlap_yields_clip_rect() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        // Lower window 0..100, upper window 50..150.
+        g.add_node(make_node(1, Rect::new(0, 0, 100, 100), true, true));
+        g.add_node(make_node(10, Rect::new(50, 0, 100, 100), true, true));
+        g.sort_by_z();
+        let stats = compute_occlusion(&mut g);
+        assert_eq!(stats.partially_occluded, 1);
+        // The lower-z node should have one clip rect = the overlap region.
+        assert_eq!(g.nodes[0].clip_regions.len(), 1);
+        assert_eq!(g.nodes[0].clip_regions[0], Rect::new(50, 0, 50, 100));
+    }
+
+    #[test]
+    fn translucent_top_does_not_occlude() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        g.add_node(make_node(1, Rect::new(0, 0, 100, 100), true, true));
+        g.add_node(make_node(10, Rect::new(0, 0, 200, 200), false, true));
+        g.sort_by_z();
+        let stats = compute_occlusion(&mut g);
+        assert_eq!(stats.fully_occluded, 0);
+        assert_eq!(stats.visible, 2);
+    }
+
+    #[test]
+    fn off_screen_node_is_culled() {
+        let mut g = MinimalRenderGraph::new(800, 600);
+        g.add_node(make_node(1, Rect::new(2000, 2000, 100, 100), true, true));
+        g.sort_by_z();
+        let stats = compute_occlusion(&mut g);
+        assert_eq!(stats.fully_occluded, 1);
+    }
+
+    #[test]
+    fn dirty_visible_nodes_emit_damage() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        g.add_node(make_node(1, Rect::new(0, 0, 50, 50), true, true));
+        g.add_node(make_node(2, Rect::new(100, 100, 50, 50), true, false));
+        g.sort_by_z();
+        compute_occlusion(&mut g);
+        // Only the dirty node should contribute damage.
+        assert_eq!(g.damage_regions.len(), 1);
+        assert_eq!(g.damage_regions[0], Rect::new(0, 0, 50, 50));
+    }
+
+    #[test]
+    fn coalesce_merges_adjacent_rects() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        g.damage_regions.push(Rect::new(0, 0, 50, 50));
+        g.damage_regions.push(Rect::new(40, 0, 50, 50));
+        g.damage_regions.push(Rect::new(500, 500, 10, 10));
+        coalesce_damage(&mut g, 10);
+        assert_eq!(g.damage_regions.len(), 2);
+    }
+
+    #[test]
+    fn coalesce_collapses_when_above_max() {
+        let mut g = MinimalRenderGraph::new(1024, 768);
+        for i in 0..15i32 {
+            // Strictly disjoint rects (gap of 5px between them).
+            g.damage_regions.push(Rect::new(i * 50, 0, 30, 10));
+        }
+        coalesce_damage(&mut g, 10);
+        // Above the cap → collapsed to one bounding box covering all.
+        assert_eq!(g.damage_regions.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
Third PR from the rapport — **Del 2: Minimalistisk Render Graph i Kjernerommet**. Adds the data layer for occlusion-aware compositing: \`RenderNode\`, \`MinimalRenderGraph\`, a front-to-back culling pass, and damage coalescing on the graph's own list.

Library-only this round — does NOT touch the existing imperative \`render_frame()\` pipeline.

## What's in
- \`compositor::render_graph::Rect\` — signed origin (\`i32\` x/y, \`u32\` w/h) so windows dragged partly off-screen survive bbox arithmetic.
- \`RenderNode\` — z_index, global_bounds, display-list bytes (the rapport's Del 1 wire format), \`is_dirty\` / \`is_opaque\` / \`is_occluded\` / \`clip_regions\`.
- \`MinimalRenderGraph\` — \`Vec<RenderNode>\` + damage list. Cleared per frame; \`Vec\` capacity stays warm so steady-state is alloc-light.
- \`compute_occlusion(graph)\` — walks \`i+1..N\` for each node:
  - any opaque node above that **fully contains** us → \`is_occluded = true\`, display list skipped entirely;
  - opaque nodes that **partially** overlap → intersection rect pushed onto our \`clip_regions\` (renderer scissors against this list);
  - dirty + visible-or-partially-occluded nodes → damage rect on \`graph.damage_regions\`.
- \`coalesce_damage(graph, max_rects)\` — overlap-merge with the same "collapse to bbox above MAX" heuristic \`damage.rs\` uses.

## What's NOT in this PR (intentional follow-ups)
- **Migration of \`render_frame()\` stages** to emit nodes instead of drawing directly. That's a sizeable refactor and deserves its own review.
- **Bridging into \`damage::DamageTracker\`** — the graph keeps a parallel list for now. They converge once render stages are on the graph.
- **Translucent-aware ordering tweaks** — current pass treats every above-z opaque rect as a potential occluder; non-opaque tops are correctly ignored, but multi-pass blending isn't yet expressed.

## Why incremental
Adding the data layer first lets Del 4 (\`libfolkui\`) consume graphs immediately — its \`UiDisplayCompiler\` will land display-list bytes onto these nodes — and lets per-stage migrations land as isolated PRs without merge churn.

## Test plan
- [ ] \`cargo check -p compositor\` passes (verified locally)
- [ ] \`compute_occlusion\` tests cover full-cover, partial-overlap, translucent-top, off-screen-cull, and dirty-emits-damage cases (visible in source under \`#[cfg(test)] mod tests\`)
- [ ] No regressions in current rendering — module is unused by the active pipeline this PR

## Test note
Tests live under \`#[cfg(test)] mod tests\` consistent with the existing 141-test userspace pattern. They don't run under \`cargo test\` due to the custom no_std target (see memory note \`folkering-userspace-test-arch.md\`); they compile cleanly against the no_std target as a shape check.

Reference: rapport Del 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)