### PR TITLE
feat(compositor): drain gfx rings inside render_frame

### DIFF
--- a/userspace/compositor/src/gfx_rings.rs
+++ b/userspace/compositor/src/gfx_rings.rs
@@ -1,0 +1,205 @@
+//! Compositor-side registry of granted display-list rings.
+//!
+//! Apps create an `IpcGraphicsRing` via `libfolk::gfx::RingHandle::create_at`,
+//! grant the shmem id to the compositor, then send `MSG_GFX_REGISTER_RING`
+//! over IPC. This module owns the receiving side: `register()` mounts the
+//! ring at a stable virtual address derived from its slot index and stores
+//! the `MountedRing` so subsequent frames can drain it.
+//!
+//! Memory layout:
+//! - Up to `MAX_RINGS` (8) concurrent producers — small fixed cap so the
+//!   per-slot virtual addresses never collide. Adding a 9th producer
+//!   currently fails the registration; the agent retries next frame.
+//! - Each slot reserves a 1 MiB virtual address range starting at
+//!   `RING_BASE_VADDR + slot * RING_SLOT_STRIDE`. Today the ring uses
+//!   ~64 KiB; the over-provisioned stride leaves room for a future
+//!   `RING_CAPACITY_BYTES` bump without re-shuffling layouts.
+//! - Slots are recycled on `unregister`. We don't compact, so slot
+//!   indices stay stable for a producer's lifetime — useful for
+//!   diagnostic logs that reference a slot by id.
+//!
+//! What this module does NOT do (intentional):
+//! - Hook itself into `render_frame()`. `drain_all()` exists and works,
+//!   but the compositor's main loop doesn't call it yet — that's the
+//!   next PR. Library-only matches the pattern set by #112/#113/#116/#118.
+//! - Authenticate the producer. Any task that knows a granted shmem id
+//!   can register. The kernel's `shmem_grant` already gates who has
+//!   permission; this module trusts that.
+//! - Auto-reap dead producers. If an app crashes without unregistering,
+//!   its slot stays mounted until the compositor restarts. A periodic
+//!   liveness probe is a follow-up.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use libfolk::gfx::{mount_ring, MountedRing, RING_CAPACITY_BYTES};
+use libfolk::sys::memory::ShmemError;
+
+use crate::framebuffer::FramebufferView;
+use crate::gfx_dispatch::{dispatch_display_list, DispatchStats};
+use crate::gfx_consumer::ParseError;
+
+/// Maximum simultaneous graphics-ring producers. Eight is enough for
+/// "compositor + a handful of foreground apps"; multi-window agents
+/// can multiplex on a single ring per process.
+pub const MAX_RINGS: usize = 8;
+
+/// Base virtual address for ring mappings. Picked to stay clear of the
+/// app heap (low canonical-half) and the kernel mappings (high
+/// canonical-half). One day this gets formalized into a proper
+/// "graphics zone" so apps don't have to think about it.
+const RING_BASE_VADDR: usize = 0x6000_0000_0000;
+
+/// Stride per slot (1 MiB). Matches the page-size requirement from
+/// `shmem_map` and leaves headroom for a larger `RING_CAPACITY_BYTES`
+/// later without renumbering slots.
+const RING_SLOT_STRIDE: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistryError {
+    /// All slots in use. App should retry later or close existing rings.
+    NoSlotAvailable,
+    /// `shmem_map` rejected the address — usually a stale shmem id or
+    /// a producer that didn't `grant_to(compositor_task_id)` first.
+    MountFailed(ShmemError),
+}
+
+/// One registered ring with the slot index that owns its virtual
+/// address. We keep `Option` slots rather than `Vec` so an unregister
+/// in the middle doesn't invalidate later slot indices.
+struct Slot {
+    ring: MountedRing,
+    /// Pre-allocated scratch buffer the dispatcher pops into. Sized
+    /// to the ring's capacity so a single drain pass can consume an
+    /// entire wrap-around-full ring; smaller would force multiple
+    /// `pop_into → dispatch` rounds per frame.
+    scratch: Vec<u8>,
+}
+
+/// Process-global slot table. The compositor is single-threaded
+/// (cooperative scheduler within one task), so a `static mut` matches
+/// the existing pattern used by other compositor internals — pulling
+/// in `spin::Mutex` would be heavier than the contention warrants.
+/// All `unsafe` accesses are confined to the four functions below;
+/// callers see safe APIs.
+static mut SLOTS: [Option<Slot>; MAX_RINGS] = [const { None }; MAX_RINGS];
+
+/// Mount a granted shmem id as a graphics ring and remember it.
+/// Returns the slot index assigned. The producer keeps using its own
+/// `RingHandle::as_ring()`; this side reads through `MountedRing`.
+pub fn register(shmem_id: u32) -> Result<u32, RegistryError> {
+    // SAFETY: compositor is single-threaded; no other code accesses
+    // SLOTS concurrently with this call.
+    let slots: &mut [Option<Slot>; MAX_RINGS] = unsafe { &mut *core::ptr::addr_of_mut!(SLOTS) };
+
+    let slot_idx = match slots.iter().position(|s: &Option<Slot>| s.is_none()) {
+        Some(i) => i,
+        None => return Err(RegistryError::NoSlotAvailable),
+    };
+    let virt_addr = RING_BASE_VADDR + slot_idx * RING_SLOT_STRIDE;
+    let ring = mount_ring(shmem_id, virt_addr).map_err(RegistryError::MountFailed)?;
+
+    // Scratch is initialized to zeros once. We reuse the buffer across
+    // frames; the dispatcher only reads `pop_into`'s returned length.
+    let scratch = alloc::vec![0u8; RING_CAPACITY_BYTES];
+
+    slots[slot_idx] = Some(Slot { ring, scratch });
+    Ok(slot_idx as u32)
+}
+
+/// Drop a slot. Best-effort: failing to unmount is logged but not
+/// propagated (we still want to free the slot so a producer that
+/// re-registers gets one).
+pub fn unregister(slot: u32) -> Result<(), RegistryError> {
+    let i = slot as usize;
+    if i >= MAX_RINGS { return Err(RegistryError::NoSlotAvailable); }
+    // SAFETY: same as `register` — single-threaded.
+    let slots: &mut [Option<Slot>; MAX_RINGS] = unsafe { &mut *core::ptr::addr_of_mut!(SLOTS) };
+    if let Some(s) = slots[i].take() {
+        let _ = s.ring.unmount();
+    }
+    Ok(())
+}
+
+/// Return the total number of currently registered rings (diagnostic).
+pub fn count() -> usize {
+    // SAFETY: read-only borrow; single-threaded.
+    let slots: &[Option<Slot>; MAX_RINGS] = unsafe { &*core::ptr::addr_of!(SLOTS) };
+    slots.iter().filter(|s: &&Option<Slot>| s.is_some()).count()
+}
+
+/// Drain every registered ring and dispatch its display list against
+/// `fb`. Returns aggregate stats so callers can log per-frame
+/// throughput. A parse error on one ring is logged via stats and the
+/// ring continues — we don't abort the whole frame because one
+/// producer is broken.
+pub fn drain_all(fb: &mut FramebufferView) -> DrainStats {
+    // SAFETY: same as `register` — single-threaded.
+    let slots: &mut [Option<Slot>; MAX_RINGS] = unsafe { &mut *core::ptr::addr_of_mut!(SLOTS) };
+    let mut total = DrainStats::default();
+    for slot in slots.iter_mut() {
+        let s = match slot.as_mut() {
+            Some(s) => s,
+            None => continue,
+        };
+        let ring = s.ring.as_ring();
+        let n = ring.pop_into(&mut s.scratch);
+        if n == 0 { continue; }
+        match dispatch_display_list(&s.scratch[..n], fb) {
+            Ok((_consumed, ds)) => {
+                total.rings_drained += 1;
+                total.bytes += n as u32;
+                total.draw_rects += ds.draw_rects;
+                total.draw_texts += ds.draw_texts;
+                total.set_clips += ds.set_clips;
+                total.draw_textures_skipped += ds.draw_textures_skipped;
+                total.unknown_skipped += ds.unknown_skipped;
+            }
+            Err(e) => {
+                total.parse_errors += 1;
+                total.last_parse_error = Some(e);
+            }
+        }
+    }
+    total
+}
+
+/// Per-frame totals from `drain_all`.
+#[derive(Default, Clone, Debug)]
+pub struct DrainStats {
+    pub rings_drained: u32,
+    pub bytes: u32,
+    pub draw_rects: u32,
+    pub draw_texts: u32,
+    pub set_clips: u32,
+    pub draw_textures_skipped: u32,
+    pub unknown_skipped: u32,
+    pub parse_errors: u32,
+    pub last_parse_error: Option<ParseError>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_registry_count_is_zero() {
+        // Note: REGISTRY is process-global, so other tests may leave
+        // residue. We check a relative invariant rather than an
+        // absolute one.
+        let before = count();
+        // No registrations happened; count shouldn't grow.
+        assert_eq!(count(), before);
+    }
+
+    #[test]
+    fn unregister_invalid_slot_returns_err() {
+        let r = unregister(MAX_RINGS as u32 + 1);
+        assert_eq!(r, Err(RegistryError::NoSlotAvailable));
+    }
+
+    // We can't exercise `register` end-to-end in cfg(test) — it'd need
+    // a working `shmem_create + shmem_grant` pair, which means a live
+    // kernel. Coverage for the actual mount path is via the boot-time
+    // smoke test once an app drives a real ring.
+}

