### PR TITLE
fix(compositor): redraw + drain when a gfx ring is registered

### DIFF
--- a/userspace/compositor/src/gfx_rings.rs
+++ b/userspace/compositor/src/gfx_rings.rs
@@ -128,6 +128,15 @@ pub fn count() -> usize {
     slots.iter().filter(|s: &&Option<Slot>| s.is_some()).count()
 }
 
+/// Whether at least one slot is registered. Used by the main loop
+/// to force a per-frame `render_frame()` call (and thus a `drain_all`)
+/// even when no other subsystem requested a redraw — otherwise an
+/// app pushing display-list bytes would never get its pixels painted
+/// because the imperative pipeline only wakes on input/clock events.
+pub fn has_active_rings() -> bool {
+    count() > 0
+}
+
 /// Drain every registered ring and dispatch its display list against
 /// `fb`. Returns aggregate stats so callers can log per-frame
 /// throughput. A parse error on one ring is logged via stats and the
@@ -137,6 +146,12 @@ pub fn drain_all(fb: &mut FramebufferView) -> DrainStats {
     // SAFETY: same as `register` — single-threaded.
     let slots: &mut [Option<Slot>; MAX_RINGS] = unsafe { &mut *core::ptr::addr_of_mut!(SLOTS) };
     let mut total = DrainStats::default();
+    // One-shot diagnostic so we can see in serial whether the drain
+    // actually finds bytes. Without this it's impossible to tell
+    // (from outside the kernel) whether the producer's writes are
+    // reaching the consumer's mapping.
+    static FIRST_PROBE: core::sync::atomic::AtomicBool =
+        core::sync::atomic::AtomicBool::new(true);
     for slot in slots.iter_mut() {
         let s = match slot.as_mut() {
             Some(s) => s,
@@ -144,6 +159,15 @@ pub fn drain_all(fb: &mut FramebufferView) -> DrainStats {
         };
         let ring = s.ring.as_ring();
         let n = ring.pop_into(&mut s.scratch);
+        if FIRST_PROBE.swap(false, core::sync::atomic::Ordering::Relaxed) {
+            // SAFETY: read-only field access through atomics.
+            let head = ring.head.load(core::sync::atomic::Ordering::Acquire);
+            let tail = ring.tail.load(core::sync::atomic::Ordering::Acquire);
+            libfolk::println!(
+                "[GFX_RINGS] first probe: head={} tail={} pop_n={}",
+                head, tail, n
+            );
+        }
         if n == 0 { continue; }
         match dispatch_display_list(&s.scratch[..n], fb) {
             Ok((_consumed, ds)) => {

--- a/userspace/compositor/src/main.rs
+++ b/userspace/compositor/src/main.rs
@@ -1108,6 +1108,13 @@ fn main() -> ! {
         }
 
         // ===== Rendering + Present (moved to rendering.rs) =====
+        // Force a redraw when any gfx ring is registered so its
+        // producer's display-list bytes actually drain into the
+        // framebuffer. Without this, render_frame() only runs on
+        // input/clock events and ring data piles up unconsumed.
+        if compositor::gfx_rings::has_active_rings() {
+            need_redraw = true;
+        }
         if need_redraw {
             let rl = rendering::RenderLayout {
                 folk_dark, folk_accent, white, gray, dark_gray, omnibar_border,

--- a/userspace/compositor/src/rendering/mod.rs
+++ b/userspace/compositor/src/rendering/mod.rs
@@ -149,6 +149,19 @@ pub fn render_frame(ctx: &mut RenderContext) -> RenderResult {
         let stats = compositor::gfx_rings::drain_all(ctx.fb);
         if stats.rings_drained > 0 {
             did_work = true;
+            // One-shot debug print the first time a drain happens this
+            // boot, so we can confirm from serial that the producer→
+            // consumer pipeline is wired through. Repeated drains are
+            // silent to avoid flooding.
+            static LOGGED: core::sync::atomic::AtomicBool =
+                core::sync::atomic::AtomicBool::new(false);
+            if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+                libfolk::println!(
+                    "[COMPOSITOR] gfx drain: rings={} bytes={} rects={} texts={}",
+                    stats.rings_drained, stats.bytes,
+                    stats.draw_rects, stats.draw_texts,
+                );
+            }
             // Damage rectangle: for now we mark a conservative fullscreen
             // damage when any ring drains. Once ring consumers report
             // their bounds (a follow-up), we replace this with a tighter


### PR DESCRIPTION
## Summary
**Last bug in the libfolkui→ring→compositor pipeline.** After #119/#120/#121/#122 the producer side worked end-to-end (folkui-demo created a ring, granted it, registered with the compositor, pushed display-list bytes) but no pixels reached the screen.

## Root cause
\`render_frame()\` is gated behind \`if need_redraw {…}\` in the main loop, and gfx ring data wasn't on any subsystem's redraw-trigger list. The compositor only repainted on input/clock events, so an app pushing display-list bytes saw its ring fill up forever, never drained.

## Fix
- **New** \`gfx_rings::has_active_rings() -> bool\`
- **Main loop**: \`need_redraw = true\` when at least one ring is registered. Drains every frame while a producer is alive — exactly the rapport's intended cadence.

## Diagnostics
Also adds two one-shot prints so future regressions are obvious from serial:
- \`[GFX_RINGS] first probe: head=N tail=N pop_n=N\` (first \`drain_all\` walk; confirms producer/consumer share the shmem region)
- \`[COMPOSITOR] gfx drain: rings=N bytes=N rects=N texts=N\` (first successful drain; confirms dispatcher reaches \`fill_rect\`/\`draw_char\`)

## Live verification on QEMU/WHPX

\`\`\`
[FOLKUI-DEMO] starting up
[FOLKUI-DEMO] ring created shmem_id=2
[FOLKUI-DEMO] granted to compositor task 5
[COMPOSITOR] Registered gfx ring shmem=2 -> slot 0
[FOLKUI-DEMO] registered as compositor slot 0
[FOLKUI-DEMO] display list = 119 bytes
[GFX_RINGS] first probe: head=357 tail=357 pop_n=357
[COMPOSITOR] gfx drain: rings=1 bytes=357 rects=2 texts=2
\`\`\`

Screenshot confirms the panel's rect + button rect actually paint on the framebuffer. The 2 rects + 2 texts per frame match exactly what \`libfolkui::compile_to_display_list\` emits for the demo's \`<Window><VBox><Text/><Button>Hi</Button></VBox></Window>\` markup.

## Known follow-up (NOT in this PR)
\`gfx_dispatch.rs::DrawText\` calls \`draw_char(x, y, ch, fg, bg)\` with \`fg == bg\` (sentinel for "transparent BG"). \`draw_char\` actually writes both fg and bg pixels unconditionally, so glyphs render as solid rectangles instead of letters. Pre-existing in #118; needs either a \`draw_char_alpha\` switch or a sentinel-aware bg-skip in the FB primitive.

## Closes the rapport's Del 1+4 implementation
This is the final glue PR. End-to-end: **DSML markup (libfolkui) → DOM → layout → display-list bytes → SPSC shmem ring → compositor parser → dispatcher → fill_rect/draw_char → VirtIO-GPU flush → pixels on screen.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)