### PR TITLE
feat(phase-d.3.7.virtio): PCI enumeration for multiple virtio_blk devices

### DIFF
--- a/kernel/src/drivers/pci.rs
+++ b/kernel/src/drivers/pci.rs
@@ -346,6 +346,51 @@ pub fn find_virtio_block() -> Option<PciDevice> {
     find_device(VIRTIO_VENDOR_ID, VIRTIO_BLK_DEVICE_TRANSITIONAL)
 }
 
+/// Find the Nth VirtIO block device on the bus (0-indexed). Used by
+/// the model-disk loader (D.3.7.virtio) to attach to a *secondary*
+/// virtio_blk PCI device alongside the primary one that hosts the
+/// FOLKDISK persistence partition.
+///
+/// Walks both the modern (0x1042) and transitional (0x1001) device
+/// IDs, treating them as one logical pool so the index is stable
+/// regardless of which transport variant the host exposes.
+pub fn find_virtio_block_nth(n: usize) -> Option<PciDevice> {
+    let list = PCI_DEVICES.lock();
+    let mut found = 0usize;
+    for i in 0..list.count {
+        if let Some(ref dev) = list.devices[i] {
+            if dev.vendor_id == VIRTIO_VENDOR_ID
+                && (dev.device_id == VIRTIO_BLK_DEVICE_MODERN
+                    || dev.device_id == VIRTIO_BLK_DEVICE_TRANSITIONAL)
+            {
+                if found == n {
+                    return Some(dev.clone());
+                }
+                found += 1;
+            }
+        }
+    }
+    None
+}
+
+/// Count how many VirtIO block devices the PCI scan picked up. The
+/// boot path uses this to decide whether a model disk is attached.
+pub fn count_virtio_block() -> usize {
+    let list = PCI_DEVICES.lock();
+    let mut found = 0usize;
+    for i in 0..list.count {
+        if let Some(ref dev) = list.devices[i] {
+            if dev.vendor_id == VIRTIO_VENDOR_ID
+                && (dev.device_id == VIRTIO_BLK_DEVICE_MODERN
+                    || dev.device_id == VIRTIO_BLK_DEVICE_TRANSITIONAL)
+            {
+                found += 1;
+            }
+        }
+    }
+    found
+}
+
 /// Find VirtIO network device (checks both transitional and modern IDs)
 pub fn find_virtio_net() -> Option<PciDevice> {
     if let Some(dev) = find_device(VIRTIO_VENDOR_ID, VIRTIO_NET_DEVICE_MODERN) {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -196,6 +196,27 @@ pub fn kernel_main_with_boot_info(boot_info: &boot::BootInfo) -> ! {
         // it (self-test, disk layout) even when NVMe wins the backend
         // race below, because the VirtIO disk carries the model and
         // Synapse DB that aren't MVFS-managed.
+        //
+        // D.3.7.virtio prep: log the total count of virtio_blk devices
+        // on the bus so the boot trace tells us at a glance whether a
+        // dedicated model disk is attached. The primary disk is always
+        // index 0 (FOLKDISK + Synapse persistence); index 1+ is where
+        // a model disk lands once the host configures it.
+        let n_virtio_blk = drivers::pci::count_virtio_block();
+        serial_str!("[INIT] VirtIO block devices found: ");
+        drivers::serial::write_dec(n_virtio_blk as u32);
+        serial_strln!("");
+        if n_virtio_blk >= 2 {
+            if let Some(model_dev) = drivers::pci::find_virtio_block_nth(1) {
+                serial_str!("[INIT] Secondary virtio_blk at PCI ");
+                drivers::serial::write_dec(model_dev.bus as u32);
+                serial_str!(":");
+                drivers::serial::write_dec(model_dev.device as u32);
+                serial_str!(".");
+                drivers::serial::write_dec(model_dev.function as u32);
+                serial_strln!(" — candidate model disk for D.3.7.virtio");
+            }
+        }
         serial_strln!("[INIT] Looking for VirtIO block device...");
         let virtio_blk_ready = match drivers::virtio_blk::init() {
             Ok(()) => {


### PR DESCRIPTION
## Summary
Foundation for the model-disk paging path (D.3.7.virtio). Adds:
- \`pci::find_virtio_block_nth(n)\` — returns the nth virtio_blk PCI device, treating modern (0x1042) and transitional (0x1001) IDs as one pool.
- \`pci::count_virtio_block()\` — total count of virtio_blk devices on the bus.
- Boot log: prints the count and, when ≥ 2, the PCI BDF of the secondary virtio_blk.

## Live verification (VM 900 KVM, second virtio_blk attached)
\`\`\`
[INIT] VirtIO block devices found: 2
[INIT] Secondary virtio_blk at PCI 0:11.0 — candidate model disk for D.3.7.virtio
[INIT] VirtIO block device ready
\`\`\`

The primary virtio_blk (FOLKDISK / Synapse persistence) still inits cleanly. The secondary one (qwen-model.img, 240 MB LVM volume) is detected but not yet driven.

## Out of scope (queued)
- \`model_disk\` driver: lift the virtio_blk handshake out of the primary module to support a second device. Today \`virtio_blk\` has single-device static state.
- FMDL header parsing (sector 0 of qwen-model.img — magic + filename + data_offset).
- \`read_model_file_shmem\` syscall: map a named file from the model disk into a shmem region. Inference's \`vfs_loader::read_file\` falls through to this when Synapse can't find the file in initrd.

## Test plan
- [x] PCI scan logs the count correctly with 1 virtio_blk
- [x] PCI scan logs count=2 + secondary BDF when qwen-model.img is attached as virtio1
- [x] Existing primary virtio_blk init unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)