### PR TITLE
fix(userspace): give shell + intent-service their own #[global_allocator]

### DIFF
--- a/userspace/intent-service/src/main.rs
+++ b/userspace/intent-service/src/main.rs
@@ -13,8 +13,51 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
+
 use libfolk::{entry, println};
 use libfolk::sys::{yield_cpu, get_pid};
+
+// ── Bump allocator ──────────────────────────────────────────────────
+//
+// Same rationale as `shell/src/main.rs`: libfolk pulled in alloc via
+// `gfx::DisplayListBuilder` in #112, so every linked binary must
+// supply a `#[global_allocator]`. Intent-service barely allocates
+// (one or two transient `Vec`s during query forwarding), so 32 KiB
+// is plenty.
+const HEAP_SIZE: usize = 32 * 1024;
+
+struct BumpAllocator {
+    heap: UnsafeCell<[u8; HEAP_SIZE]>,
+    offset: UnsafeCell<usize>,
+}
+
+unsafe impl Sync for BumpAllocator {}
+
+unsafe impl GlobalAlloc for BumpAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let offset = &mut *self.offset.get();
+        let align = layout.align();
+        let aligned = (*offset + align - 1) & !(align - 1);
+        let new_offset = aligned + layout.size();
+        if new_offset > HEAP_SIZE {
+            core::ptr::null_mut()
+        } else {
+            *offset = new_offset;
+            (*self.heap.get()).as_mut_ptr().add(aligned)
+        }
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static ALLOCATOR: BumpAllocator = BumpAllocator {
+    heap: UnsafeCell::new([0; HEAP_SIZE]),
+    offset: UnsafeCell::new(0),
+};
 use libfolk::sys::ipc::{recv_async, reply_with_token, CallerToken, AsyncIpcMessage};
 use libfolk::sys::intent::{
     INTENT_OP_REGISTER, INTENT_OP_SUBMIT, INTENT_OP_QUERY,

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -11,12 +11,57 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
+
 use libfolk::{entry, println};
 use libfolk::sys::ipc::{recv_async, reply_with_token, IpcError};
 use libfolk::sys::{get_pid, yield_cpu};
 
 use shell::input::print_prompt;
 use shell::ipc::handle_ipc_command;
+
+// ── Bump allocator ──────────────────────────────────────────────────
+//
+// libfolk grew an alloc-using module (`libfolk::gfx::DisplayListBuilder`)
+// in #112, which made every binary that links libfolk require a
+// `#[global_allocator]` even if the binary itself never touches it
+// directly. The other userspace bins (draug-daemon, draug-streamer,
+// inference-server, compositor) all use this same bump pattern; we
+// match it here. Heap is 32 KiB — shell allocates very little (one or
+// two transient `Vec`s during graph commands at most).
+const HEAP_SIZE: usize = 32 * 1024;
+
+struct BumpAllocator {
+    heap: UnsafeCell<[u8; HEAP_SIZE]>,
+    offset: UnsafeCell<usize>,
+}
+
+unsafe impl Sync for BumpAllocator {}
+
+unsafe impl GlobalAlloc for BumpAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let offset = &mut *self.offset.get();
+        let align = layout.align();
+        let aligned = (*offset + align - 1) & !(align - 1);
+        let new_offset = aligned + layout.size();
+        if new_offset > HEAP_SIZE {
+            core::ptr::null_mut()
+        } else {
+            *offset = new_offset;
+            (*self.heap.get()).as_mut_ptr().add(aligned)
+        }
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static ALLOCATOR: BumpAllocator = BumpAllocator {
+    heap: UnsafeCell::new([0; HEAP_SIZE]),
+    offset: UnsafeCell::new(0),
+};
 
 entry!(main);
 


### PR DESCRIPTION
## What broke
\`#112\` added \`libfolk::gfx::DisplayListBuilder\`, which uses \`alloc::Vec\`. Pulling alloc into libfolk made every binary that links libfolk require a \`#[global_allocator]\` — even ones that never touch the gfx module.

Two bins didn't have one — \`shell\` and \`intent-service\` — so \`cargo check --release\` started failing on main:

\`\`\`
error: no global memory allocator found but one is required;
link to std or add \`#[global_allocator]\` to a static item that
implements the GlobalAlloc trait
\`\`\`

This was masked by the libfolk-only PRs (#112, #114, #115) since their CI only checked the libfolk crate; the workspace-wide \`cargo check --release\` step in \`userspace-check\` is where it surfaced.

## Fix
Same bump-allocator pattern as \`draug-streamer\` / \`draug-daemon\` / \`inference-server\` / \`compositor\`. 32 KiB heap each (both bins allocate very little — transient \`Vec\`s during graph commands / intent forwarding).

## Verified locally
\`\`\`
$ cargo check --release   # workspace
    Finished \`release\` profile [optimized] target(s) in 1.44s
\`\`\`

## Test plan
- [ ] CI userspace-check passes
- [ ] Boot OS, confirm shell still responds to commands and intent-service still routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)