### PR TITLE
feat(phase-d.3.2): embedding lookup + RMSNorm over loaded .fbin tensors

### DIFF
--- a/userspace/inference/src/main.rs
+++ b/userspace/inference/src/main.rs
@@ -135,6 +135,17 @@ fn main() -> ! {
         println!("[INFERENCE] weights D.3.1 self-test PASS");
     }
 
+    // D.3.2: end-to-end exercise of the new ops over the loaded
+    // weights. Pulls the same `.fbin` tensors into actual math:
+    // embedding_lookup followed by RMSNorm, with hand-computed
+    // expected output. Proves the data path goes from on-disk
+    // bytes → parsed tensor → live forward-pass code.
+    if !run_d32_self_test() {
+        println!("[INFERENCE] FATAL: D.3.2 self-test failed");
+    } else {
+        println!("[INFERENCE] D.3.2 self-test PASS");
+    }
+
     println!("[INFERENCE] ready — awaiting IPC requests on this task id");
 
     let mut req_count: u64 = 0;
@@ -238,6 +249,68 @@ fn run_fbin_self_test() -> bool {
     println!(
         "[INFERENCE] fbin: embed_hash=0x{:x} weight_hash=0x{:x}",
         h_embed, h_weight
+    );
+    true
+}
+
+/// D.3.2 end-to-end self-test:
+/// 1. Parse the embedded `.fbin` blob.
+/// 2. Treat `embed_test` (4×4 f32) as a 4-vocab × 4-hidden_dim
+///    embedding table, look up `vocab_id = 1` → row [5, 6, 7, 8].
+/// 3. Treat `weight_test` (4 f32) as the RMSNorm scale and apply.
+/// 4. Sum the result and compare against the hand-computed value
+///    from `tensor_math::self_test`.
+///
+/// This is the first time we run "real" forward-pass code over
+/// data that came in via the .fbin loader. When D.3.1.2 lands and
+/// the source switches to Synapse VFS, this same function is the
+/// regression test.
+fn run_d32_self_test() -> bool {
+    use weights::FbinView;
+
+    let view = match FbinView::parse(weights_test_blob::TEST_FBIN) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let embed = view.find("embed_test");
+    let weight = view.find("weight_test");
+    let (Some(embed), Some(weight)) = (embed, weight) else {
+        println!("[INFERENCE] D.3.2: missing tensors in .fbin");
+        return false;
+    };
+
+    let embed_data = match view.read_f32(embed) {
+        Some(v) => v,
+        None => return false,
+    };
+    let weight_data = match view.read_f32(weight) {
+        Some(v) => v,
+        None => return false,
+    };
+
+    // Embedding lookup: vocab_id 1 → row [5, 6, 7, 8]
+    let vec = match tensor_math::embedding_lookup(&embed_data, 4, 4, 1) {
+        Some(v) => v,
+        None => return false,
+    };
+    if vec != [5.0_f32, 6.0, 7.0, 8.0] {
+        println!("[INFERENCE] D.3.2: embed lookup row 1 wrong");
+        return false;
+    }
+
+    // RMSNorm with weight_test → expected sum ≈ 2.65336
+    let normed = match tensor_math::rmsnorm(&vec, &weight_data, 1e-6) {
+        Some(v) => v,
+        None => return false,
+    };
+    let sum: f32 = normed.iter().sum();
+    if (sum - 2.65336).abs() > 5e-3 {
+        println!("[INFERENCE] D.3.2: RMSNorm sum {} off from expected 2.65336", sum);
+        return false;
+    }
+    println!(
+        "[INFERENCE] D.3.2: embed[1] -> RMSNorm -> sum={} (expected 2.65336)",
+        sum
     );
     true
 }

--- a/userspace/inference/src/tensor_math.rs
+++ b/userspace/inference/src/tensor_math.rs
@@ -106,12 +106,76 @@ pub fn matmul(a: &Tensor2, b: &Tensor2) -> Tensor2 {
     out
 }
 
