### PR TITLE
feat(gfx): rounded corners + tight per-ring damage bbox

### DIFF
--- a/userspace/compositor/src/gfx_dispatch.rs
+++ b/userspace/compositor/src/gfx_dispatch.rs
@@ -49,7 +49,11 @@ fn rgba_to_fb(rgba: u32) -> u32 {
 }
 
 /// Counters reported back to callers so render_frame() can log how
-/// much display-list traffic flowed this frame.
+/// much display-list traffic flowed this frame. The `damage` field
+/// carries the screen-clipped bounding box of every pixel the
+/// dispatcher actually wrote — drain_all hands it to the
+/// DamageTracker so the next VirtIO-GPU flush copies only the
+/// touched rect, not the whole screen.
 #[derive(Default, Clone, Copy, Debug)]
 pub struct DispatchStats {
     pub draw_rects: u32,
@@ -57,6 +61,78 @@ pub struct DispatchStats {
     pub set_clips: u32,
     pub draw_textures_skipped: u32,
     pub unknown_skipped: u32,
+    /// Union of every painted rect, in screen coords. `None` if
+    /// nothing was drawn (Sync-only or all-clipped frames).
+    pub damage: Option<ClipRect>,
+}
+
+#[inline]
+fn extend_damage(damage: &mut Option<ClipRect>, rect: ClipRect) {
+    *damage = Some(match *damage {
+        Some(prev) => prev.union(&rect),
+        None => rect,
+    });
+}
+
+/// Fill a rectangle with rounded corners using a quarter-circle
+/// distance test. Pre-clipped to fb bounds by the caller. The body
+/// is split into three horizontal bands so the all-rectangle middle
+/// avoids the per-pixel distance check entirely — that's where the
+/// vast majority of pixels live for typical UI shapes.
+fn fill_rect_rounded(
+    fb: &mut FramebufferView,
+    x: usize, y: usize, w: u32, h: u32,
+    color: u32, radius: u32,
+) {
+    // Cap radius to half the smaller side so a small rect with a
+    // big radius still produces something sensible (a circle when
+    // radius == w/2 == h/2).
+    let r = radius.min(w / 2).min(h / 2);
+    if r == 0 {
+        fb.fill_rect(x, y, w as usize, h as usize, color);
+        return;
+    }
+    let r2 = (r * r) as i64;
+
+    // Top band: rows [y .. y+r), per-row clipped by the top corners.
+    for row in 0..r {
+        let dy = (r - row) as i64; // distance from the corner centre
+        let dx2 = r2 - dy * dy;
+        // Inset = r - sqrt(r^2 - dy^2). Approximate sqrt with a
+        // tight integer search since r is small (typically <= 16).
+        let mut sx = 0u32;
+        while ((r - sx) as i64) * ((r - sx) as i64) > dx2 {
+            sx += 1;
+        }
+        let inset = sx;
+        let row_x = x + inset as usize;
+        let row_w = (w - 2 * inset) as usize;
+        if row_w > 0 {
+            fb.fill_rect(row_x, y + row as usize, row_w, 1, color);
+        }
+    }
+
+    // Middle band: rows [y+r .. y+h-r), full width.
+    let mid_h = h.saturating_sub(2 * r);
+    if mid_h > 0 {
+        fb.fill_rect(x, y + r as usize, w as usize, mid_h as usize, color);
+    }
+
+    // Bottom band: rows [y+h-r .. y+h), mirror of the top.
+    for row in 0..r {
+        let dy = (row + 1) as i64;
+        let dx2 = r2 - dy * dy;
+        let mut sx = 0u32;
+        while ((r - sx) as i64) * ((r - sx) as i64) > dx2 {
+            sx += 1;
+        }
+        let inset = sx;
+        let row_x = x + inset as usize;
+        let row_w = (w - 2 * inset) as usize;
+        if row_w > 0 {
+            fb.fill_rect(row_x, y + (h - r + row) as usize, row_w, 1, color);
+        }
+    }
 }
 
 /// Dispatch every command in `bytes` against `fb`. Stops at the first
@@ -111,15 +187,20 @@ pub fn dispatch_display_list(
                 let fr = (clipped.x as i64 + clipped.w as i64).min(fb_w);
                 let fbottom = (clipped.y as i64 + clipped.h as i64).min(fb_h);
                 if fr <= fx || fbottom <= fy { continue; }
-                fb.fill_rect(
-                    fx as usize,
-                    fy as usize,
-                    (fr - fx) as usize,
-                    (fbottom - fy) as usize,
-                    rgba_to_fb(rcolor),
-                );
-                // corner_radius != 0 currently silently rounds to 0 —
-                // see module-level comment for why.
+                let rect_w = (fr - fx) as u32;
+                let rect_h = (fbottom - fy) as u32;
+                let radius = r.corner_radius as u32;
+                if radius == 0 {
+                    fb.fill_rect(fx as usize, fy as usize,
+                        rect_w as usize, rect_h as usize,
+                        rgba_to_fb(rcolor));
+                } else {
+                    fill_rect_rounded(fb, fx as usize, fy as usize,
+                        rect_w, rect_h, rgba_to_fb(rcolor), radius);
+                }
+                extend_damage(&mut stats.damage, ClipRect::new(
+                    fx as i32, fy as i32, rect_w, rect_h,
+                ));
             }
 
             Command::DrawText { x, y, color_rgba, font_size: _, text } => {
@@ -143,6 +224,7 @@ pub fn dispatch_display_list(
                 // Manual char-by-char so we can scissor to the current
                 // clip on each glyph rather than relying on
                 // draw_string's wrap-at-edge behaviour.
+                let text_x_start = cursor_x;
                 for ch in s.chars() {
                     if cursor_x + 8 > fb.width { break; }
                     if let Some(top) = clips.last() {
@@ -158,6 +240,12 @@ pub fn dispatch_display_list(
                     // someone later flips the alpha to non-zero.
                     fb.draw_char_alpha(cursor_x, cursor_y, ch, fg, 0, 0);
                     cursor_x += 8;
+                }
+                if cursor_x > text_x_start {
+                    extend_damage(&mut stats.damage, ClipRect::new(
+                        text_x_start as i32, cursor_y as i32,
+                        (cursor_x - text_x_start) as u32, 16,
+                    ));
                 }
             }
 

--- a/userspace/compositor/src/gfx_rings.rs
+++ b/userspace/compositor/src/gfx_rings.rs
@@ -38,6 +38,7 @@ use libfolk::sys::memory::ShmemError;
 use crate::framebuffer::FramebufferView;
 use crate::gfx_dispatch::{dispatch_display_list, DispatchStats};
 use crate::gfx_consumer::ParseError;
+use crate::render_graph::Rect as DispatchRect;
 
 /// Maximum simultaneous graphics-ring producers. Eight is enough for
 /// "compositor + a handful of foreground apps"; multi-window agents
@@ -178,6 +179,12 @@ pub fn drain_all(fb: &mut FramebufferView) -> DrainStats {
                 total.set_clips += ds.set_clips;
                 total.draw_textures_skipped += ds.draw_textures_skipped;
                 total.unknown_skipped += ds.unknown_skipped;
+                if let Some(r) = ds.damage {
+                    total.damage = Some(match total.damage {
+                        Some(prev) => prev.union(&r),
+                        None => r,
+                    });
+                }
             }
             Err(e) => {
                 total.parse_errors += 1;
@@ -200,6 +207,11 @@ pub struct DrainStats {
     pub unknown_skipped: u32,
     pub parse_errors: u32,
     pub last_parse_error: Option<ParseError>,
+    /// Union of every painted rect across all drained rings, in
+    /// screen coords. Callers feed this to the DamageTracker so the
+    /// VirtIO-GPU flush only copies the touched region instead of
+    /// the whole framebuffer.
+    pub damage: Option<DispatchRect>,
 }
 
 #[cfg(test)]

--- a/userspace/compositor/src/rendering/mod.rs
+++ b/userspace/compositor/src/rendering/mod.rs
@@ -157,18 +157,29 @@ pub fn render_frame(ctx: &mut RenderContext) -> RenderResult {
                 core::sync::atomic::AtomicBool::new(false);
             if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
                 libfolk::println!(
-                    "[COMPOSITOR] gfx drain: rings={} bytes={} rects={} texts={}",
+                    "[COMPOSITOR] gfx drain: rings={} bytes={} rects={} texts={} damage={:?}",
                     stats.rings_drained, stats.bytes,
-                    stats.draw_rects, stats.draw_texts,
+                    stats.draw_rects, stats.draw_texts, stats.damage,
                 );
             }
-            // Damage rectangle: for now we mark a conservative fullscreen
-            // damage when any ring drains. Once ring consumers report
-            // their bounds (a follow-up), we replace this with a tighter
-            // union of per-ring bboxes.
-            ctx.damage.add_damage(compositor::damage::Rect::new(
-                0, 0, ctx.fb.width as u32, ctx.fb.height as u32,
-            ));
+            // Damage rectangle: tight per-ring bbox aggregated by the
+            // dispatcher. Falls back to fullscreen damage when an
+            // unknown opcode skipped (we don't know what region the
+            // skipped op would have touched, so be conservative).
+            let fallback = stats.unknown_skipped > 0;
+            if let (Some(r), false) = (stats.damage, fallback) {
+                let x = r.x.max(0) as u32;
+                let y = r.y.max(0) as u32;
+                let w = r.w.min(ctx.fb.width as u32 - x);
+                let h = r.h.min(ctx.fb.height as u32 - y);
+                if w > 0 && h > 0 {
+                    ctx.damage.add_damage(compositor::damage::Rect::new(x, y, w, h));
+                }
+            } else {
+                ctx.damage.add_damage(compositor::damage::Rect::new(
+                    0, 0, ctx.fb.width as u32, ctx.fb.height as u32,
+                ));
+            }
         }
     }
 

--- a/userspace/folkui-demo/src/main.rs
+++ b/userspace/folkui-demo/src/main.rs
@@ -80,10 +80,10 @@ static ALLOCATOR: BumpAllocator = BumpAllocator {
 // Hard-coded for the smoke test. A future demo replaces this with
 // "ask Draug to author a UI" — that's the actual rapport endgame.
 const DEMO_MARKUP: &str = concat!(
-    r##"<Window x="40" y="40" width="320" height="120" bg_color="#1E2030">"##,
+    r##"<Window x="40" y="40" width="320" height="120" bg_color="#1E2030" corner_radius="8">"##,
     r##"  <VBox padding="16" spacing="12">"##,
     r##"    <Text color="#C0CAF5" font_size="18">Hello from libfolkui</Text>"##,
-    r##"    <Button bg_color="#7AA2F7">Click me</Button>"##,
+    r##"    <Button bg_color="#7AA2F7" corner_radius="6">Click me</Button>"##,
     r##"  </VBox>"##,
     r##"</Window>"##,
 );

--- a/userspace/libfolkui/src/compiler.rs
+++ b/userspace/libfolkui/src/compiler.rs
@@ -38,13 +38,14 @@ fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
             "Window" => {
                 // Background fill from `bg_color`, default black.
                 if let Some(color) = node.attrs.get_color("bg_color") {
+                    let radius = node.attrs.get_u32("corner_radius").unwrap_or(0) as u16;
                     b.draw_rect(DrawRectCmd {
                         x: node.bounds.x,
                         y: node.bounds.y,
                         width: node.bounds.w,
                         height: node.bounds.h,
                         color_rgba: color,
-                        corner_radius: 0,
+                        corner_radius: radius,
                     });
                 }
                 emit_children(tree, idx, b);


### PR DESCRIPTION
## Summary
Two polish items the prior dispatcher PRs left as TODOs, bundled in one PR since they share the same files.

## 1. Rounded corners
\`DrawRect\`'s \`corner_radius\` field used to silently round to 0. New \`fill_rect_rounded()\` renders properly-rounded rects in three horizontal bands:
- Top band: per-row inset from a quarter-circle distance test
- Middle band: full-width \`fill_rect\` (most pixels live here)
- Bottom band: mirror of the top

Caps radius to half the smaller side, so small rect + big radius = circle. Integer-only — no \`f64\` / \`sqrt\`.

\`libfolkui::compile_to_display_list\` now propagates \`corner_radius\` on \`<Window>\` (was hardcoded to 0); \`<Button>\` already did.

## 2. Tight per-ring damage bbox
Previous flush-damage path marked the whole framebuffer as dirty on every drain (1024×768 VirtIO-GPU copy for a 320×120 panel). Now:
- \`DispatchStats\` carries an \`Option<Rect>\` damage bbox, extended on every painted rect / text run
- \`gfx_rings::DrainStats\` aggregates the union across all rings
- \`render_frame()\` Stage 5b feeds that bbox into the \`DamageTracker\`; falls back to fullscreen only when an unknown opcode was skipped (we don't know what region it would have touched)

## Live verification on QEMU/WHPX
folkui-demo markup updated to \`corner_radius="8"\` on Window and \`corner_radius="6"\` on Button so the screenshot exercises the new path.

\`\`\`
[COMPOSITOR] gfx drain: rings=1 bytes=238 rects=2 texts=2
                        damage=Some(Rect { x:40, y:40, w:320, h:120 })
\`\`\`

Visual: panel + button both render with rounded corners; damage is the panel's exact bbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)