### PR TITLE
perf(kernel): cap com2_async_poll drain at 256 per call (was 4096)

### DIFF
--- a/kernel/src/drivers/serial.rs
+++ b/kernel/src/drivers/serial.rs
@@ -173,12 +173,21 @@ pub fn com2_async_send(data: &[u8]) {
 
 /// Poll COM2 RX (non-blocking). Call this every frame from the compositor.
 /// Drains any available COM2 bytes into the ring buffer.
+///
+/// Iteration cap: 256 per call. Each `com2_read_byte` does a port-I/O LSR
+/// check, which traps to the hypervisor under KVM/WHPX (~5-15µs per
+/// VMEXIT). If COM2 is unconnected the LSR can return 0xFF, so bit 0
+/// (data-ready) reads as set and the loop *would* spin out the full
+/// budget every call. The old 4096 cap turned this into a 26-54ms tax
+/// per frame in the compositor (Issue #135). At 115200 baud the wire
+/// can deliver at most ~180 B/frame, so 256 leaves comfortable
+/// headroom; if real traffic ever overflows it the next poll picks up
+/// the rest.
 pub fn com2_async_poll() {
     if !COM2_ASYNC_ACTIVE.load(Ordering::Acquire) {
         return;
     }
-    // Drain all available COM2 bytes into ring (up to 4096 per poll to avoid starving the main loop)
-    for _ in 0..4096 {
+    for _ in 0..256 {
         if let Some(byte) = com2_read_byte() {
             let head = COM2_RX_HEAD.load(Ordering::Relaxed);
             if head < COM2_RING_SIZE {


### PR DESCRIPTION
## Summary
- **Issue #135** — compositor frame budget on KVM was ~75ms, 99% in the render path. Drilled down to ~28ms/frame in \`mcp::client::poll()\` even when no MCP proxy was connected.
- **Root cause**: kernel-side \`com2_async_poll\` busy-loops up to 4096 times reading COM2's LSR via port I/O. Each read traps through the hypervisor (~5-15µs VMEXIT). With COM2 unconnected the LSR returns 0xFF, so bit 0 (data-ready) reads as set and the loop spins out the full 4096 budget every call.
- **Fix**: cap the loop at 256. At 115200 baud the wire delivers ≤180 bytes per 16ms frame, so this is well over the real-traffic headroom; if a saturated COM2 ever overflows, the next poll picks up the rest.

## Measured impact (Proxmox VM 800, KVM)
\`\`\`
before: ~75ms total per frame, 41ms in com2_async_poll
 after: ~42ms total per frame, ~3ms in com2_async_poll
\`\`\`
**44% reduction. ~13fps → ~24fps.** Remaining gap to 60fps is in non-MCP parts of the main loop — separate investigation.

## Test plan
- [x] \`cargo build --release -p kernel\` clean
- [x] Live boot on Proxmox VM 800
- [x] Verify \`TIMING\` samples drop from ~75ms to ~42ms
- [x] folkui-demo calculator E2E click pipeline still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)