### PR TITLE
fix(libfolkui): diff first-frame emit was missing 80% of widgets

### DIFF
--- a/kernel/src/drivers/virtio_gpu/mod.rs
+++ b/kernel/src/drivers/virtio_gpu/mod.rs
@@ -237,33 +237,31 @@ pub fn init() -> Result<(), &'static str> {
     //   2. Legacy (RESOURCE_CREATE_2D + ATTACH_BACKING + SET_SCANOUT) for
     //      older QEMU that doesn't advertise the feature, or as a fallback
     //      if the blob commands fail (e.g. host rejects USE_MAPPABLE).
+    // Try blob first when the feature is negotiated. Only fall back to
+    // legacy if `CREATE_BLOB` itself fails — at that point no host-side
+    // resource was created so the legacy `CREATE_2D` can take id 1 cleanly.
+    // If `CREATE_BLOB` succeeds but `SET_SCANOUT_BLOB` fails, we don't
+    // try to recover: the host already owns a blob resource at id 1 and
+    // legacy `CREATE_2D` would collide on that id. Surface the error
+    // instead so it's visible in serial.
     let mut took_blob_path = false;
     if state.has_resource_blob {
         match resources::create_framebuffer_blob(&mut state) {
             Ok(()) => {
                 crate::serial_strln!("[VIRTIO_GPU] Blob resource created (zero-copy)");
-                match resources::set_scanout_blob(&mut state) {
-                    Ok(()) => {
-                        crate::serial_strln!("[VIRTIO_GPU] Scanout active (blob)!");
-                        state.using_blob = true;
-                        took_blob_path = true;
-                    }
-                    Err(e) => {
-                        crate::serial_str!("[VIRTIO_GPU] SET_SCANOUT_BLOB failed (");
-                        crate::serial_str!(e);
-                        crate::serial_strln!(") — falling back to legacy");
-                        // Pages already allocated in fb_phys_pages; reuse for
-                        // legacy path so we don't double-allocate. Drop the
-                        // guest's blob resource_id so legacy create_2d can take
-                        // the same id 1.
-                        state.fb_phys_pages.clear();
-                    }
-                }
+                resources::set_scanout_blob(&mut state)?;
+                crate::serial_strln!("[VIRTIO_GPU] Scanout active (blob)!");
+                state.using_blob = true;
+                took_blob_path = true;
             }
             Err(e) => {
                 crate::serial_str!("[VIRTIO_GPU] RESOURCE_CREATE_BLOB failed (");
                 crate::serial_str!(e);
                 crate::serial_strln!(") — falling back to legacy");
+                // No host-side resource was created — fb_phys_pages may
+                // hold guest pages we allocated; clear them so the legacy
+                // path's allocator starts fresh and we don't leak.
+                state.fb_phys_pages.clear();
             }
         }
     }

