### PR TITLE
perf(tensor_math): AVX2 + FMA Q8 matmul — 8-lane FMA inner loop

### DIFF
--- a/userspace/inference/src/tensor_math.rs
+++ b/userspace/inference/src/tensor_math.rs
@@ -17,6 +17,52 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+// CPUID-cached SIMD-feature detection for the Q8 matmul fast path.
+//
+// AVX2 + FMA gives us 8-lane FMA per instruction in `_mm256_fmadd_ps`,
+// which matches the Q8_0 block geometry exactly: 32 elements per block
+// = 4 × `__m256`. Replacing the scalar 4-way ILP unroll with vector
+// FMA cuts the inner-loop instruction count ~8× and cache-streams the
+// weight row at full memory bandwidth. CPUID gates this so we still
+// boot on hosts without AVX2 (Proxmox `kvm64`, ancient CPUs).
+//
+// Detection runs once on the first call and caches the verdict. The
+// dispatch in `WeightView::matmul` is one `Relaxed` atomic load per
+// matmul invocation — negligible against MB-scale weight reads.
+const CPU_FEAT_UNINIT: u8 = 0;
+const CPU_FEAT_NO_AVX2: u8 = 1;
+const CPU_FEAT_HAS_AVX2_FMA: u8 = 2;
+static CPU_FEATURES: AtomicU8 = AtomicU8::new(CPU_FEAT_UNINIT);
+
+#[cfg(target_arch = "x86_64")]
+fn detect_avx2_fma() -> bool {
+    use core::arch::x86_64::{__cpuid, __cpuid_count};
+    // CPUID.1:ECX[12] = FMA, [28] = AVX. AVX is required to even
+    // execute AVX2 ops; we already verified XSAVE/AVX in the kernel
+    // boot path before enabling preemption-safe context switches.
+    let leaf1 = __cpuid(1);
+    let has_fma = (leaf1.ecx >> 12) & 1 == 1;
+    // CPUID.7.0:EBX[5] = AVX2.
+    let leaf7 = __cpuid_count(7, 0);
+    let has_avx2 = (leaf7.ebx >> 5) & 1 == 1;
+    has_avx2 && has_fma
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn detect_avx2_fma() -> bool { false }
+
+#[inline]
+fn has_avx2_fma() -> bool {
+    let cached = CPU_FEATURES.load(Ordering::Relaxed);
+    if cached != CPU_FEAT_UNINIT {
+        return cached == CPU_FEAT_HAS_AVX2_FMA;
+    }
+    let result = if detect_avx2_fma() { CPU_FEAT_HAS_AVX2_FMA } else { CPU_FEAT_NO_AVX2 };
+    CPU_FEATURES.store(result, Ordering::Relaxed);
+    result == CPU_FEAT_HAS_AVX2_FMA
+}
 
 /// Yield budget: how many cells we compute per matmul row before
 /// calling `yield_cpu()`. The original 32 was tuned for the D.1
@@ -80,7 +126,20 @@ impl<'a> WeightView<'a> {
     ) -> Option<Vec<f32>> {
         match self {
             Self::F32(w) => matmul_batch_f32(w, in_dim, out_dim, x, seq),
-            Self::Q8(blocks) => matmul_batch_q8(blocks, in_dim, out_dim, x, seq),
+            Self::Q8(blocks) => {
+                #[cfg(target_arch = "x86_64")]
+                {
+                    if has_avx2_fma() {
+                        // SAFETY: CPUID verified AVX2+FMA at runtime,
+                        // so the `target_feature` annotation on the
+                        // callee is satisfied.
+                        return unsafe {
+                            matmul_batch_q8_avx2(blocks, in_dim, out_dim, x, seq)
+                        };
+                    }
+                }
+                matmul_batch_q8(blocks, in_dim, out_dim, x, seq)
+            }
         }
     }
 }
@@ -192,6 +251,107 @@ pub fn matmul_batch_q8(
                     k += 4;
                 }
                 out[s * out_dim + j] += a0 + a1 + a2 + a3;
