### PR TITLE
🎯 feat(smp): parallel-Q8 GEMM via 4 vCPUs — 1.4× decode speedup

### DIFF
--- a/kernel/src/arch/x86_64/smp.rs
+++ b/kernel/src/arch/x86_64/smp.rs
@@ -31,6 +31,13 @@ pub struct GemmWork {
     pub col_start: u32,
     pub col_end: u32,
     pub quant_type: u8,
+    /// Page table to load before executing this work. APs swap CR3
+    /// to this so the userspace virtual addresses in the three ptr
+    /// fields above resolve identically to how the BSP sees them —
+    /// each access goes through the MMU per-page, so scattered
+    /// shmem-backed weights (the 165 MiB Q8 model file is the
+    /// motivating case) just work.
+    pub task_cr3: u64,
 }
 
 static mut WORK_ITEMS: [GemmWork; MAX_CPUS] = unsafe { core::mem::zeroed() };
@@ -149,6 +156,13 @@ fn ap_worker_loop(cpu_index: usize) -> ! {
     crate::drivers::serial::write_dec(cpu_index as u32);
     crate::serial_str!("] Worker loop entered\n");
 
+    // Capture this AP's boot-time CR3 — Limine set up a kernel-only
+    // page table for the AP, identical to the BSP's pre-userspace
+    // mapping. We restore to it after each job so the AP keeps
+    // running in a known kernel address space between dispatches.
+    let mut boot_cr3: u64;
+    unsafe { core::arch::asm!("mov {}, cr3", out(reg) boot_cr3); }
+
     loop {
         // PAUSE-based spin wait. Under WHPX each vCPU is a real thread —
         // PAUSE hints to the CPU that we're spin-waiting, reducing power.
@@ -156,15 +170,23 @@ fn ap_worker_loop(cpu_index: usize) -> ! {
             core::hint::spin_loop();
         }
 
-        // NO CR3 swap! Pointers in WORK_ITEMS are already HHDM-translated
-        // by the BSP in dispatch_parallel_gemm.
-
+        // Swap to the task's page table so the userspace virtual
+        // pointers in WORK_ITEMS resolve through the same MMU
+        // mappings the BSP sees. This is the fix for shmem-backed
+        // weights whose physical pages are scattered — the previous
+        // HHDM-linear translation only worked when userspace virt
+        // mapped to physically-contiguous frames.
         let work = unsafe { &WORK_ITEMS[cpu_index] };
-        unsafe { execute_gemm_work(work); }
-
-        crate::serial_str!("[AP");
-        crate::drivers::serial::write_dec(cpu_index as u32);
-        crate::serial_str!("] Work done\n");
+        let task_cr3 = work.task_cr3;
+        unsafe {
+            if task_cr3 != 0 {
+                core::arch::asm!("mov cr3, {}", in(reg) task_cr3);
+            }
+            execute_gemm_work(work);
+            if task_cr3 != 0 {
+                core::arch::asm!("mov cr3, {}", in(reg) boot_cr3);
+            }
+        }
 
         WORK_DONE[cpu_index].store(1, Ordering::Release);
         WORK_READY[cpu_index].store(0, Ordering::Release);
@@ -187,19 +209,11 @@ pub fn dispatch_parallel_gemm(
         return -1;
     }
 
-    // Translate userspace pointers to HHDM addresses so APs can access them
-    // without switching CR3. BSP walks the task's page table to find physical
-    // addresses, then adds HHDM offset.
-    let hhdm = crate::memory::paging::hhdm_offset() as u64;
-    let input_hhdm = virt_to_hhdm(task_cr3, input_ptr, hhdm);
-    let weight_hhdm = virt_to_hhdm(task_cr3, weight_ptr, hhdm);
-    let output_hhdm = virt_to_hhdm(task_cr3, output_ptr, hhdm);
-
-    if input_hhdm == 0 || weight_hhdm == 0 || output_hhdm == 0 {
-        crate::serial_str!("[PGEMM] HHDM translation failed!\n");
-        return -1;
-    }
-
+    // APs now swap CR3 to the task's page table inside their work
+    // loop, so userspace virtual pointers are valid as-is. No HHDM
+    // pre-translation needed — the MMU handles per-page lookups,
+    // which is the only thing that works for shmem-backed weights
+    // whose physical pages are scattered across the heap.
     let total_workers = num_aps + 1;
     let n_usize = n as usize;
     let cols_per_worker = n_usize / total_workers;
@@ -217,13 +231,14 @@ pub fn dispatch_parallel_gemm(
 
         unsafe {
             WORK_ITEMS[worker_idx] = GemmWork {
-                input_ptr: input_hhdm,   // HHDM-translated for APs
-                weight_ptr: weight_hhdm,
-                output_ptr: output_hhdm,
+                input_ptr,    // userspace virt — AP swaps CR3
+                weight_ptr,
+                output_ptr,
                 k, n,
                 col_start: col as u32,
                 col_end: (col + my_cols) as u32,
                 quant_type,
+                task_cr3,
             };
         }
 
@@ -232,13 +247,16 @@ pub fn dispatch_parallel_gemm(
         col += my_cols;
     }
 
-    // BSP does its share
+    // BSP does its share. BSP is already running in task's CR3
+    // (we're inside a syscall on this task), so userspace virt
+    // pointers resolve through the MMU per-page just like the APs.
     let bsp_work = GemmWork {
         input_ptr, weight_ptr, output_ptr,
         k, n,
         col_start: bsp_col_start as u32,
         col_end: (bsp_col_start + bsp_cols) as u32,
         quant_type,
+        task_cr3: 0, // BSP doesn't swap; it's already in task_cr3
     };
 
     crate::serial_str!("[PGEMM] BSP cols ");
@@ -354,11 +372,100 @@ fn has_avx2() -> bool {
     result & (1 << 5) != 0
 }
 
+// Q8_0: 32 values per block, 34 bytes (1× f16 scale + 32× i8 vals).
+// Same convention as `userspace::inference::tensor_math` and llama.cpp.
+const Q8_0_BLOCK_SIZE: usize = 34;
+const Q8_0_BLOCK_VALUES: usize = 32;
+
 unsafe fn execute_gemm_work(work: &GemmWork) {
-    if has_avx2() {
-        execute_gemm_work_avx2(work);
-    } else {
-        execute_gemm_work_scalar(work);
+    // quant_type: 0 = Q8_0, 1 = Q6_K. Q8_0 is the format the
+    // inference task uses end-to-end (PRs #166/#168/#170); Q6_K is
+    // legacy from libtensor / inference-server. AVX2 path required
+    // for both — we already gate AVX2 enablement at boot (#165 +
+    // smp.rs CR4 setup), so no fallback below.
+    match work.quant_type {
+        0 => execute_gemm_work_q8_avx2(work),
+        _ => {
+            if has_avx2() {
+                execute_gemm_work_avx2(work);
+            } else {
+                execute_gemm_work_scalar(work);
+            }
+        }
+    }
+}
+
+/// Q8_0 GEMM column-strip executor for one AP. Mirror of the
+/// userspace `matmul_batch_q8_avx2` for the seq=1 case: caller
+/// provides one input vector of length `k` (in_dim) and a Q8_0-
+/// quantised weight matrix of shape `[n × k]` with `n` being
+/// out_dim. We compute `c[col] = sum_i (input[i] * dequant(B[col, i]))`
+/// for each `col` in our assigned `[col_start, col_end)` strip.
+///
+/// Layout matches the `.fbin`'s row-major Q8 layout: each output
+/// row (one output element here) is `n_blocks * Q8_0_BLOCK_SIZE`
+/// bytes, with `n_blocks = k / 32`.
+#[target_feature(enable = "avx2", enable = "fma")]
+unsafe fn execute_gemm_work_q8_avx2(work: &GemmWork) {
+    use core::arch::x86_64::*;
+    let k = work.k as usize;
+    let n = work.n as usize;
+    let col_start = work.col_start as usize;
+    let col_end = work.col_end as usize;
+    let n_blocks = k / Q8_0_BLOCK_VALUES;
+    let row_bytes = n_blocks * Q8_0_BLOCK_SIZE;
+
+    let a_f32 = core::slice::from_raw_parts(work.input_ptr as *const f32, k);
+    let b_q8 = core::slice::from_raw_parts(work.weight_ptr as *const u8, n * row_bytes);
+    let c = core::slice::from_raw_parts_mut(work.output_ptr as *mut f32, n);
+
+    for col in col_start..col_end {
+        let row_off = col * row_bytes;
+        let mut acc = _mm256_setzero_ps();
+
+        for b in 0..n_blocks {
+            let block_off = row_off + b * Q8_0_BLOCK_SIZE;
+            // Block scale from f16 → f32, broadcast to 8 lanes.
+            let scale_bits = u16::from_le_bytes([
+                b_q8[block_off],
+                b_q8[block_off + 1],
+            ]);
+            let scale = f16_to_f32(scale_bits);
+            let scale_v = _mm256_set1_ps(scale);
+
+            // Dequant 32 i8s → 4 × __m256. _mm256_cvtepi8_epi32
+            // sign-extends low 8 bytes of __m128i; we slide the
+            // window with srli_si128 to cover all 32 bytes.
+            let q_ptr = b_q8.as_ptr().add(block_off + 2) as *const __m128i;
+            let raw_lo = _mm_loadu_si128(q_ptr);
+            let raw_hi = _mm_loadu_si128(q_ptr.add(1));
+            let deq0 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(raw_lo)), scale_v);
+            let deq1 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(raw_lo, 8))), scale_v);
+            let deq2 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(raw_hi)), scale_v);
+            let deq3 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(raw_hi, 8))), scale_v);
+
+            let a_base = b * Q8_0_BLOCK_VALUES;
+            let xs_ptr = a_f32.as_ptr().add(a_base);
+            let xs0 = _mm256_loadu_ps(xs_ptr);
+            let xs1 = _mm256_loadu_ps(xs_ptr.add(8));
+            let xs2 = _mm256_loadu_ps(xs_ptr.add(16));
+            let xs3 = _mm256_loadu_ps(xs_ptr.add(24));
+
+            acc = _mm256_fmadd_ps(deq0, xs0, acc);
+            acc = _mm256_fmadd_ps(deq1, xs1, acc);
+            acc = _mm256_fmadd_ps(deq2, xs2, acc);
+            acc = _mm256_fmadd_ps(deq3, xs3, acc);
+        }
+
+        // Horizontal reduce 8 lanes to scalar.
+        let lo = _mm256_castps256_ps128(acc);
+        let hi = _mm256_extractf128_ps(acc, 1);
+        let s4 = _mm_add_ps(lo, hi);
+        let s4_hi = _mm_movehdup_ps(s4);
+        let s2 = _mm_add_ps(s4, s4_hi);
+        let s2_hi = _mm_movehl_ps(s4_hi, s2);
+        let s1 = _mm_add_ss(s2, s2_hi);
+        c[col] = _mm_cvtss_f32(s1);
     }
 }
 

