### PR TITLE
feat(smp): batched-seq parallel-Q8 GEMM API — one syscall per matmul

### DIFF
--- a/kernel/src/arch/x86_64/smp.rs
+++ b/kernel/src/arch/x86_64/smp.rs
@@ -28,6 +28,9 @@ pub struct GemmWork {
     pub output_ptr: u64,
     pub k: u32,
     pub n: u32,
+    /// Batch dimension. Input shape `[seq, k]`, output `[seq, n]`.
+    /// seq=1 = decode, seq=14 = ChatML prefill.
+    pub seq: u32,
     pub col_start: u32,
     pub col_end: u32,
     pub quant_type: u8,
@@ -201,6 +204,7 @@ pub fn dispatch_parallel_gemm(
     output_ptr: u64,
     k: u32,
     n: u32,
+    seq: u32,
     quant_type: u8,
     task_cr3: u64,
 ) -> i64 {
@@ -234,7 +238,7 @@ pub fn dispatch_parallel_gemm(
                 input_ptr,    // userspace virt — AP swaps CR3
                 weight_ptr,
                 output_ptr,
-                k, n,
+                k, n, seq,
                 col_start: col as u32,
                 col_end: (col + my_cols) as u32,
                 quant_type,
@@ -252,7 +256,7 @@ pub fn dispatch_parallel_gemm(
     // pointers resolve through the MMU per-page just like the APs.
     let bsp_work = GemmWork {
         input_ptr, weight_ptr, output_ptr,
-        k, n,
+        k, n, seq,
         col_start: bsp_col_start as u32,
         col_end: (bsp_col_start + bsp_cols) as u32,
         quant_type,
@@ -385,33 +389,50 @@ unsafe fn execute_gemm_work(work: &GemmWork) {
     }
 }
 
-/// Q8_0 GEMM column-strip executor for one AP. Mirror of the
-/// userspace `matmul_batch_q8_avx2` for the seq=1 case: caller
-/// provides one input vector of length `k` (in_dim) and a Q8_0-
-/// quantised weight matrix of shape `[n × k]` with `n` being
-/// out_dim. We compute `c[col] = sum_i (input[i] * dequant(B[col, i]))`
-/// for each `col` in our assigned `[col_start, col_end)` strip.
+/// Q8_0 batched GEMM column-strip executor for one AP. Caller
+/// provides:
+///   - input  shape `[seq, k]`   row-major f32
+///   - weights shape `[n, k]`    row-major Q8_0 (34 B per 32-elem block)
+///   - output shape `[seq, n]`   row-major f32
+/// We compute `c[s, col] = sum_i (a[s, i] * dequant(B[col, i]))` for
+/// each `col` in `[col_start, col_end)` and each `s` in `[0, seq)`.
 ///
-/// Layout matches the `.fbin`'s row-major Q8 layout: each output
-/// row (one output element here) is `n_blocks * Q8_0_BLOCK_SIZE`
-/// bytes, with `n_blocks = k / 32`.
+/// Per-block dequant is reused across all `seq` rows: the weight
+/// row's bytes are loaded + sign-extended + scaled ONCE per (col,
+/// block), then 4 FMAs are issued per `s` within that block. This
+/// amortises ~the entire dequant cost across the batch — the
+/// motivating case is prefill at seq = 14 where naive per-row
+/// dispatch did 14× redundant dequant work.
+///
+/// Per-s accumulators live on the stack (a fixed-size array of
+/// `__m256` vectors). MAX_SEQ = 64 is comfortably larger than
+/// the ChatML prefill (seq = 14) and uses 64 × 32 = 2 KiB of
+/// stack per executor — well within budget.
+const MAX_SEQ: usize = 64;
+
 #[target_feature(enable = "avx2", enable = "fma")]
 unsafe fn execute_gemm_work_q8_avx2(work: &GemmWork) {
     use core::arch::x86_64::*;
     let k = work.k as usize;
     let n = work.n as usize;
+    let seq = (work.seq as usize).max(1).min(MAX_SEQ);
     let col_start = work.col_start as usize;
     let col_end = work.col_end as usize;
     let n_blocks = k / Q8_0_BLOCK_VALUES;
     let row_bytes = n_blocks * Q8_0_BLOCK_SIZE;
 
-    let a_f32 = core::slice::from_raw_parts(work.input_ptr as *const f32, k);
+    let a_f32 = core::slice::from_raw_parts(work.input_ptr as *const f32, seq * k);
     let b_q8 = core::slice::from_raw_parts(work.weight_ptr as *const u8, n * row_bytes);
-    let c = core::slice::from_raw_parts_mut(work.output_ptr as *mut f32, n);
+    let c = core::slice::from_raw_parts_mut(work.output_ptr as *mut f32, seq * n);
+
+    // Per-s accumulators. Reset to zero at the top of each col.
+    let mut acc: [__m256; MAX_SEQ] = [_mm256_setzero_ps(); MAX_SEQ];
 
     for col in col_start..col_end {
         let row_off = col * row_bytes;
-        let mut acc = _mm256_setzero_ps();
+        for s in 0..seq {
+            acc[s] = _mm256_setzero_ps();
+        }
 
         for b in 0..n_blocks {
             let block_off = row_off + b * Q8_0_BLOCK_SIZE;
@@ -423,9 +444,9 @@ unsafe fn execute_gemm_work_q8_avx2(work: &GemmWork) {
             let scale = f16_to_f32(scale_bits);
             let scale_v = _mm256_set1_ps(scale);
 
-            // Dequant 32 i8s → 4 × __m256. _mm256_cvtepi8_epi32
-            // sign-extends low 8 bytes of __m128i; we slide the
-            // window with srli_si128 to cover all 32 bytes.
+            // Dequant 32 i8s → 4 × __m256, ONCE per (col, block).
+            // _mm256_cvtepi8_epi32 sign-extends low 8 bytes of an
+            // __m128i; we slide with srli_si128 to cover 32 bytes.
             let q_ptr = b_q8.as_ptr().add(block_off + 2) as *const __m128i;
             let raw_lo = _mm_loadu_si128(q_ptr);
             let raw_hi = _mm_loadu_si128(q_ptr.add(1));
@@ -434,28 +455,36 @@ unsafe fn execute_gemm_work_q8_avx2(work: &GemmWork) {
             let deq2 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(raw_hi)), scale_v);
             let deq3 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(raw_hi, 8))), scale_v);
 
+            // FMA the dequantised block into each row's accumulator.
+            // Reused dequant means the per-(col, block) cost is paid
+            // once across all `seq` rows — that's the whole point of
+            // the batched API.
             let a_base = b * Q8_0_BLOCK_VALUES;
-            let xs_ptr = a_f32.as_ptr().add(a_base);
-            let xs0 = _mm256_loadu_ps(xs_ptr);
-            let xs1 = _mm256_loadu_ps(xs_ptr.add(8));
-            let xs2 = _mm256_loadu_ps(xs_ptr.add(16));
-            let xs3 = _mm256_loadu_ps(xs_ptr.add(24));
-
-            acc = _mm256_fmadd_ps(deq0, xs0, acc);
-            acc = _mm256_fmadd_ps(deq1, xs1, acc);
-            acc = _mm256_fmadd_ps(deq2, xs2, acc);
-            acc = _mm256_fmadd_ps(deq3, xs3, acc);
+            for s in 0..seq {
+                let xs_ptr = a_f32.as_ptr().add(s * k + a_base);
+                let xs0 = _mm256_loadu_ps(xs_ptr);
+                let xs1 = _mm256_loadu_ps(xs_ptr.add(8));
+                let xs2 = _mm256_loadu_ps(xs_ptr.add(16));
+                let xs3 = _mm256_loadu_ps(xs_ptr.add(24));
+                acc[s] = _mm256_fmadd_ps(deq0, xs0, acc[s]);
+                acc[s] = _mm256_fmadd_ps(deq1, xs1, acc[s]);
+                acc[s] = _mm256_fmadd_ps(deq2, xs2, acc[s]);
+                acc[s] = _mm256_fmadd_ps(deq3, xs3, acc[s]);
+            }
         }
 
-        // Horizontal reduce 8 lanes to scalar.
-        let lo = _mm256_castps256_ps128(acc);
-        let hi = _mm256_extractf128_ps(acc, 1);
-        let s4 = _mm_add_ps(lo, hi);
-        let s4_hi = _mm_movehdup_ps(s4);
-        let s2 = _mm_add_ps(s4, s4_hi);
-        let s2_hi = _mm_movehl_ps(s4_hi, s2);
-        let s1 = _mm_add_ss(s2, s2_hi);
-        c[col] = _mm_cvtss_f32(s1);
+        // Horizontal reduce each row's accumulator and write to c.
+        for s in 0..seq {
+            let v = acc[s];
+            let lo = _mm256_castps256_ps128(v);
+            let hi = _mm256_extractf128_ps(v, 1);
+            let s4 = _mm_add_ps(lo, hi);
+            let s4_hi = _mm_movehdup_ps(s4);
+            let s2 = _mm_add_ps(s4, s4_hi);
+            let s2_hi = _mm_movehl_ps(s4_hi, s2);
+            let s1 = _mm_add_ss(s2, s2_hi);
+            c[s * n + col] = _mm_cvtss_f32(s1);
+        }
     }
 }
 

--- a/kernel/src/arch/x86_64/syscall/handlers/compute.rs
+++ b/kernel/src/arch/x86_64/syscall/handlers/compute.rs
@@ -4,14 +4,17 @@ pub fn syscall_parallel_gemm(
     input_ptr: u64,
     weight_ptr: u64,
     output_ptr: u64,
-    k: u64,
+    k_seq: u64,
     n_qt: u64,
 ) -> u64 {
-    // Userspace packs `quant_type` into the top byte of `n` because the
-    // syscall entry shuffle drops C-ABI arg6 (mov r9, r8 overwrites it
-    // before r9 can be preserved). Lower 32 bits of n_qt = n; bits 56..64
-    // = quant_type. See `libfolk::sys::parallel_gemm` doc.
-    let n = (n_qt & 0xFFFF_FFFF) as u64;
+    // Packed ABI (see `libfolk::sys::parallel_gemm`):
+    //   k_seq lower 32 = k (in_dim), upper 32 = seq (batch size)
+    //   n_qt  lower 32 = n (out_dim), top byte = quant_type
+    // The syscall entry shuffle drops C-ABI arg6, so we live within
+    // 5 args and pack two pairs of fields.
+    let k = (k_seq & 0xFFFF_FFFF) as u32;
+    let seq = ((k_seq >> 32) & 0xFFFF_FFFF) as u32;
+    let n = (n_qt & 0xFFFF_FFFF) as u32;
     let quant_type = ((n_qt >> 56) & 0xFF) as u8;
 
     let task_id = crate::task::task::get_current_task();
@@ -24,9 +27,10 @@ pub fn syscall_parallel_gemm(
         input_ptr,
         weight_ptr,
         output_ptr,
-        k as u32,
-        n as u32,
-        quant_type as u8,
+        k,
+        n,
+        seq,
+        quant_type,
         cr3,
     );
 

--- a/userspace/inference/src/tensor_math.rs
+++ b/userspace/inference/src/tensor_math.rs
@@ -117,42 +117,22 @@ fn try_parallel_q8(
     if weights_q8.len() != out_dim * row_bytes { return None; }
 
     let mut out = vec![0.0f32; seq * out_dim];
-    if seq == 1 {
-        // Decode hot path. Direct call — no loop, no slice-by-row,
-        // matches the structure that benchmarked at ~2.9 s/token in
-        // PR #176. Wrapping this in a `for s in 0..1` loop turned out
-        // to add ~40 % overhead on the per-token wall-clock, presumably
-        // from the loop scaffolding interfering with LLVM's syscall
-        // inlining.
-        let ok = libfolk::sys::parallel_gemm(
-            x.as_ptr(),
-            weights_q8.as_ptr(),
-            out.as_mut_ptr(),
-            in_dim,
-            out_dim,
-            0,            // quant_type 0 = Q8_0
-        );
-        return if ok { Some(out) } else { None };
-    }
-    // Prefill / batched path: loop per row.
-    for s in 0..seq {
-        let x_row = &x[s * in_dim..(s + 1) * in_dim];
-        // SAFETY: out_row is a disjoint slice of `out` (we never
-        // re-enter for the same s), so the kernel's SMP workers
-        // can write into it without interference. The shared
-        // `weights_q8` is read-only.
-        let out_row_ptr = unsafe { out.as_mut_ptr().add(s * out_dim) };
-        let ok = libfolk::sys::parallel_gemm(
-            x_row.as_ptr(),
-            weights_q8.as_ptr(),
-            out_row_ptr,
-            in_dim,
-            out_dim,
-            0,            // quant_type 0 = Q8_0
-        );
-        if !ok { return None; }
-    }
-    Some(out)
+    // One batched syscall covers all `seq` rows. The kernel's
+    // execute_gemm_work_q8_avx2 dequants each weight block ONCE
+    // per (col, block) and FMAs into per-row accumulators — so
+    // prefill (seq = 14) pays ~the same dequant cost as decode
+    // (seq = 1), and the syscall coordination overhead is
+    // amortised across the whole batch instead of repeated 14×.
+    let ok = libfolk::sys::parallel_gemm(
+        x.as_ptr(),
+        weights_q8.as_ptr(),
+        out.as_mut_ptr(),
+        in_dim,
+        out_dim,
+        seq,
+        0, // quant_type 0 = Q8_0
+    );
+    if ok { Some(out) } else { None }
 }
 
 /// Q8_0 block size — same as llama.cpp / GGUF. Picked for

--- a/userspace/libfolk/src/sys/task.rs
+++ b/userspace/libfolk/src/sys/task.rs
@@ -50,20 +50,28 @@ pub fn spawn(binary: &[u8]) -> Option<u32> {
 /// Dispatch parallel GEMM across AP compute workers.
 /// Returns true on success (APs available), false on failure (fallback to sequential).
 ///
-/// ABI note: the x86_64 syscall entry shuffle in `kernel::arch::x86_64::syscall::entry`
-/// overwrites C-ABI arg6 with the C-ABI arg5 (it does `mov r9, r8` before
-/// preserving r9). So we have 5 reliable args; we pack `quant_type` into
-/// the upper byte of the `n` argument. Vocab sizes ≤ 16 M (24 bits) fit
-/// fine — Qwen3's 151 936 needs only 18 bits.
+/// ABI note: the x86_64 syscall entry shuffle drops C-ABI arg6
+/// (mov r9, r8 overwrites it before r9 can be preserved). We have
+/// 5 reliable args, so we pack:
+///   arg4 = (seq << 32) | k      (both u32; 4 G samples × 4 G dim each)
+///   arg5 = (quant_type << 56) | n  (top byte = quant_type, low 24 bits = n)
+///
+/// `seq` is the batch dimension — input shape `[seq, k]`, output
+/// `[seq, n]`. seq=1 covers decode; seq=14 covers our ChatML prefill.
+/// One syscall amortises BSP+AP coordination across all `seq` rows.
 pub fn parallel_gemm(
     input: *const f32,
     weights: *const u8,
     output: *mut f32,
     k: usize,
     n: usize,
+    seq: usize,
     quant_type: u8,
 ) -> bool {
+    debug_assert!(k < (1 << 32), "k must fit in 32 bits for packed ABI");
+    debug_assert!(seq < (1 << 32), "seq must fit in 32 bits for packed ABI");
     debug_assert!(n < (1 << 24), "n must fit in 24 bits for packed ABI");
+    let k_seq = (k as u64) | ((seq as u64) << 32);
     let n_qt = (n as u64) | ((quant_type as u64) << 56);
     let ret = unsafe {
         syscall5(
@@ -71,7 +79,7 @@ pub fn parallel_gemm(
             input as u64,
             weights as u64,
             output as u64,
-            k as u64,
+            k_seq,
             n_qt,
         )
     };


### PR DESCRIPTION
## Summary

Extends `SYS_PARALLEL_GEMM` to handle batched inputs. Userspace now passes shape `[seq, k]` input + `[seq, n]` output in a single syscall; the kernel partitions work by output column and FMAs into per-row accumulators inside the kernel function.

**Motivation**: prefill (seq = 14 for our ChatML prompt) used to issue 14 syscalls per matmul × 196 matmuls = **2 744 dispatches per prefill** via PR #177's per-row loop. With the batched API: **196 dispatches**.

## ABI

```
arg4 = (seq << 32) | k          (both u32, packed)
arg5 = (quant_type << 56) | n   (top byte qt, low 24 bits n)
```

Still 5 args, dodging the kernel-side syscall-entry shuffle that drops C-ABI arg6 (see #175).

## Kernel-side

- `GemmWork.seq` field added.
- `execute_gemm_work_q8_avx2` dequants each weight block ONCE per (col, block) and FMAs the result into stacked `__m256` accumulators — one per s. Dequant work is reused across the batch instead of repeated seq× as in the per-row dispatch.
- `MAX_SEQ = 64` caps stack-allocated accumulator array at 2 KiB.

## Live verification

```
[INFERENCE] D.3.7: prefill (14 tokens × 28 layers) took ~53233 ms
[INFERENCE] D.3.7: first token = 151667 ("<think>")
[INFERENCE] D.3.7: argmax matches numpy reference (151667)
[STREAM] step=000 ~2901ms id=017642 "\n\t\n"
[STREAM] step=001 ~2908ms id=000271 "\n\n"
[STREAM] step=002 ~2898ms id=151668 "</think>"
[STREAM] step=003 ~2898ms id=151643 "<|endoftext|>"
```

- **Argmax bit-identical to numpy reference (151 667).** ✅
- **Decode ~2.9 s/token** (same as #176/#177 hot path). ✅
- **Prefill 53 s** — not measurably faster than #177 on this host (likely register pressure on the 14-accumulator inner loop spilling: 14 acc + 4 deq + scratch > 16 ymm regs; plus KVM noise floor).

The infrastructure win is real: syscall count dropped 14× and the API now correctly models batched matmuls. Future tile-by-8 optimisation should unlock the math speedup once register pressure is managed.

## Out of scope

- **Seq-tiling** to reduce register pressure when seq > 8. The current inner loop has 14 acc + 4 deq + scratch in flight; AVX2 has 16 ymm registers, so we spill on every block. Tile seq into chunks of ≤ 8 to keep everything in registers — should unblock the 3-4× theoretical prefill speedup.
- Per-task accumulator arena so `MAX_SEQ` can grow beyond 64 without a stack budget hike.

## Test plan

- [x] Kernel + userspace `cargo build --release` green
- [x] D.3.7 First Blood reaches `argmax = 151667`
- [x] Decode wall-clock unchanged at ~2.9 s/token
- [x] Streaming output matches expected token sequence
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)