+            }
+        }
+        since_yield += blocks_per_row * Q8_BLOCK_SIZE * seq;
+        if since_yield >= MATMUL_YIELD_EVERY {
+            since_yield = 0;
+            libfolk::sys::yield_cpu();
+        }
+    }
+    Some(out)
+}
+
+/// AVX2 + FMA Q8_0 batched matmul. Same shape and result as
+/// `matmul_batch_q8`, but the per-block dequant + per-(j,s) inner
+/// dot product run on 256-bit `__m256` vectors. The Q8 block size
+/// matches AVX2's lane width 4× exactly: 32 elements = 4 × 8 lanes,
+/// so each block dequantizes into 4 f32 vectors and each (j,s) dot
+/// product is exactly 4 FMAs + a horizontal reduction. The scalar
+/// path's 4-way ILP unroll becomes 4-way vector parallelism.
+///
+/// Numerical equivalence: FMA does `a*b + c` with a single rounding,
+/// vs. scalar `a*b` (rounded) `+ c` (rounded), so per-element
+/// results can differ by ≤ 1 ulp at intermediate accumulators.
+/// Top-1 argmax at the inference layer is robust to this; in
+/// practice the dispatched logits drift < 1e-5 from the scalar
+/// reference on Qwen3-0.6B fixtures.
+///
+/// SAFETY: caller must verify CPUID for AVX2 + FMA before calling.
+/// `WeightView::matmul` enforces this via `has_avx2_fma()`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+pub unsafe fn matmul_batch_q8_avx2(
+    weights_q8: &[u8],
+    in_dim: usize,
+    out_dim: usize,
+    x: &[f32],
+    seq: usize,
+) -> Option<Vec<f32>> {
+    use core::arch::x86_64::*;
+
+    if in_dim % Q8_BLOCK_SIZE != 0 { return None; }
+    if x.len() != seq * in_dim { return None; }
+    let blocks_per_row = in_dim / Q8_BLOCK_SIZE;
+    let row_bytes = blocks_per_row * Q8_BLOCK_BYTES;
+    if weights_q8.len() != out_dim * row_bytes { return None; }
+
+    let mut out = vec![0.0f32; seq * out_dim];
+    let mut since_yield: usize = 0;
+
+    for j in 0..out_dim {
+        let row_off = j * row_bytes;
+        for b in 0..blocks_per_row {
+            let block_off = row_off + b * Q8_BLOCK_BYTES;
+
+            // Block scale: f16 → f32 broadcast across 8 lanes.
+            let scale = f16_to_f32(u16::from_le_bytes([
+                weights_q8[block_off],
+                weights_q8[block_off + 1],
+            ]));
+            let scale_v = _mm256_set1_ps(scale);
+
+            // Dequant 32 i8s → 4 × __m256. _mm256_cvtepi8_epi32 sign-
+            // extends the LOW 8 bytes of an __m128i into 8 i32 lanes.
+            // We slide the byte window with `srli_si128` to cover all
+            // 32 bytes in two halves of 16.
+            let q_ptr = weights_q8.as_ptr().add(block_off + 2) as *const __m128i;
+            let raw_lo = _mm_loadu_si128(q_ptr);
+            let raw_hi = _mm_loadu_si128(q_ptr.add(1));
+            let deq0 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(raw_lo)), scale_v);
+            let deq1 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(raw_lo, 8))), scale_v);
+            let deq2 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(raw_hi)), scale_v);
+            let deq3 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(raw_hi, 8))), scale_v);
+
+            let x_off_b = b * Q8_BLOCK_SIZE;
+            for s in 0..seq {
+                let xs_ptr = x.as_ptr().add(s * in_dim + x_off_b);
+                // 32 contiguous f32s = 4 × 8 lanes. `loadu` handles
+                // unaligned input — `x` comes from arbitrary scratch
+                // arenas in the forward pass, no alignment guarantee.
+                let xs0 = _mm256_loadu_ps(xs_ptr);
+                let xs1 = _mm256_loadu_ps(xs_ptr.add(8));
+                let xs2 = _mm256_loadu_ps(xs_ptr.add(16));
+                let xs3 = _mm256_loadu_ps(xs_ptr.add(24));
+
+                let mut acc = _mm256_setzero_ps();
+                acc = _mm256_fmadd_ps(deq0, xs0, acc);
+                acc = _mm256_fmadd_ps(deq1, xs1, acc);
+                acc = _mm256_fmadd_ps(deq2, xs2, acc);
+                acc = _mm256_fmadd_ps(deq3, xs3, acc);
+
+                // Horizontal sum: high half + low half, then reduce
+                // the resulting 128-bit lane down to a scalar.
+                let lo = _mm256_castps256_ps128(acc);
+                let hi = _mm256_extractf128_ps(acc, 1);
+                let s4 = _mm_add_ps(lo, hi);
+                let s4_hi = _mm_movehdup_ps(s4);
+                let s2 = _mm_add_ps(s4, s4_hi);
+                let s2_hi = _mm_movehl_ps(s4_hi, s2);
+                let s1 = _mm_add_ss(s2, s2_hi);
+                let sum = _mm_cvtss_f32(s1);
+
+                *out.get_unchecked_mut(s * out_dim + j) += sum;
             }
         }
         since_yield += blocks_per_row * Q8_BLOCK_SIZE * seq;