--- a/kernel/src/arch/x86_64/syscall/dispatch.rs
+++ b/kernel/src/arch/x86_64/syscall/dispatch.rs
@@ -199,7 +199,7 @@ pub(super) extern "C" fn syscall_handler(
         0xE2 => crate::net::tcp_async::syscall_tcp_poll_recv(arg1, arg2, arg3),
         0xE3 => crate::net::tcp_async::syscall_tcp_close(arg1),
         // SMP: Parallel GEMM
-        0x60 => syscall_parallel_gemm(arg1, arg2, arg3, arg4, arg5, arg6),
+        0x60 => syscall_parallel_gemm(arg1, arg2, arg3, arg4, arg5),
         // Hybrid AI: Ask Gemini cloud API
         0x70 => syscall_ask_gemini(arg1, arg2, arg3),
         // VirtIO GPU

--- a/kernel/src/arch/x86_64/syscall/handlers/compute.rs
+++ b/kernel/src/arch/x86_64/syscall/handlers/compute.rs
@@ -5,13 +5,20 @@ pub fn syscall_parallel_gemm(
     weight_ptr: u64,
     output_ptr: u64,
     k: u64,
-    n: u64,
-    quant_type: u64,
+    n_qt: u64,
 ) -> u64 {
+    // Userspace packs `quant_type` into the top byte of `n` because the
+    // syscall entry shuffle drops C-ABI arg6 (mov r9, r8 overwrites it
+    // before r9 can be preserved). Lower 32 bits of n_qt = n; bits 56..64
+    // = quant_type. See `libfolk::sys::parallel_gemm` doc.
+    let n = (n_qt & 0xFFFF_FFFF) as u64;
+    let quant_type = ((n_qt >> 56) & 0xFF) as u8;
     crate::serial_str!("[PGEMM] syscall entry k=");
     crate::drivers::serial::write_dec(k as u32);
     crate::serial_str!(" n=");
     crate::drivers::serial::write_dec(n as u32);
+    crate::serial_str!(" qt=");
+    crate::drivers::serial::write_dec(quant_type as u32);
     crate::drivers::serial::write_newline();
 
     let task_id = crate::task::task::get_current_task();

--- a/userspace/inference/src/tensor_math.rs
+++ b/userspace/inference/src/tensor_math.rs
@@ -180,14 +180,20 @@ impl<'a> WeightView<'a> {
                 matmul_batch_f32(w, in_dim, out_dim, x, seq)
             }
             Self::Q8(blocks) => {
-                // SMP fast path scaffolded but disabled — kernel-side
-                // Q8 GEMM produces wrong argmax for unknown reasons;
-                // single-core AVX2 below is the verified path.
-                // `try_parallel_q8` and `SMP_DISPATCH_MIN_OUT_DIM`
-                // remain in source for the future SMP debug session
-                // but won't be reached at runtime.
+                // SMP fast path — only worth the cross-CPU
+                // coordination overhead for very large `out_dim`.
+                // lm_head at 151 936 dominates decode wall-clock by
+                // ~50 %; everything else (Q/K/V/Wo at ≤3072) stays
+                // on the single-core AVX2 path.
                 #[cfg(target_arch = "x86_64")]
                 {
+                    if seq == 1 && out_dim >= SMP_DISPATCH_MIN_OUT_DIM {
+                        if let Some(out) = try_parallel_q8(blocks, in_dim, out_dim, x) {
+                            return Some(out);
+                        }
+                        // Fall through to single-core if SMP is
+                        // unavailable (no APs online, syscall failed).
+                    }
                     if has_avx2_fma() {
                         // SAFETY: CPUID verified AVX2+FMA at runtime,
                         // so the `target_feature` annotation on the

--- a/userspace/inference/src/tensor_math.rs
+++ b/userspace/inference/src/tensor_math.rs
@@ -76,6 +76,46 @@ fn has_avx2_fma() -> bool {
 /// yield is a cheap nudge, not a guarantee.
 const MATMUL_YIELD_EVERY: usize = 1_048_576;
 
+/// Minimum `out_dim` before `WeightView::matmul` tries the SMP
+/// parallel-GEMM path. Below this, the cross-CPU job dispatch
+/// (~tens of µs of syscall + spin coordination) costs more than
+/// the AVX2 single-core path saves. Empirically the lm_head
+/// (151 936-class) wins decisively; everything else (≤ 3072) stays
+/// single-core. Tunable.
+const SMP_DISPATCH_MIN_OUT_DIM: usize = 16_384;
+
+/// Try to run a seq=1 Q8 matmul across the AP cores via
+/// `SYS_PARALLEL_GEMM`. Returns `None` if SMP is unavailable
+/// (no APs online, syscall failed) so the caller can fall back
+/// to single-core. Returns `Some(out)` of length `out_dim` on
+/// success.
+///
+/// `quant_type = 0` matches the kernel's Q8_0 dispatch branch.
+#[cfg(target_arch = "x86_64")]
+fn try_parallel_q8(
+    weights_q8: &[u8],
+    in_dim: usize,
+    out_dim: usize,
+    x: &[f32],
+) -> Option<Vec<f32>> {
+    if x.len() != in_dim { return None; }
+    if in_dim % Q8_BLOCK_SIZE != 0 { return None; }
+    let blocks_per_row = in_dim / Q8_BLOCK_SIZE;
+    let row_bytes = blocks_per_row * Q8_BLOCK_BYTES;
+    if weights_q8.len() != out_dim * row_bytes { return None; }
+
+    let mut out = vec![0.0f32; out_dim];
+    let ok = libfolk::sys::parallel_gemm(
+        x.as_ptr(),
+        weights_q8.as_ptr(),
+        out.as_mut_ptr(),
+        in_dim,
+        out_dim,
+        0,            // quant_type 0 = Q8_0
+    );
+    if ok { Some(out) } else { None }
+}
+
 /// Q8_0 block size — same as llama.cpp / GGUF. Picked for
 /// cache-friendly inner loops: a 32-element block is one f16 scale
 /// + 32 i8 vals = 34 bytes, fits comfortably in any sane L1.
@@ -140,6 +180,12 @@ impl<'a> WeightView<'a> {
                 matmul_batch_f32(w, in_dim, out_dim, x, seq)
             }
             Self::Q8(blocks) => {
+                // SMP fast path scaffolded but disabled — kernel-side
+                // Q8 GEMM produces wrong argmax for unknown reasons;
+                // single-core AVX2 below is the verified path.
+                // `try_parallel_q8` and `SMP_DISPATCH_MIN_OUT_DIM`
+                // remain in source for the future SMP debug session
+                // but won't be reached at runtime.
                 #[cfg(target_arch = "x86_64")]
                 {
                     if has_avx2_fma() {

--- a/userspace/libfolk/src/sys/task.rs
+++ b/userspace/libfolk/src/sys/task.rs
@@ -49,6 +49,12 @@ pub fn spawn(binary: &[u8]) -> Option<u32> {
 
 /// Dispatch parallel GEMM across AP compute workers.
 /// Returns true on success (APs available), false on failure (fallback to sequential).
+///
+/// ABI note: the x86_64 syscall entry shuffle in `kernel::arch::x86_64::syscall::entry`
+/// overwrites C-ABI arg6 with the C-ABI arg5 (it does `mov r9, r8` before
+/// preserving r9). So we have 5 reliable args; we pack `quant_type` into
+/// the upper byte of the `n` argument. Vocab sizes ≤ 16 M (24 bits) fit
+/// fine — Qwen3's 151 936 needs only 18 bits.
 pub fn parallel_gemm(
     input: *const f32,
     weights: *const u8,
@@ -57,15 +63,16 @@ pub fn parallel_gemm(
     n: usize,
     quant_type: u8,
 ) -> bool {
+    debug_assert!(n < (1 << 24), "n must fit in 24 bits for packed ABI");
+    let n_qt = (n as u64) | ((quant_type as u64) << 56);
     let ret = unsafe {
-        syscall6(
+        syscall5(
             SYS_PARALLEL_GEMM,
             input as u64,
             weights as u64,
             output as u64,
             k as u64,
-            n as u64,
-            quant_type as u64,
+            n_qt,
         )
     };
     ret == 0


### PR DESCRIPTION
## Summary

Distributes the 1024 → 151 936 lm_head matmul across the 4 vCPUs (BSP + 3 APs) for the inference task's decode loop. Live wall-clock per token drops from ~10 s (single-core, PR #173) to ~7 s on full 28-layer Qwen3-0.6B. Bit-identical first-token argmax to numpy reference (151 667 = `<think>`).

This PR went through three engineering layers: kernel SMP infrastructure, AP-side address-space handling, and a syscall-ABI fix that turned out to be the actual blocker.

## Layer 1 — Kernel-side SMP-Q8 dispatch

`kernel::arch::x86_64::smp::execute_gemm_work` now dispatches on `quant_type`: 0 → new `execute_gemm_work_q8_avx2`, 1 → existing Q6_K path. The Q8 implementation mirrors `userspace::tensor_math::matmul_batch_q8_avx2` byte-for-byte: f16-scale broadcast, 4 × `_mm256_cvtepi8_epi32` dequant lanes, 4-FMA inner loop, horizontal reduce.

## Layer 2 — AP CR3 swap (replaces broken HHDM-linear translation)

Pre-existing `virt_to_hhdm` walks the page table for ONE virtual address and assumes the rest of the buffer is physically contiguous. **Broken for shmem-backed weights** — the 165 MiB Q8 embedding lives across 155 K scattered 4 KiB pages, only the first resolves correctly.

Fix: APs swap CR3 to the task's PML4 at job entry, swap back to their boot CR3 at exit. The MMU resolves user-virtual addresses per-page via task_cr3, exactly like the BSP. New `GemmWork.task_cr3` field carries the page table; sentinel `task_cr3 = 0` skips the swap (BSP is already in task_cr3 from being inside a syscall).

## Layer 3 — Syscall ABI fix (the actual blocker)

The x86_64 syscall entry shuffle in `kernel::arch::x86_64::syscall::entry` does:
```asm
mov r9, r8     ; r9 = arg5 (kernel C-ABI)
mov r8, r10    ; r8 = arg4
```

The first instruction **overwrites r9 BEFORE preserving the user's 6th argument**. So C-ABI arg6 sees garbage (the user's a5 value). For parallel_gemm this meant `quant_type` arrived as `n` (151 936), match-armed to default Q6_K path, ran Q6_K math on Q8-formatted weights → argmax 124 795 instead of 151 667.

**Fix**: pack `quant_type` (1 byte) into the upper byte of `n` (24-bit vocab fits Qwen3's 151 936 with 4 bits to spare). Userspace + kernel unpack symmetrically. Syscall is now a 5-arg call, dodging the ABI gap.

The kernel Q8 AVX2 math was correct from day one. The whole multi-day debug arc was chasing a syscall-ABI bug.

## Live verification

```
[PGEMM] syscall entry k=1024 n=151936 qt=0      ← qt arrives correctly
[PGEMM] task CR3=0x4a9f000 APs=3
[PGEMM] BSP cols 0-37984 AVX2=1
[PGEMM] All workers done
[INFERENCE] D.3.7: first token = 151667 ("<think>")
[INFERENCE] D.3.7: argmax matches numpy reference (151667)
[INFERENCE] D.3.7: sampled 23 tokens, ids=[..., 151645]
[INFERENCE] D.3.7: Draug response: "<think>olingراضًا من تقدر قابلة بسياندي ق
                                    </think>
                                     لست؟
                                    <|im_end|>"
[INFERENCE] D.3.7 First Blood — model lives.
```

Cross-referenced against `[DRAUG-DAEMON] alive uptime=` markers in the serial log:
- D.3.7 start: < 30 s
- first token: ~120–150 s (streaming + prefill, unparallelised)
- model lives: ~300–330 s

## Performance

| Phase | Single-core (PR #173) | SMP (this PR) | Speedup |
|---|---|---|---|
| Streaming + prefill (14 tokens × 28 layers) | ~120 s | ~120–150 s | (unchanged, not parallelised) |
| Per token (decode) | ~10 s | **~7 s** | **1.4×** |

Amdahl's law for lm_head-only parallelisation:
- lm_head ≈ 50 % of decode work (151 936 × 1024 matmul)
- parallelised ≈ 4× across BSP + 3 APs
- expected total = 0.5/4 + 0.5 = 0.625 × original ≈ 1.6×
- observed 1.4× includes coordination overhead

Layer matmuls (Q/K/V/Wo/gate/up/down at ≤ 3072 out_dim) stay single-core — below `SMP_DISPATCH_MIN_OUT_DIM = 16 384` threshold. Worth dispatching only for the lm_head class.

## Test plan

- [x] Kernel + userspace `cargo build --release` green
- [x] D.3.7 First Blood reaches `model lives` with `argmax = 151667`
- [x] Wall-clock per token drops to ~7 s (vs 10 s single-core)
- [x] PGEMM dispatches print `qt=0` (quant_type correctly received)
- [ ] CI green

## Out of scope

- Layer-level parallelisation (would need adaptive threshold; current 16 384 keeps small matmuls on single core to avoid coordination overhead dominance)
- Removing `[PGEMM] ...` debug prints from production (keeping for visibility this PR; can quiet later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)