-/// Boot-time correctness check. Runs the same 2×2 matmul we used as
-/// the original D.1 demo and returns true iff every entry matches.
-/// Cheap (single-digit microseconds) — invoked once from `main`
-/// so a regression in our matmul shows up immediately rather than
-/// 800 LOC into a real model forward pass.
+/// Embedding lookup: `table[vocab_id, :]` from a row-major
+/// `[n_vocab, hidden_dim]` table. Allocates a fresh `Vec<f32>` of
+/// length `hidden_dim` so the caller can mutate it for the rest of
+/// the forward pass without poisoning the table.
+///
+/// Returns None on out-of-range vocab_id, NOT an empty Vec — empty
+/// would be silently wrong if the caller forgot to validate.
+pub fn embedding_lookup(
+    table: &[f32],
+    n_vocab: usize,
+    hidden_dim: usize,
+    vocab_id: u32,
+) -> Option<Vec<f32>> {
+    let id = vocab_id as usize;
+    if id >= n_vocab { return None; }
+    if table.len() != n_vocab * hidden_dim { return None; }
+    let start = id * hidden_dim;
+    let mut out = Vec::with_capacity(hidden_dim);
+    out.extend_from_slice(&table[start..start + hidden_dim]);
+    Some(out)
+}
+
+/// Fast inverse square root (Quake-style) with 2 Newton-Raphson
+/// iterations. ~0.0001% precision — needed because Qwen2.5 stacks
+/// RMSNorm 60× across 30 layers, and a single-iteration version's
+/// 0.175% drift compounds to ~11% by the final layer (lifted from
+/// `libtensor::ops::fast_rsqrt`, project memory:
+/// `folkering-bpe-tokenizer.md`'s sibling lessons).
+///
+/// Avoids pulling in libm. Stable on QEMU TCG where the FPU-emulated
+/// libm sqrt is ~100× slower than this.
+#[inline]
+fn fast_rsqrt(x: f32) -> f32 {
+    if x <= 0.0 { return 0.0; }
+    let i = 0x5F375A86u32.wrapping_sub(x.to_bits() >> 1);
+    let y = f32::from_bits(i);
+    let y = y * (1.5 - 0.5 * x * y * y);
+    y * (1.5 - 0.5 * x * y * y)
+}
+
+/// RMSNorm — Qwen2.5 / Llama-style normalization.
+///
+///   y_i = x_i / sqrt(mean(x²) + eps) * weight_i
+///
+/// Operates in-place-style by allocating a fresh `Vec<f32>`. We
+/// could mutate `x` directly to save the alloc, but at D.3.2 scale
+/// the explicit allocation makes the data flow obvious; we'll
+/// switch to in-place when D.3.4 starts caring about per-token
+/// throughput.
+pub fn rmsnorm(x: &[f32], weight: &[f32], eps: f32) -> Option<Vec<f32>> {
+    if x.len() != weight.len() { return None; }
+    if x.is_empty() { return Some(Vec::new()); }
+    let n = x.len();
+    let mut sum_sq: f32 = 0.0;
+    for &v in x { sum_sq += v * v; }
+    let mean_sq = sum_sq / (n as f32);
+    let inv_rms = fast_rsqrt(mean_sq + eps);
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(x[i] * inv_rms * weight[i]);
+    }
+    Some(out)
+}
+
+/// Boot-time correctness check. Runs all `tensor_math` ops on small
+/// inputs with hand-computed expected outputs. Cheap; invoked once
+/// from `main` so a regression in any op shows up immediately
+/// rather than 800 LOC into a real model forward pass.
 pub fn self_test() -> bool {
+    // ── 1. matmul (2×2 @ 2×2) ──
     let a = Tensor2::from_rows(&[
         &[1.0, 2.0],
         &[3.0, 4.0],
@@ -121,9 +185,47 @@ pub fn self_test() -> bool {
         &[7.0, 8.0],
     ]);
     let c = matmul(&a, &b);
-    (c.get(0, 0) - 19.0).abs() < 1e-6
+    let matmul_ok = (c.get(0, 0) - 19.0).abs() < 1e-6
         && (c.get(0, 1) - 22.0).abs() < 1e-6
         && (c.get(1, 0) - 43.0).abs() < 1e-6
-        && (c.get(1, 1) - 50.0).abs() < 1e-6
+        && (c.get(1, 1) - 50.0).abs() < 1e-6;
+    if !matmul_ok { return false; }
+
+    // ── 2. fast_rsqrt sanity ──
+    // 1/sqrt(4) = 0.5 exactly. Our 2-iteration NR converges close.
+    let r = fast_rsqrt(4.0);
+    if (r - 0.5).abs() > 1e-3 { return false; }
+
+    // ── 3. RMSNorm against hand-computed reference ──
+    // x = [5, 6, 7, 8], mean(x²) = (25+36+49+64)/4 = 43.5
+    // rms = sqrt(43.5) ≈ 6.5954529791
+    // w = [0.25, 0.5, 0.75, 1.0]
+    // y_i = x_i / rms * w_i:
+    //   y_0 = 5 / 6.5954529791 * 0.25 ≈ 0.18952
+    //   y_1 = 6 / 6.5954529791 * 0.50 ≈ 0.45486
+    //   y_2 = 7 / 6.5954529791 * 0.75 ≈ 0.79601
+    //   y_3 = 8 / 6.5954529791 * 1.00 ≈ 1.21297
+    //   sum ≈ 2.65336
+    let xs = [5.0_f32, 6.0, 7.0, 8.0];
+    let ws = [0.25_f32, 0.5, 0.75, 1.0];
+    let normed = match rmsnorm(&xs, &ws, 1e-6) {
+        Some(v) => v,
+        None => return false,
+    };
+    let sum: f32 = normed.iter().sum();
+    if (sum - 2.65336).abs() > 5e-3 { return false; }
+
+    // ── 4. embedding_lookup ──
+    // table is 4×4 row-major [1..16]. Row 1 = [5, 6, 7, 8].
+    let table: Vec<f32> = (1..=16).map(|n| n as f32).collect();
+    let row1 = match embedding_lookup(&table, 4, 4, 1) {
+        Some(v) => v,
+        None => return false,
+    };
+    if row1 != [5.0_f32, 6.0, 7.0, 8.0] { return false; }
+    // out-of-range returns None
+    if embedding_lookup(&table, 4, 4, 9).is_some() { return false; }
+
+    true
 }
 


### PR DESCRIPTION
## Summary

First time the inference task runs **real forward-pass code** over data that came in via the .fbin loader. Two new ops in \`tensor_math\` plus a boot self-test that wires the .fbin loader to the new ops end-to-end.

## What's new

**\`embedding_lookup(table, n_vocab, hidden_dim, vocab_id) -> Option<Vec<f32>>\`**
Returns the (vocab_id)-th row of a row-major \`[n_vocab, hidden_dim]\` table. Out-of-range returns \`None\`.

**\`rmsnorm(x, weight, eps) -> Option<Vec<f32>>\`**
Standard Llama/Qwen formula: \`y_i = x_i / sqrt(mean(x²) + eps) * w_i\`. Uses \`fast_rsqrt\` (Quake-style + 2× Newton-Raphson) for ~0.0001% precision — needed because Qwen2.5 stacks 60 RMSNorms across 30 layers and a single-iteration's 0.175% error compounds to ~11% drift by the final layer. Helper lifted from \`libtensor::ops::fast_rsqrt\` with attribution.

## Boot self-test (live, Proxmox VM 800)

\`\`\`
[INFERENCE] D.3.2: embed[1] -> RMSNorm -> sum=2.6533327 (expected 2.65336)
[INFERENCE] D.3.2 self-test PASS
\`\`\`

Hand-computed reference (in the source comment): mean(x²) = 43.5, rms ≈ 6.5955, scale by [0.25, 0.5, 0.75, 1.0], sum = 2.65336. Runtime drift: **3e-5**. Within bounds for f32 + Newton-Raphson convergence.

## What this unblocks
- **D.3.3 (FFN block)**: build SiLU + gated MLP using the same pattern. SiLU is the only new op needed.
- **D.3.4 (attention)**: RMSNorm runs at the start of every transformer block; first usable op in the stack.
- **D.3.1.2 (Synapse VFS)**: when the .fbin source switches from const to VFS read, this same self-test is the regression test.

## Test plan
- [x] \`cargo build --release -p inference\` clean
- [x] All previous self-tests still pass (matmul, .fbin parser)
- [x] D.3.2 boot self-test PASS on Proxmox VM 800

🤖 Generated with [Claude Code](https://claude.com/claude-code)