--- a/userspace/compositor/src/ipc_helpers.rs
+++ b/userspace/compositor/src/ipc_helpers.rs
@@ -17,6 +17,12 @@ pub const MSG_CLOSE: u64 = 0x03;
 pub const MSG_CREATE_UI_WINDOW: u64 = 0x06;
 pub const MSG_QUERY_NAME: u64 = 0x10;
 pub const MSG_QUERY_FOCUS: u64 = 0x11;
+/// Register a granted display-list ring. Request: opcode | (shmem_id << 8).
+/// Reply: slot index on success, u64::MAX on failure.
+pub const MSG_GFX_REGISTER_RING: u64 = 0x20;
+/// Unregister a previously registered ring. Request: opcode | (slot << 8).
+/// Reply: 0 on success, u64::MAX on failure.
+pub const MSG_GFX_UNREGISTER_RING: u64 = 0x21;
 
 /// Execute a tool call and write result back to TokenRing for AI feedback.
 /// Shows brief status in window; full result goes to ring for KV-cache injection.
@@ -351,6 +357,32 @@ pub fn handle_message(compositor: &mut Compositor, payload0: u64) -> u64 {
                     ((window_id as u64) << 32) | (node_id & 0xFFFF_FFFF)
                 }
                 None => u64::MAX
