### PR TITLE
feat(libfolkui): reactive bindings via AppState

### DIFF
--- a/userspace/folkui-demo/src/main.rs
+++ b/userspace/folkui-demo/src/main.rs
@@ -33,7 +33,11 @@ use libfolk::{entry, println};
 use libfolk::sys::yield_cpu;
 use libfolk::sys::compositor::{register_gfx_ring, COMPOSITOR_TASK_ID};
 use libfolk::gfx::RingHandle;
-use libfolkui::{compile_to_display_list, layout, parse, LayoutConstraint};
+use libfolk::gfx::DisplayListBuilder;
+use libfolkui::{
+    compile_into, layout, parse,
+    AppState, LayoutConstraint,
+};
 
 // ── Bump allocator ──────────────────────────────────────────────────
 //
@@ -80,9 +84,10 @@ static ALLOCATOR: BumpAllocator = BumpAllocator {
 // Hard-coded for the smoke test. A future demo replaces this with
 // "ask Draug to author a UI" — that's the actual rapport endgame.
 const DEMO_MARKUP: &str = concat!(
-    r##"<Window x="40" y="40" width="320" height="120" bg_color="#1E2030" corner_radius="8">"##,
-    r##"  <VBox padding="16" spacing="12">"##,
+    r##"<Window x="40" y="40" width="320" height="140" bg_color="#1E2030" corner_radius="8">"##,
+    r##"  <VBox padding="16" spacing="8">"##,
     r##"    <Text color="#C0CAF5" font_size="18">Hello from libfolkui</Text>"##,
+    r##"    <Text color="#A9B1D6" font_size="14" bind_text="counter">tick=0</Text>"##,
     r##"    <Button bg_color="#7AA2F7" corner_radius="6">Click me</Button>"##,
     r##"  </VBox>"##,
     r##"</Window>"##,
@@ -144,22 +149,69 @@ fn main() -> ! {
         max_w: 1024, max_h: 768, // matches the compositor's typical FB
     });
 
-    // 3. Push one frame's display list, then yield. The compositor
-    //    drains it inside render_frame; the producer doesn't need to
-    //    push at framerate — pushing only when content changes is a
-    //    follow-up. For the smoke test we push every wakeup so a
-    //    visible "Hello from libfolkui" stays painted.
-    let builder = compile_to_display_list(&tree);
-    let bytes = builder.as_slice();
-    println!("[FOLKUI-DEMO] display list = {} bytes", bytes.len());
+    // 3. Push display lists with a live-updating counter binding.
+    //    Each tick we bump `counter`, set it on AppState, recompile,
+    //    and push. The compiler resolves <Text bind_text="counter">
+    //    against state, so the on-screen panel shows an incrementing
+    //    value — proof that reactive bindings reach pixels.
+    let mut state = AppState::new();
+    let mut counter: u64 = 0;
+    let mut buf = [0u8; 24]; // "tick=NNNNNNNNNNNNNNNN\0"
+    // Single builder reused across frames — `compile_into` clears it
+    // before re-filling, so the heap buffer's capacity stays warm and
+    // we don't leak through the bump allocator (which never frees).
+    let mut builder = DisplayListBuilder::new();
+    let mut printed_once = false;
 
     loop {
+        let written = format_counter(&mut buf, counter);
+        // SAFETY: `format_counter` writes ASCII bytes only.
+        let s = unsafe { core::str::from_utf8_unchecked(&buf[..written]) };
+        state.set("counter", s);
+
+        compile_into(&tree, &state, &mut builder);
+        let bytes = builder.as_slice();
+        if !printed_once {
+            println!("[FOLKUI-DEMO] display list = {} bytes", bytes.len());
+            printed_once = true;
+        }
+
         let ring = handle.as_ring();
         // `Full` just means the consumer is behind. Drop the frame
         // and try next tick — apps shouldn't spin on the ring.
         let _ = ring.push(bytes);
+
+        counter = counter.wrapping_add(1);
         yield_cpu();
     }
+}
+
+/// Render `counter` into `buf` as `b"tick=N"` ASCII. Returns the
+/// number of bytes written. Uses a fixed-size scratch buffer
+/// because we don't want to call `format!` (allocates) on every
+/// frame.
+fn format_counter(buf: &mut [u8], counter: u64) -> usize {
+    const PREFIX: &[u8] = b"tick=";
+    let mut i = 0;
+    for &b in PREFIX {
+        if i >= buf.len() { return i; }
+        buf[i] = b;
+        i += 1;
+    }
+    if counter == 0 {
+        if i < buf.len() { buf[i] = b'0'; i += 1; }
+        return i;
+    }
+    // Render digits backwards, then reverse in place.
+    let start = i;
+    let mut n = counter;
+    while n > 0 && i < buf.len() {
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        i += 1;
+    }
+    buf[start..i].reverse();
+    i
 }
 
 fn idle_forever() -> ! {

--- a/userspace/libfolkui/src/compiler.rs
+++ b/userspace/libfolkui/src/compiler.rs
@@ -17,20 +17,48 @@ extern crate alloc;
 use libfolk::gfx::{DisplayListBuilder, DrawRectCmd};
 
 use crate::dom::{NodeKind, Tree};
+use crate::state::AppState;
 
-/// Compile `tree` into a builder. The builder is returned with an
-/// already-appended `Sync` end-of-frame marker, so the caller can
-/// directly `push()` `builder.as_slice()` onto the SPSC ring.
+/// Compile `tree` into a builder using an empty state map. Equivalent
+/// to `compile_to_display_list_with_state(tree, &AppState::empty())`,
+/// kept as a convenience for apps that don't have any bindings.
 pub fn compile_to_display_list(tree: &Tree) -> DisplayListBuilder {
+    compile_to_display_list_with_state(tree, &AppState::empty())
+}
+
+/// Compile `tree` into a builder, resolving `bind_text="key"` on
+/// `<Text>` elements against `state`. The builder is returned with an
+/// already-appended `Sync` end-of-frame marker.
+///
+/// Resolution rules for `<Text>`:
+/// - If `bind_text` is set AND `state.get(key)` returns `Some(v)` →
+///   emit a `DrawText` carrying `v` directly. The element's child
+///   text (if any) is ignored.
+/// - If `bind_text` is set but the key is absent from `state` → fall
+///   back to whatever child text the markup has. Useful for the
+///   "first frame before state is populated" case.
+/// - If `bind_text` isn't set → emit children as before.
+pub fn compile_to_display_list_with_state(tree: &Tree, state: &AppState) -> DisplayListBuilder {
     let mut b = DisplayListBuilder::new();
-    if let Some(root) = tree.root() {
-        emit_node(tree, root, &mut b);
-    }
-    b.end_frame();
+    compile_into(tree, state, &mut b);
     b
 }
 
-fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
+/// Reuse-friendly variant: clears `b` and re-fills it with the
+/// current frame's display list. Apps that emit a fresh frame each
+/// tick should hold onto a single `DisplayListBuilder` and call this
+/// instead of `compile_to_display_list_with_state` to avoid
+/// allocating a new heap buffer per frame — important for callers on
+/// bump allocators that don't deallocate.
+pub fn compile_into(tree: &Tree, state: &AppState, b: &mut DisplayListBuilder) {
+    b.clear();
+    if let Some(root) = tree.root() {
+        emit_node(tree, root, state, b);
+    }
+    b.end_frame();
+}
+
+fn emit_node(tree: &Tree, idx: u32, state: &AppState, b: &mut DisplayListBuilder) {
     let node = &tree.nodes[idx as usize];
 
     match node.kind {
@@ -48,7 +76,7 @@ fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
                         corner_radius: radius,
                     });
                 }
