### PR TITLE
perf(compositor): cap god_mode::poll_com3 drain at 256 (was 4096)

### DIFF
--- a/userspace/compositor/src/god_mode.rs
+++ b/userspace/compositor/src/god_mode.rs
@@ -17,8 +17,17 @@ use libfolk::sys::io::write_str;
 /// #1 — root cause of Issue #49. Same defensive cap used by
 /// `com2_async_poll` in the kernel for the analogous COM2 ring drain.
 pub fn poll_com3(buf: &mut [u8; 512], len: &mut usize, queue: &mut Vec<String>) -> bool {
+    // Iteration cap dropped from 4096 to 256: same root cause as
+    // `com2_async_poll` in PR #136. On unconnected COM3 the LSR returns
+    // 0xFF every read, the data-ready bit is set, so the loop *would*
+    // spin out the full budget on every frame. Each `com3_read` is a
+    // syscall + port-I/O VMEXIT (~13µs under KVM), turning into ~38ms
+    // of compositor frame budget per call (Issue #135). 256 is well
+    // above any realistic god-mode injection burst (the line-oriented
+    // dispatch above reads at most ~80 bytes per command); overflow
+    // just rolls into the next frame's poll.
     let mut did_work = false;
-    for _ in 0..4096 {
+    for _ in 0..256 {
         let Some(byte) = libfolk::sys::com3_read() else { break; };
         if byte == b'\n' && *len > 0 {
             if let Ok(cmd) = alloc::str::from_utf8(&buf[..*len]) {


### PR DESCRIPTION
## Summary
- Same root cause as PR #136 (kernel \`com2_async_poll\`): a 4096-iteration drain loop. On an unconnected serial port the LSR returns 0xFF, so the data-ready bit is set every read, and the loop burns the full budget on syscalls + port-I/O VMEXITs (~38ms per call under KVM).
- Cap the userspace \`god_mode::poll_com3\` loop at 256. Real god-mode commands are line-oriented (~80 bytes each) so this is well over the headroom needed; overflow rolls into the next frame.

## Measured impact (Proxmox VM 800, KVM)

| baseline | after PR #136 (com2) | after this PR (com3) |
|---:|---:|---:|
| 75ms/frame (~13fps) | 42ms/frame (~24fps) | **5.5ms/frame (~180fps headroom)** |

Net: **14x** improvement vs. the original Issue #135 baseline.

## Test plan
- [x] \`cargo build --release -p compositor\` clean
- [x] Live boot on Proxmox VM 800
- [x] \`TIMING\` samples drop from ~42ms to ~5.5ms; folkui-demo calculator still works end-to-end (no input regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)