+            }
+        }
+
+        MSG_GFX_REGISTER_RING => {
+            // Payload: opcode (8) | shmem_id (32). Higher bits unused.
+            let shmem_id = ((payload0 >> 8) & 0xFFFF_FFFF) as u32;
+            match compositor::gfx_rings::register(shmem_id) {
+                Ok(slot) => {
+                    println!("[COMPOSITOR] Registered gfx ring shmem={} -> slot {}", shmem_id, slot);
+                    slot as u64
+                }
+                Err(e) => {
+                    println!("[COMPOSITOR] gfx ring register failed: {:?}", e);
+                    u64::MAX
+                }
+            }
+        }
+
+        MSG_GFX_UNREGISTER_RING => {
+            let slot = ((payload0 >> 8) & 0xFF) as u32;
+            match compositor::gfx_rings::unregister(slot) {
+                Ok(()) => {
+                    println!("[COMPOSITOR] Unregistered gfx ring slot {}", slot);
+                    0
+                }
+                Err(_) => u64::MAX,
             }
         }
 

--- a/userspace/compositor/src/lib.rs
+++ b/userspace/compositor/src/lib.rs
@@ -55,6 +55,7 @@ pub mod blend;
 pub mod damage;
 pub mod gfx_consumer;
 pub mod gfx_dispatch;
+pub mod gfx_rings;
 pub mod render_graph;
 pub mod framebuffer;
 pub mod font;

--- a/userspace/compositor/src/rendering/mod.rs
+++ b/userspace/compositor/src/rendering/mod.rs
@@ -137,6 +137,28 @@ pub fn render_frame(ctx: &mut RenderContext) -> RenderResult {
         statusbar::render_ram_graph(ctx);
     }
 