### PR DESCRIPTION
## Summary

Replaces the scalar 4-way ILP unroll inside `matmul_batch_q8` with a `_mm256_fmadd_ps` inner loop. The Q8_0 block geometry maps exactly to AVX2: **32 elements per block = 4 × 8-lane `__m256`**, so each block dequantizes into 4 vectors and each `(j, s)` dot product collapses to 4 FMAs + a horizontal reduction.

Builds on the kernel xsave/xrstor work merged as 044146f (#165) — xsave64 was the prereq for any AVX2 in userspace, since fxsave64-only context saves would silently lose YMM[255:128] across preemption.

## Dispatch

CPUID-gated. `CPU_FEATURES` caches the verdict in an `AtomicU8` after a one-time `__cpuid(1)` + `__cpuid_count(7, 0)` check (FMA bit + AVX2 bit). `WeightView::matmul` does one `Relaxed` load per call before choosing scalar vs AVX2 — negligible against MB-scale weight reads. Hosts without AVX2+FMA fall through to the existing scalar path.

```rust
match self {
    Self::F32(w) => matmul_batch_f32(...),
    Self::Q8(blocks) => {
        if has_avx2_fma() {
            return unsafe { matmul_batch_q8_avx2(...) };
        }
        matmul_batch_q8(...)  // scalar fallback
    }
}
```

## Live verification on Proxmox VM 900 KVM

```
[INFERENCE] D.3.5: token_ids=[1,2,3] -> argmax=3 logits[3]=1.1470144
[INFERENCE] D.3.5 forward-pass self-test PASS
[INFERENCE] D.3.1.q: Q8 forward -> argmax=3 logits[3]=1.1469464
[INFERENCE] D.3.1.q Q8 self-test PASS
[INFERENCE] D.3.7: First Blood — real Qwen3-0.6B (4 layers, Q8)...
[INFERENCE] D.3.7: loaded qwen.fbin (604 MB) via keep-mapped shmem
[INFERENCE] D.3.7: parsed 312 tensors from .fbin
[INFERENCE] D.3.7: encoded prompt -> 14 tokens
[INFERENCE] D.3.7: first token = 72 ("i")
[INFERENCE] D.3.7: argmax matches numpy reference (72)
[INFERENCE] D.3.7: sampled 8 tokens, ids=[72, 2282, 815, 9693, 268, 269, 745, 72]
[INFERENCE] D.3.7: Draug response: \"iscriptioyesenorallyi\"
[INFERENCE] D.3.7 First Blood — model lives.
```

**Same 8 sampled ids, same response string as PR #160** (the original scalar 4-layer First Blood) — bit-identical at the argmax layer through prefill + 7 decode steps + the 151,936-class lm_head.

The 1-ulp drift on D.3.5 logits[3] (1.1470144 vs scalar's 1.1470145) is FMA's single-rounding semantics; argmax is robust to this.

## Disassembly confirms the path is real

```asm
vfmadd213ps %ymm0,%ymm1,%ymm5
vfmadd231ps -0x40(%rdi),%ymm2,%ymm5
vfmadd231ps -0x20(%rdi),%ymm3,%ymm5
vfmadd231ps   (%rdi),%ymm4,%ymm5
```

LLVM fused load+FMA into single instructions where possible.

## Out of scope (next perf axes)

- **`MATMUL_YIELD_EVERY` is too aggressive once the math is fast.** Yield syscall overhead now dominates First Blood wall-clock (~7 min for 4-layer instead of seconds). Tuning + maybe a \"no yield in inference task\" flag is the next PR.
- **`forward_pass`'s lm_head still calls `matvec`** (scalar `linear_q8`) rather than `matmul` with `seq=1`. Migrating that gives AVX2 to the dominant 1024 → 151936 projection.
- **Per-call scratch arena** to drop bump-heap pressure for long-form generation.

## Test plan

- [x] Userspace `cargo build --release` green
- [x] Disassembly shows `vfmadd*ps` in `matmul_batch_q8_avx2`
- [x] All 11 self-tests PASS through D.4 KV-cache
- [x] D.3.7 First Blood matches PR #160's reference output bit-for-bit
- [ ] CI green (kernel-build + userspace-check + host-tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)