### PR TITLE
fix(compositor): poll app IPC inside the graphics-mode main loop

### DIFF
--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -870,6 +870,22 @@ fn main() -> ! {
             if ai.need_redraw { need_redraw = true; }
         }
 
+        // ===== App IPC polling (MSG_CREATE_UI_WINDOW, MSG_GFX_REGISTER_RING,
+        // MSG_QUERY_NAME, MSG_QUERY_FOCUS, …) =====
+        // The graphics-mode main loop wasn't polling IPC from other tasks
+        // before — only `run_ipc_loop` (the no-graphics fallback) did.
+        // That's why apps blocked forever on `register_gfx_ring` (#119)
+        // and similar requests. Calling this every iteration drains one
+        // queued message per pass, which is enough since we don't expect
+        // a single app to flood the compositor.
+        {
+            let ipc = mcp_handler::tick_ipc_and_streaming(
+                &mut wm, &mut stream, &mut fb, &mut damage, &mut compositor,
+            );
+            if ipc.did_work { did_work = true; }
+            if ipc.need_redraw { need_redraw = true; }
+        }
+
         // GOD MODE: Poll COM3 for injected commands (moved to god_mode.rs)
         if god_mode::poll_com3(&mut com3_buf, &mut com3_len, &mut com3_queue) {
             did_work = true;


### PR DESCRIPTION
## What broke
The graphics-mode main loop never called \`recv_async\` — only \`run_ipc_loop\` (the no-graphics fallback) did. That meant every non-streaming IPC op from a userspace task blocked forever:
- \`MSG_CREATE_UI_WINDOW\`
- \`MSG_GFX_REGISTER_RING\` (#119)
- \`MSG_QUERY_NAME\` / \`MSG_QUERY_FOCUS\`
- \`MSG_GFX_UNREGISTER_RING\`

\`token_stream::tick\` already does the right thing — \`recv_async\` one message, dispatch through \`handle_message\`, \`reply_with_token\`. But it was only reachable via \`mcp_handler::tick_ipc_and_streaming\`, which nothing called from the live pipeline.

## Fix
Invoke \`tick_ipc_and_streaming\` once per main-loop iteration, right after \`tick_ai_systems\`. Drains one queued message per pass — enough since we don't expect a single app to flood the compositor at framerate.

## Why this didn't bite earlier
- \`MSG_CREATE_UI_WINDOW\`: only the legacy "create UI from FKUI" path used it, and that path was already migrated to other mechanisms.
- \`MSG_QUERY_NAME\`/\`QUERY_FOCUS\`: intent-service is the only caller, and it doesn't currently exercise these in the live boot path.
- \`MSG_GFX_REGISTER_RING\` (#119): brand-new, no producer existed before #121.

## Live verification
Booted on QEMU/WHPX with \`folkui-demo\` (#121):

\`\`\`
[FOLKUI-DEMO] starting up
[FOLKUI-DEMO] ring created shmem_id=2
[FOLKUI-DEMO] granted to compositor task 5
[COMPOSITOR] Registered gfx ring shmem=2 -> slot 0   ← was missing without fix
[FOLKUI-DEMO] registered as compositor slot 0
[FOLKUI-DEMO] display list = 119 bytes
\`\`\`

The "Registered gfx ring" line is the producer-blocked-on-syscall giveaway — before this fix, \`folkui-demo\` sat in \`syscall_ipc_send\` forever waiting for the compositor to pick up the message.

## Test plan
- [ ] Boot OS, observe all six markers above land in serial within ~30s of compositor scheduling
- [ ] Confirm no regression on existing token_stream / autodream paths (same fn is called, just from a new caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)