--- a/tools/boot_for_calc_test.ps1
+++ b/tools/boot_for_calc_test.ps1
@@ -1,0 +1,63 @@
+# boot_for_calc_test.ps1 — Boot Folkering OS in QEMU/WHPX, wait for
+# compositor-ready, then leave the VM running for the calc demo client.
+#
+# Usage: .\tools\boot_for_calc_test.ps1
+[CmdletBinding()]
+param(
+    [int]$VncDisplay = 1,
+    [int]$BootTimeoutSec = 180,
+    [ValidateSet('whpx', 'tcg')]
+    [string]$Accel = 'whpx'
+)
+$ErrorActionPreference = 'Stop'
+$FolkeringDir = 'C:\Users\merkn\folkering\folkering-os'
+$BootImg   = Join-Path $FolkeringDir 'boot\current.img'
+$DataImg   = Join-Path $FolkeringDir 'boot\virtio-data.img'
+$SerialLog = Join-Path $FolkeringDir 'tools\calc_serial.log'
+$StderrLog = Join-Path $FolkeringDir 'tools\calc_stderr.log'
+$QemuExe   = 'C:\Program Files\qemu\qemu-system-x86_64.exe'
+
+Get-Process -Name 'qemu-system-x86_64' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Milliseconds 500
+'' | Set-Content $SerialLog -Force
+'' | Set-Content $StderrLog -Force
+
+$qemuArgs = @(
+    '-drive', "file=$BootImg,format=raw,if=ide",
+    '-drive', "file=$DataImg,format=raw,if=none,id=vdisk0",
+    '-device', 'virtio-blk-pci,drive=vdisk0',
+    '-vga', 'virtio',
+    '-usb', '-device', 'usb-tablet',
+    '-accel', $(if ($Accel -eq 'whpx') { 'whpx,kernel-irqchip=off' } else { 'tcg' }),
+    '-cpu', 'qemu64,rdrand=on,+avx2,+fma,+avx,+sse4.1,+sse4.2',
+    '-smp', '4',
+    '-m', '2048M',
+    '-serial', "file:$SerialLog",
+    '-display', "vnc=0.0.0.0:$VncDisplay",
+    '-no-reboot'
+)
+$proc = Start-Process -FilePath $QemuExe -ArgumentList $qemuArgs -PassThru -RedirectStandardError $StderrLog -NoNewWindow
+Write-Host "QEMU PID=$($proc.Id) VNC=:$VncDisplay" -ForegroundColor Cyan
+
+$deadline = (Get-Date).AddSeconds($BootTimeoutSec)
+$ready = $false
+while ((Get-Date) -lt $deadline) {
+    if ($proc.HasExited) {
+        Write-Host "QEMU died (exit=$($proc.ExitCode))" -ForegroundColor Red
+        Get-Content $StderrLog -Raw | Write-Host
+        exit 1
+    }
+    $log = Get-Content $SerialLog -Raw -ErrorAction SilentlyContinue
+    if ($log -match '\[FOLKUI-DEMO\] input ring shmem=') {
+        $ready = $true; break
+    }
+    Start-Sleep -Milliseconds 500
+}
+if (-not $ready) {
+    Write-Host "Timed out waiting for [FOLKUI-DEMO] input ring marker" -ForegroundColor Yellow
+    Get-Content $SerialLog -Tail 30 | Write-Host
+    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+Write-Host "folkui-demo ready. Run: py -3.12 tools\vnc_calc_demo.py --serial tools\calc_serial.log" -ForegroundColor Green
+Write-Host "PID $($proc.Id) — kill with: Stop-Process -Id $($proc.Id) -Force" -ForegroundColor DarkGray

--- a/tools/vnc_calc_demo.py
+++ b/tools/vnc_calc_demo.py
@@ -1,0 +1,168 @@
+"""Drive the folkui-demo calculator over VNC. Boots assumed to be done.
+Sends pointer drags + clicks to a sequence of (x,y) pairs and prints
+serial-side `[FOLKUI-DEMO] click #N` lines that confirm the input
+pipeline + hit_test resolved each click to the intended button id.
+
+Calculator window: x=100 y=60, w=260 h=320. Buttons in 4 rows × 4 cols
+per the markup in `userspace/folkui-demo/src/main.rs`. Centers below
+are picked by hand from the layout (see comment below) — the script's
+job is to *verify* hit_test agrees, not recompute the layout itself.
+
+Usage:
+  py -3.12 tools/vnc_calc_demo.py --port 5901 --serial tools/calc_serial.log
+"""
+
+from __future__ import annotations
+import argparse
+import socket
+import struct
+import sys
+import time
+from pathlib import Path
+
+
+# Window: (100,60)..(360,380). VBox padding=12 → inner (112,72)..(348,368).
+# Display row ≈ 24 px tall; spacing=6 between rows; 4 rows × 4 cols of
+# buttons fill the rest. Approx button centers (verified empirically):
+ROW_Y = [133, 201, 269, 337]
+COL_X = [139, 197, 255, 313]
+BUTTONS = {
+    "btn_7": (COL_X[0], ROW_Y[0]),
+    "btn_8": (COL_X[1], ROW_Y[0]),
+    "btn_9": (COL_X[2], ROW_Y[0]),
+    "btn_div": (COL_X[3], ROW_Y[0]),
+    "btn_4": (COL_X[0], ROW_Y[1]),
+    "btn_5": (COL_X[1], ROW_Y[1]),
+    "btn_6": (COL_X[2], ROW_Y[1]),
+    "btn_mul": (COL_X[3], ROW_Y[1]),
+    "btn_1": (COL_X[0], ROW_Y[2]),
+    "btn_2": (COL_X[1], ROW_Y[2]),
+    "btn_3": (COL_X[2], ROW_Y[2]),
+    "btn_sub": (COL_X[3], ROW_Y[2]),
+    "btn_0": (COL_X[0], ROW_Y[3]),
+    "btn_clear": (COL_X[1], ROW_Y[3]),
+    "btn_eq": (COL_X[2], ROW_Y[3]),
+    "btn_add": (COL_X[3], ROW_Y[3]),
+}
+
+
+def rfb_handshake(sock):
+    server_version = sock.recv(12)
+    if not server_version.startswith(b"RFB"):
+        raise RuntimeError(f"unexpected greeting: {server_version!r}")
+    sock.sendall(b"RFB 003.008\n")
+    n = sock.recv(1)[0]
+    if n == 0:
+        reason_len = struct.unpack(">I", sock.recv(4))[0]
+        raise RuntimeError(f"server rejected: {sock.recv(reason_len)!r}")
+    sec_types = sock.recv(n)
+    if 1 not in sec_types:
+        raise RuntimeError(f"no None security; offered={list(sec_types)}")
+    sock.sendall(bytes([1]))
+    if struct.unpack(">I", sock.recv(4))[0] != 0:
+        raise RuntimeError("security failed")
+    sock.sendall(b"\x01")
+    init = sock.recv(24)
+    width, height = struct.unpack(">HH", init[:4])
+    name_len = struct.unpack(">I", init[20:24])[0]
+    if name_len:
+        sock.recv(name_len)
+    return width, height
+
+
+def pointer_event(sock, x, y, buttons=0):
+    sock.sendall(struct.pack(">BBHH", 5, buttons & 0xFF, x, y))
+
+
+def drag_to(sock, last_xy, target_xy, steps=20, step_ms=15):
+    """Walk the cursor toward target with small accumulating relative
+    deltas. PS/2 mouse won't move on a single huge jump — QEMU clamps
+    the relative delta — so we feather it out."""
+    lx, ly = last_xy
+    tx, ty = target_xy
+    for i in range(1, steps + 1):
+        ix = lx + (tx - lx) * i // steps
+        iy = ly + (ty - ly) * i // steps
+        pointer_event(sock, ix, iy, 0)
+        time.sleep(step_ms / 1000.0)
+
+
+def click_at(sock, x, y, hold_ms=80, settle_ms=200):
+    pointer_event(sock, x, y, 1)  # left down
+    time.sleep(hold_ms / 1000.0)
+    pointer_event(sock, x, y, 0)  # left up
+    time.sleep(settle_ms / 1000.0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5901)
+    ap.add_argument("--serial", default=None,
+                    help="Path to QEMU serial log; we tail it after the run")
+    ap.add_argument("--sequence", default="5,add,3,eq",
+                    help="Comma-separated calculator buttons (digits or "
+                         "add/sub/mul/div/eq/clear)")
+    args = ap.parse_args()
+
+    seq = args.sequence.split(",")
+    targets = []
+    for s in seq:
+        s = s.strip()
+        if s.isdigit() and len(s) == 1:
+            targets.append(f"btn_{s}")
+        elif s in ("add", "sub", "mul", "div", "eq", "clear"):
+            targets.append(f"btn_{s}")
+        else:
+            raise SystemExit(f"unknown button: {s!r}")
+    print(f"plan: {' '.join(targets)}")
+
+    sock = socket.create_connection((args.host, args.port), timeout=10.0)
+    try:
+        w, h = rfb_handshake(sock)
+        print(f"RFB connected: {w}x{h}")
+        sock.settimeout(0.05)
+
+        # PS/2 mouse only sees relative deltas. Force the guest's
+        # cursor to the top-left by sweeping the VNC pointer all the
+        # way from (w-1, h-1) to a large negative origin. QEMU clamps
+        # the relative delta into the real frame, so 60 steps of
+        # ~-30 in each axis is more than enough to floor any starting
+        # position. Then drive forward from a known origin.
+        for i in range(60):
+            tx = (w - 1) - (w + 200) * i // 60
+            ty = (h - 1) - (h + 200) * i // 60
+            pointer_event(sock, max(tx, 0), max(ty, 0), 0)
+            time.sleep(0.01)
+        cur = (1, 1)
+        pointer_event(sock, *cur, 0)
+        time.sleep(0.5)
+
+        for label in targets:
+            tgt = BUTTONS[label]
+            print(f"  -> {label} @ ({tgt[0]},{tgt[1]})")
+            drag_to(sock, cur, tgt)
+            cur = tgt
+            click_at(sock, *cur)
+
+    finally:
+        sock.close()
+
+    if args.serial:
+        time.sleep(0.5)
+        log = Path(args.serial)
+        if not log.exists():
+            print(f"\n(serial log not at {log})")
+            return 0
+        text = log.read_text(errors="replace").splitlines()
+        click_lines = [l for l in text if "[FOLKUI-DEMO] click" in l]
+        print("\n=== folkui-demo click log ===")
+        for l in click_lines[-20:]:
+            print(l)
+        if not click_lines:
+            print("(no [FOLKUI-DEMO] click lines — input pipeline didn't deliver)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/vnc_cursor_probe.py
+++ b/tools/vnc_cursor_probe.py
@@ -1,0 +1,76 @@
+"""Single-shot VNC cursor probe. Sends a long sequence of deliberate
+small relative motions, then a click, and we read the serial for what
+the compositor thinks the cursor coords were on the click edge."""
+
+from __future__ import annotations
+import socket
+import struct
+import sys
+import time
+
+
+def rfb_handshake(sock):
+    server_version = sock.recv(12)
+    sock.sendall(b"RFB 003.008\n")
+    n = sock.recv(1)[0]
+    sec_types = sock.recv(n)
+    sock.sendall(bytes([1]))
+    if struct.unpack(">I", sock.recv(4))[0] != 0:
+        raise RuntimeError("security failed")
+    sock.sendall(b"\x01")
+    init = sock.recv(24)
+    width, height = struct.unpack(">HH", init[:4])
+    name_len = struct.unpack(">I", init[20:24])[0]
+    if name_len:
+        sock.recv(name_len)
+    return width, height
+
+
+def pe(sock, x, y, b=0):
+    sock.sendall(struct.pack(">BBHH", 5, b & 0xFF, x, y))
+
+
+def main():
+    target_x = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    target_y = int(sys.argv[2]) if len(sys.argv) > 2 else 200
+
+    sock = socket.create_connection(("127.0.0.1", 5901), timeout=10.0)
+    w, h = rfb_handshake(sock)
+    print(f"connected {w}x{h}")
+    sock.settimeout(0.05)
+
+    # 1) Hard floor: 200 events stepping toward (-1, -1) so QEMU's
+    # internal vnc pointer ends at (0,0) and the guest's accumulator
+    # has been driven to its 0-clamp.
+    cur_x, cur_y = w - 1, h - 1
+    pe(sock, cur_x, cur_y, 0)
+    time.sleep(0.05)
+    for _ in range(200):
+        cur_x = max(0, cur_x - 20)
+        cur_y = max(0, cur_y - 20)
+        pe(sock, cur_x, cur_y, 0)
+        time.sleep(0.02)
+    # Park, give the guest a beat to drain the kernel ring.
+    pe(sock, 0, 0, 0)
+    time.sleep(1.0)
+
+    # 2) Walk to target with small steps (PS/2 won't accept a giant
+    # single delta).
+    steps = 80
+    for i in range(1, steps + 1):
+        ix = target_x * i // steps
+        iy = target_y * i // steps
+        pe(sock, ix, iy, 0)
+        time.sleep(0.02)
+    time.sleep(0.5)
+
+    # 3) Click
+    print(f"clicking at ({target_x},{target_y})")
+    pe(sock, target_x, target_y, 1)
+    time.sleep(0.1)
+    pe(sock, target_x, target_y, 0)
+    time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/userspace/compositor/src/input_mouse.rs
+++ b/userspace/compositor/src/input_mouse.rs
@@ -128,17 +128,19 @@ pub fn process_mouse(
         let prev_left = latest_buttons & 1 != 0;
         let now_left  = event.buttons & 1 != 0;
         if now_left != prev_left {
-            // Diagnostic: log first edge + first routing attempt so
-            // we can tell from serial whether bbox matching succeeds.
-            static EDGE_LOGGED: core::sync::atomic::AtomicBool =
-                core::sync::atomic::AtomicBool::new(false);
+            // Diagnostic: log button edges + routing outcome. Capped
+            // at 20 edges to keep serial from filling under a flood,
+            // but enough to see a few clicks of input-pipeline work.
+            static EDGE_COUNT: core::sync::atomic::AtomicU32 =
+                core::sync::atomic::AtomicU32::new(0);
             let routed = compositor::gfx_rings::route_mouse_event(
                 event_cursor_x, event_cursor_y, 1, now_left,
             );
-            if !EDGE_LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            let n = EDGE_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            if n < 20 {
                 libfolk::println!(
-                    "[INPUT_MOUSE] first edge prev={} now={} at ({},{}) routed={:?}",
-                    prev_left as u8, now_left as u8,
+                    "[INPUT_MOUSE] edge#{} prev={} now={} at ({},{}) routed={:?}",
+                    n, prev_left as u8, now_left as u8,
                     event_cursor_x, event_cursor_y, routed,
                 );
             }

--- a/userspace/folkui-demo/src/main.rs
+++ b/userspace/folkui-demo/src/main.rs
@@ -224,12 +224,13 @@ fn main() -> ! {
             if ev.kind == EventKind::Mouse as u32 && ev.button == 1 && ev.down == 1 {
                 clicks = clicks.wrapping_add(1);
                 let hit = hit_test_id(&tree, ev.x, ev.y).unwrap_or("(none)");
-                println!("[FOLKUI-DEMO] click #{} at ({},{}) hit={}",
-                    clicks, ev.x, ev.y, hit);
-                if calc.handle_button(hit) {
+                let handled = calc.handle_button(hit);
+                if handled {
                     state.set("display", calc.text());
                     state_dirty = true;
                 }
+                println!("[FOLKUI-DEMO] click #{} at ({},{}) hit={} -> display={}",
+                    clicks, ev.x, ev.y, hit, calc.text());
             }
         }
         // First-frame primer: state needs to be set so DiffState's

--- a/userspace/libfolkui/src/diff.rs
+++ b/userspace/libfolkui/src/diff.rs
@@ -138,18 +138,16 @@ fn emit_full(
     diff: &mut DiffState,
     b: &mut DisplayListBuilder,
 ) {
+    // First-frame emit — same shape as `compile_into` would produce,
+    // but with a side-table populated for binding diff on later frames.
+    // We can't reuse `compile_into` directly because it appends a
+    // `Sync` marker we'd have to peel off; rolling our own walk that
+    // ends *before* the Sync keeps the wire format symmetric (the
+    // outer `compile_diff_into` adds Sync for both the full and diff
+    // paths via `b.end_frame()`). The builder is assumed already
+    // cleared by the caller (`compile_diff_into` does `b.clear()` up
+    // front).
     if let Some(root) = tree.root() {
-        // Reuse the production compiler for the full path; we just
-        // tail-walk afterwards to populate the binding cache.
-        crate::compiler::compile_into(tree, state, b);
-        // Note: `compile_into` already emitted Sync. We strip it
-        // here so the wrapper can re-add Sync at the end (keeps the
-        // diff and full paths symmetric for the caller). But the
-        // builder's `as_slice()` already includes Sync — undoing it
-        // means peeking into the buffer, which is brittle. Cleaner:
-        // skip `end_frame` in `compile_into` by rolling our own
-        // walk here. That's what we do.
-        b.clear();
         walk_full(tree, root, state, /*ancestor_bg=*/0, diff, b);
     }
 }


### PR DESCRIPTION
## Summary
- `compile_diff_into` → `emit_full` was emitting only ~166 bytes for a 16-button calculator that should produce ~768 bytes. The cause was a wasted `compile_into(...) + b.clear()` call before the actual walk, which somehow left the builder in a state where the subsequent walk emitted far less than it should.
- On the wire, the slot's `last_damage` ended up nowhere near the actual window. `route_mouse_event` returned `None` for every click → no app ever received a mouse event. Calculator demo couldn't compute anything.
- Drop the redundant call. `walk_full` alone produces the correct full first-frame list. Verified end-to-end on Proxmox VM 800: `5 + 3 = 8` lands in the calc app's display state with the diff path, last_damage matches the Window bounds (`100,60 260x320`), and `hit_test_id` resolves clicks correctly.

## What's bundled
- **fix**: drop redundant `compile_into` in `libfolkui::diff::emit_full`
- **diag**: compositor `EDGE_COUNT` (20 edges instead of 1) so multiple clicks are visible
- **diag**: folkui-demo click log includes `display=` so calc state is observable in serial
- **fix**: kernel virtio_gpu blob fallback no longer tries to recover from `SET_SCANOUT_BLOB` failure (legacy `CREATE_2D` would collide on resource id 1)
- **tools**: `tools/boot_for_calc_test.ps1`, `tools/vnc_calc_demo.py`, `tools/vnc_cursor_probe.py` — click-driven E2E rig

## Live verification (Proxmox VM 800, KVM)
```
[FOLKUI-DEMO] first display list = 768 bytes      ← was 166 before fix
[ROUTE] slot 0 bbox=(100,60 260x320) hit (196,200)
[INPUT_MOUSE] edge#0 prev=0 now=1 at (196,200) routed=Some(0)
[FOLKUI-DEMO] click #1 hit=btn_5 -> display=5
[FOLKUI-DEMO] click #2 hit=btn_add -> display=5
[FOLKUI-DEMO] click #3 hit=btn_3 -> display=3
[FOLKUI-DEMO] click #4 hit=btn_eq -> display=8
```

## Adjacent perf finding (not addressed here, just observed)
Compositor `TIMING` samples on KVM after warmup show **~75ms total per frame** (almost entirely render-side; GPU present is ~100µs). Same regression issue #15 noted at 80–105ms under WHPX. Worth a separate perf issue if anyone wants to chase it.

## Test plan
- [x] `cargo build --release -p libfolkui -p folkui-demo -p compositor` clean
- [x] `cargo build --release -p kernel` clean
- [x] Live boot on Proxmox VM 800 (KVM)
- [x] VNC click sequence `5,add,3,eq` → serial shows `display=8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)