-                emit_children(tree, idx, b);
+                emit_children(tree, idx, state, b);
             }
             "Button" => {
                 let color = node.attrs.get_color("bg_color").unwrap_or(0x3A_3A_3A_FF);
@@ -63,7 +91,7 @@ fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
                 });
                 // Children (typically a `<Text>`) draw on top of the
                 // button background.
-                emit_children(tree, idx, b);
+                emit_children(tree, idx, state, b);
             }
             "ProgressBar" => {
                 // Track
@@ -95,23 +123,32 @@ fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
                 }
             }
             "Text" => {
-                // Top-level <Text> directly under another container. The
-                // text content lives in the child Text node, so emit that
-                // recursively. (When a <Text> is empty/self-closing with
-                // a `bind_text=` attr, the runtime is supposed to fill
-                // it before layout/compile — that's a Del-4-follow-up.)
-                emit_children(tree, idx, b);
+                // Reactive binding: `<Text bind_text="key">` resolves
+                // against AppState. If the key is present we emit the
+                // bound value at this node's own bounds; otherwise we
+                // fall through to whatever child text the markup has,
+                // so a "first frame before state populated" doesn't
+                // produce a blank panel.
+                if let Some(key) = node.attrs.get("bind_text") {
+                    if let Some(value) = state.get(key) {
+                        let color = node.attrs.get_color("color").unwrap_or(0xFF_FF_FF_FF);
+                        let font_size = node.attrs.get_u32("font_size").unwrap_or(14) as u16;
+                        b.draw_text(node.bounds.x, node.bounds.y, color, font_size, value);
+                        return;
+                    }
+                }
+                emit_children(tree, idx, state, b);
             }
             "VBox" | "HBox" => {
                 // Layout containers don't paint themselves — they only
                 // position children. Pure structural.
-                emit_children(tree, idx, b);
+                emit_children(tree, idx, state, b);
             }
             _ => {
                 // Unknown element: no warning, no draw. Children still
                 // render, so a future tag we forgot to handle (`<Card>`,
                 // `<Spacer>`) at least stacks layout-wise.
-                emit_children(tree, idx, b);
+                emit_children(tree, idx, state, b);
             }
         },
         NodeKind::Text => {
@@ -130,10 +167,10 @@ fn emit_node(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
     }
 }
 
