### PR TITLE
🎙 feat(inference): streaming generation — tokens stream to serial as decoded

### DIFF
--- a/userspace/inference/src/main.rs
+++ b/userspace/inference/src/main.rs
@@ -1564,12 +1564,20 @@ fn run_d37_first_blood() -> bool {
         let t_end = unsafe { core::arch::x86_64::_rdtsc() };
         let cycles = t_end.wrapping_sub(t_start);
         let ms = cycles / (tsc_freq_hz / 1000);
-        if step < 4 || step % 8 == 0 {
-            println!(
-                "[INFERENCE] D.3.7 token: step={} took ~{} ms (next_id={})",
-                step, ms, next_token,
-            );
-        }
+
+        // Streaming output: decode the just-sampled token and emit it
+        // to serial in real time. Wrapping the fragment in [STREAM]
+        // markers keeps the per-token diagnostic separable from the
+        // free-form text in the log. `decode_seq(&[t])` reverses the
+        // tokenizer's GPT-2 byte mapping, so the user sees the same
+        // characters they'd get in HF. Multi-byte UTF-8 fragments
+        // (CJK / emoji) come out as the actual bytes — serial-tail
+        // tools (or `tee` to a file) can render them.
+        let fragment = tok.decode_seq(&[next_token]);
+        println!(
+            "[STREAM] step={:03} ~{}ms id={:06} {:?}",
+            step, ms, next_token, fragment,
+        );
 
         next = next_token;
         sampled.push(next);


### PR DESCRIPTION
## Summary

After each token is sampled in the D.3.7 decode loop, decode it via `tok.decode_seq(&[next_token])` and emit the UTF-8 fragment to serial. The user watching via Proxmox console / `tail -f` now sees Draug write character-by-character as decoding runs, instead of waiting for the full response at the end.

## Live verification

```
[INFERENCE] D.3.7: prefill (14 tokens × 28 layers) took ~53239 ms
[INFERENCE] D.3.7: first token = 151667 ("<think>")
[STREAM] step=000 ~2897ms id=000319 "\r\n"
[STREAM] step=001 ~2895ms id=000715 " \n"
[STREAM] step=002 ~2892ms id=151668 "</think>"
[STREAM] step=003 ~2896ms id=000271 "\n\n"
[STREAM] step=004 ~2941ms id=004128 " language"
[STREAM] step=005 ~2896ms id=000025 ":"
[STREAM] step=006 ~2894ms id=000662 " en"
[STREAM] step=007 ~2894ms id=001962 " ke"
[STREAM] step=008 ~2832ms id=000072 "i"
[STREAM] step=009 ~2909ms id=002305 "ä"
```

Reading the stream: Draug opens `<think>`, then `\r\n`, ` \n`, closes `</think>` quickly, then attempts `\n\n language: en kei ä...` — model trying to emit a language tag for the Norwegian input.

Each token lands ~2.9 s apart, matching the SMP all-layers benchmark from #176. The previous decode regression to ~4 s in #177 was KVM host-scheduling noise — same code path produces 2.9 s tokens this run.

## Implementation note

The String allocation for the fragment lives between THIS iteration's `reset_to(arena_base)` and the NEXT iteration's. Small (~10–50 bytes), bounded, reclaimed on the next reset. No heap pressure, no behaviour change in the sampler / KV-cache.

`decode_seq` reverses the GPT-2 byte mapping: `Ġ` → space, `Ċ` → newline, multi-byte CJK / Arabic glyphs emit as actual character bytes — terminals tailing the file can render them.

## Test plan

- [x] Userspace `cargo build --release` green
- [x] D.3.7 First Blood reaches `argmax = 151667`
- [x] Streaming `[STREAM]` lines emit per token, matching ~2.9 s/step cadence
- [ ] CI green

## Out of scope

- Pushing fragments via IPC to a foreground shell window — serial is the lowest-friction streaming surface today. IPC streaming lands when we wire Draug into a chat UI.
- Smoothing the bursty serial output (each `[STREAM]` line is ~50 bytes — small impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)