+    // Stage 5b — Drain all registered gfx rings.
+    //
+    // Apps that registered an IpcGraphicsRing via MSG_GFX_REGISTER_RING
+    // produce display-list bytes; we pop them, walk through gfx_consumer,
+    // and dispatch to fill_rect/draw_char primitives. Drains happen after
+    // the imperative stages so app surfaces land on top of the desktop
+    // chrome — matches the rapport's z-order intent (apps own foreground,
+    // statusbar is the only thing above them, handled at Stage 5).
+    {
+        let stats = compositor::gfx_rings::drain_all(ctx.fb);
+        if stats.rings_drained > 0 {
+            did_work = true;
+            // Damage rectangle: for now we mark a conservative fullscreen
+            // damage when any ring drains. Once ring consumers report
+            // their bounds (a follow-up), we replace this with a tighter
+            // union of per-ring bboxes.
+            ctx.damage.add_damage(compositor::damage::Rect::new(
+                0, 0, ctx.fb.width as u32, ctx.fb.height as u32,
+            ));
+        }
+    }
+
     // Stage 6 — Targeted damage tracking + cursor save
     statusbar::add_targeted_damage(ctx, wasm_fullscreen);
     if ctx.cursor_drawn {

--- a/userspace/libfolk/src/sys/compositor.rs
+++ b/userspace/libfolk/src/sys/compositor.rs
@@ -73,6 +73,16 @@ pub const COMP_OP_QUERY_NAME: u64 = 0x10;
 /// Reply: (window_id << 32) | node_id, or u64::MAX if no focus
 pub const COMP_OP_QUERY_FOCUS: u64 = 0x11;
 
+/// Register a granted graphics-ring shmem id with the compositor.
+/// Request: opcode | (shmem_id << 8)
+/// Reply: slot index on success, u64::MAX on failure.
+pub const COMP_OP_GFX_REGISTER_RING: u64 = 0x20;
+
+/// Unregister a previously registered ring slot.
+/// Request: opcode | (slot << 8)
+/// Reply: 0 on success, u64::MAX on failure.
+pub const COMP_OP_GFX_UNREGISTER_RING: u64 = 0x21;
+
 // ============================================================================
 // Error Types
 // ============================================================================
@@ -233,6 +243,48 @@ pub fn query_focus() -> Result<Option<(u64, u64)>, CompError> {
         let window_id = ret >> 32;
         let node_id = ret & 0xFFFF_FFFF;
         Ok(Some((node_id, window_id)))
+    }
+}
+
+// ============================================================================
+// Graphics-ring registration
+// ============================================================================
+
+/// Register a previously created+granted display-list ring with the
+/// compositor. Returns the slot index assigned.
+///
+/// Caller responsibilities (in order):
+/// 1. `RingHandle::create_at(virt)` — allocates the shmem region.
+/// 2. `handle.grant_to(COMPOSITOR_TASK_ID)` — gives compositor permission
+///    to map the same id.
+/// 3. Pass the resulting `handle.id` here.
+///
+/// The slot index is stable for the lifetime of the registration and
+/// can be passed to `unregister_gfx_ring` when the producer shuts down.
+pub fn register_gfx_ring(shmem_id: u32) -> Result<u32, CompError> {
+    let payload0 = (COMP_OP_GFX_REGISTER_RING & 0xFF)
+        | ((shmem_id as u64) << 8);
+    let ret = unsafe {
+        syscall3(SYS_IPC_SEND, COMPOSITOR_TASK_ID as u64, payload0, 0)
+    };
+    if ret == u64::MAX {
+        Err(CompError::ServiceUnavailable)
+    } else {
+        Ok(ret as u32)
+    }
+}
+
+/// Unregister a slot returned by `register_gfx_ring`.
+pub fn unregister_gfx_ring(slot: u32) -> Result<(), CompError> {
+    let payload0 = (COMP_OP_GFX_UNREGISTER_RING & 0xFF)
+        | ((slot as u64 & 0xFF) << 8);
+    let ret = unsafe {
+        syscall3(SYS_IPC_SEND, COMPOSITOR_TASK_ID as u64, payload0, 0)
+    };
+    if ret == u64::MAX {
+        Err(CompError::ServiceUnavailable)
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
Wires \`gfx_rings::drain_all()\` into \`render_frame()\`'s tail. Apps that register a ring via \`MSG_GFX_REGISTER_RING\` (#119) now actually contribute pixels to the shadow buffer once per frame.

> **Stacks on #119 (gfx_rings registry).** Branch already includes #119's commit.

## What changed
22 lines in \`rendering/mod.rs\`:
- Stage 5b inserted between the statusbar overlay stage and the cursor-save stage
- Calls \`drain_all()\`; if any ring drained, marks fullscreen damage so the next VirtIO-GPU flush carries the new pixels
- Sets \`did_work = true\` so the scheduler doesn't yield prematurely while a producer has work to do

## Damage marking
Conservative this PR: any frame that drains at least one ring marks the entire framebuffer as damaged. Tighter per-ring bboxes are a follow-up — the dispatcher doesn't yet report which rect each command touched. For the typical "one foreground app drives a window-sized ring" case, fullscreen damage is barely worse than tight tracking, and it's strictly safe.

## Closes the producer→consumer pipeline
After this lands, the rapport's full pipeline is end-to-end in code:

\`\`\`
app:  DSML → DOM → layout → DisplayListBuilder bytes
      → IpcGraphicsRing::push (libfolk::gfx)
      → register_gfx_ring IPC (libfolk::sys::compositor)
comp: drain_all() inside render_frame
      → gfx_consumer::Walker → gfx_dispatch::dispatch_display_list
      → fill_rect / draw_char on the shadow buffer
      → existing VirtIO-GPU flush path
\`\`\`

## What's NOT in this PR
- **End-to-end demo app** — separate PR. Today no app actually drives a ring, so \`drain_all()\` is a no-op until one shows up.
- **Per-ring damage bboxes** — see "Damage marking" above.

## Test plan
- [ ] \`cargo check --release\` (workspace) passes — verified locally, 0.65s
- [ ] Boot OS — confirm no regression in existing rendering (no app drives a ring yet, so \`drain_all\` should be a fast no-op every frame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)