-fn emit_children(tree: &Tree, idx: u32, b: &mut DisplayListBuilder) {
+fn emit_children(tree: &Tree, idx: u32, state: &AppState, b: &mut DisplayListBuilder) {
     let children = &tree.nodes[idx as usize].children;
     for &c in children {
-        emit_node(tree, c, b);
+        emit_node(tree, c, state, b);
     }
 }
 

--- a/userspace/libfolkui/src/lib.rs
+++ b/userspace/libfolkui/src/lib.rs
@@ -29,19 +29,17 @@
 //! - Compiler: emits `DrawRect` + `DrawText` per node. `<Button>`
 //!   composes (rect + text). Color attributes parse `#RRGGBB`.
 //!
-//! Not in this PR (separate follow-ups, deliberate):
+//! Reactive bindings: `<Text bind_text="key">` resolves against an
+//! `AppState` map at compile time. Apps call `state.set(key, value)`
+//! once per frame; markup stays static. See `state.rs`.
+//!
+//! Not in this PR (deliberate follow-ups):
 //! - Tree-diffing / virtual DOM reconciliation. Today every frame
-//!   re-parses + re-emits. The framework already keeps `Vec` capacity
-//!   warm so this is alloc-light.
+//!   re-parses + re-emits. `Vec` capacity stays warm so this is
+//!   alloc-light after the first frame.
 //! - Real flexbox. The `layout::layout` API takes a width/height
 //!   constraint and is shaped to grow into bidirectional passes when
 //!   we add it.
-//! - Reactive bindings (`bind_text="status_message"`). Today text
-//!   content is whatever the markup contains literally.
-//! - Wiring into a WASM app and the kernel-side ring. The producer half
-//!   of the SPSC ring (`libfolk::gfx`) is in a sibling PR; once the
-//!   shmem syscall lands, an end-to-end demo replaces an existing
-//!   FKUI-backed widget.
 
 #![no_std]
 
@@ -51,8 +49,10 @@ pub mod parser;
 pub mod dom;
 pub mod layout;
 pub mod compiler;
+pub mod state;
 
 pub use parser::{parse, ParseError};
 pub use dom::{Node, NodeKind, Tree, AttrMap};
 pub use layout::{layout, LayoutConstraint};
-pub use compiler::compile_to_display_list;
+pub use compiler::{compile_to_display_list, compile_to_display_list_with_state, compile_into};
+pub use state::AppState;

--- a/userspace/libfolkui/src/state.rs
+++ b/userspace/libfolkui/src/state.rs
@@ -1,0 +1,105 @@
+//! Reactive state for `bind_text="..."` resolution.
+//!
+//! The agent emits markup once and updates state every frame. The
+//! compiler resolves `<Text bind_text="key">` against this map at
+//! emit-time, so apps don't have to mutate the DOM tree on each
+//! tick — they just call `state.set(key, value)` and rebuild the
+//! display list.
+//!
+//! Storage is a `Vec<(String, String)>` rather than `BTreeMap` for
+//! the same reasons as `AttrMap`: bindings are typically tiny
+//! (handful per app), linear scan wins on cache locality, and we
+//! avoid `alloc::collections` in the dependency closure. Insertion
+//! order is preserved so debug prints are stable.
+
+extern crate alloc;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+#[derive(Debug, Default, Clone)]
+pub struct AppState {
+    entries: Vec<(String, String)>,
+}
+
+impl AppState {
+    /// Empty state — used as the "no-op" default by
+    /// `compile_to_display_list`. Apps that don't need bindings can
+    /// keep ignoring state entirely.
+    pub const fn empty() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up the value for `key`. `None` if no binding exists; the
+    /// compiler treats that as "fall back to literal child text".
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries.iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// Set or replace a binding. Allocates only when the key is new
+    /// or the new value's length exceeds the existing capacity —
+    /// steady-state updates with same-length values reuse the buffer.
+    pub fn set(&mut self, key: &str, value: &str) {
+        if let Some(slot) = self.entries.iter_mut().find(|(k, _)| k == key) {
+            slot.1.clear();
+            slot.1.push_str(value);
+        } else {
+            self.entries.push((key.to_string(), value.to_string()));
+        }
+    }
+
+    /// Remove a binding. Returns `true` if it was present.
+    pub fn remove(&mut self, key: &str) -> bool {
+        if let Some(pos) = self.entries.iter().position(|(k, _)| k == key) {
+            self.entries.swap_remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn len(&self) -> usize { self.entries.len() }
+    pub fn is_empty(&self) -> bool { self.entries.is_empty() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_get_round_trip() {
+        let mut s = AppState::new();
+        s.set("counter", "42");
+        assert_eq!(s.get("counter"), Some("42"));
+    }
+
+    #[test]
+    fn set_overwrites() {
+        let mut s = AppState::new();
+        s.set("k", "v1");
+        s.set("k", "v2");
+        assert_eq!(s.get("k"), Some("v2"));
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let s = AppState::new();
+        assert!(s.get("nope").is_none());
+    }
+
+    #[test]
+    fn remove_works() {
+        let mut s = AppState::new();
+        s.set("a", "1");
+        s.set("b", "2");
+        assert!(s.remove("a"));
+        assert!(s.get("a").is_none());
+        assert_eq!(s.get("b"), Some("2"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds the rapport's Del 4 reactive layer. Apps emit static markup once; per-frame state updates flow through \`AppState\` and the compiler resolves \`<Text bind_text="key">\` against it at emit time.

## What's in
- New \`state::AppState\` — small Vec-backed key/value map (new/set/get/remove/len). Linear-scan matches AttrMap; binding counts are tiny and we avoid pulling \`alloc::collections\` into the dep closure.
- \`compile_to_display_list_with_state(tree, state)\` resolves \`bind_text\` on \`<Text>\` nodes:
  - key in state → emit \`DrawText\` with state value
  - \`bind_text\` set but no key → fall back to literal child text (handles "first frame before state is populated")
  - no \`bind_text\` → unchanged
- \`compile_into(tree, state, &mut builder)\` — reuse an existing builder. Critical for bump-allocator callers; folkui-demo OOMed at ~25 ticks before this.

## Demo update
\`folkui-demo\` drives a \`tick=NNN\` counter via reactive binding.

## Live verification on QEMU/WHPX
\`\`\`
[COMPOSITOR] gfx drain: rings=1 bytes=432 rects=2 texts=3
                        damage=Some(Rect{x:40,y:40,w:320,h:140})
\`\`\`
Two screenshots 8s apart show \`tick=461\` → \`tick=633\` — ~22 fps end-to-end, no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)