### PR TITLE
feat(userspace): 12 GiB inference heap unlocks long-context KV cache

### DIFF
--- a/userspace/inference/src/main.rs
+++ b/userspace/inference/src/main.rs
@@ -50,6 +50,7 @@ extern crate alloc;
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
 
 use libfolk::{entry, println};
 use libfolk::sys::yield_cpu;
@@ -131,8 +132,15 @@ mod forward_pass;
 // write.
 const HEAP_SIZE: usize = 12 * 1024 * 1024 * 1024;
 
+// `MaybeUninit` instead of `[u8; HEAP_SIZE] = [0; HEAP_SIZE]` so rustc
+// doesn't try to const-evaluate a 12 GiB zero array during codegen.
+// At HEAP_SIZE=1.5 GiB the const-eval was tolerable; at 12 GiB it
+// OOM-kills `cargo check --release` on a 7 GB GitHub Actions runner.
+// The kernel ELF loader zero-fills .bss pages at task spawn anyway,
+// so the runtime semantics are identical — the array is observably
+// zero on first access.
 struct BumpAllocator {
-    heap: UnsafeCell<[u8; HEAP_SIZE]>,
+    heap: UnsafeCell<MaybeUninit<[u8; HEAP_SIZE]>>,
     offset: UnsafeCell<usize>,
 }
 
@@ -148,7 +156,7 @@ unsafe impl GlobalAlloc for BumpAllocator {
             return core::ptr::null_mut();
         }
         *offset = new_offset;
-        (*self.heap.get()).as_mut_ptr().add(aligned)
+        (*self.heap.get()).as_mut_ptr().cast::<u8>().add(aligned)
     }
     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
 }
@@ -182,7 +190,7 @@ impl BumpAllocator {
 
 #[global_allocator]
 static ALLOCATOR: BumpAllocator = BumpAllocator {
-    heap: UnsafeCell::new([0; HEAP_SIZE]),
+    heap: UnsafeCell::new(MaybeUninit::uninit()),
     offset: UnsafeCell::new(0),
 };
 

--- a/userspace/inference/src/main.rs
+++ b/userspace/inference/src/main.rs
@@ -113,7 +113,23 @@ mod forward_pass;
 // top-5 = ['<think>', '<|im_start|>', 'ол', '<|im_end|>', '</think>'].
 // Qwen3 is a thinking-mode model — responses open with reasoning tags
 // before the user-facing text.
-const HEAP_SIZE: usize = 1536 * 1024 * 1024;
+// 12 GiB inference heap — sized to fit a Qwen3-4B KvCache at
+// max_pos=32768 (n_layers=36 × 2 × 32768 × n_kv=8 × head_dim=128 ×
+// 4 = 9 GiB) plus per-chunk forward scratch (~360 MiB leaked into
+// the bump arena until each chunk's reset_to). Remaining ~2.5 GiB
+// is headroom for embeds, lm_head logits, sampler scratch.
+//
+// Static array — committed at task start, so the VM's RAM
+// allocation must cover this plus kernel/userspace (Proxmox VM 900
+// needs ≥16 GiB; we ship recommending 24-32 GiB).
+//
+// Linking past 2 GiB of `.bss` requires `code-model = medium` in
+// the userspace target spec (small mode caps PC32 reach at ±2 GiB).
+// `link.ld` also emits a `QUAD(0)` anchor in `.data` so lld keeps
+// the writable PHDR alive — without it, medium mode merges `.bss`
+// into the preceding R+X PT_LOAD and the task #PFs on first heap
+// write.
+const HEAP_SIZE: usize = 12 * 1024 * 1024 * 1024;
 
 struct BumpAllocator {
     heap: UnsafeCell<[u8; HEAP_SIZE]>,

--- a/userspace/link.ld
+++ b/userspace/link.ld
@@ -22,10 +22,18 @@ SECTIONS
     /* Start at a reasonable userspace address */
     . = 0x200000;
 
-    /* Read-only data section */
+    /* Read-only data section.
+     *
+     * `.lrodata` is the "long rodata" section rustc emits under
+     * code-model=medium for >2 GiB-reachable read-only data.
+     * Catch it here so it lands in the R-only PHDR alongside
+     * regular `.rodata`. Without this, lld leaves `.lrodata`
+     * orphaned and merges it into a different segment.
+     */
     .rodata ALIGN(4096) :
     {
         *(.rodata .rodata.*)
+        *(.lrodata .lrodata.*)
     } :rodata
 
     /* Executable code section - page aligned */
@@ -35,17 +43,35 @@ SECTIONS
         *(.text .text.*)
     } :text
 
-    /* Read-write data section - page aligned */
+    /* Read-write data section - page aligned.
+     *
+     * `.ldata` and `.lbss` are the "long" data/bss sections rustc
+     * emits under code-model=medium for symbols that might exceed
+     * the 2 GiB PC-relative reach. Without explicitly gathering
+     * them here, lld leaves them orphaned and silently merges them
+     * into the preceding R+X PT_LOAD — which causes a #PF on the
+     * first write because the kernel applies R+X (no W) page flags
+     * based on the segment's ELF flags. This bit synapse hard:
+     * its 4.2 MB `SQLITE_BUFFER` was a `.lbss` symbol and the task
+     * faulted on first write at 0x214000.
+     *
+     * The `QUAD(0)` anchor ensures `.data` is non-empty so the
+     * writable PHDR stays alive across both small and medium code
+     * models even when a binary has no other `.data` symbols.
+     */
     . = ALIGN(4096);
     .data :
     {
+        QUAD(0);
         *(.data .data.*)
+        *(.ldata .ldata.*)
     } :data
 
     /* BSS (uninitialized data) - same segment as data */
     .bss :
     {
         *(.bss .bss.*)
+        *(.lbss .lbss.*)
         *(COMMON)
     } :data
 

--- a/userspace/x86_64-folkering-userspace.json
+++ b/userspace/x86_64-folkering-userspace.json
@@ -11,7 +11,7 @@
   "linker": "rust-lld",
   "panic-strategy": "abort",
   "disable-redzone": true,
-  "code-model": "small",
+  "code-model": "medium",
   "relocation-model": "static",
   "pre-link-args": {
     "ld.lld": ["-Tlink.ld"]


### PR DESCRIPTION
## Summary

Wires three changes together to lift the inference task heap from 1.5 GiB → 12 GiB, enabling long-context KvCaches (target: max_pos=32768 Qwen3-4B = 9 GiB cache).

### 1. \`code-model = small\` → \`medium\`
The 12 GiB \`.bss\` overflows the small code model's ±2 GiB PC32 relocation range. Medium uses 64-bit absolute addressing for data while keeping 32-bit PC-rel branches for code — negligible runtime cost.

### 2. \`link.ld\` gathers \`.lrodata\` / \`.ldata\` / \`.lbss\`
Under \`code-model = medium\` rustc emits these \"long\" sections alongside the standard ones for symbols that may exceed 2 GiB reach. The previous \`*(.bss .bss.*)\` glob didn't match \`.lbss\`, so they fell through and lld silently merged them into the preceding R+X PT_LOAD. The kernel ELF loader mapped them R+X (no write), and synapse #PF'd on first write to its 4.2 MB \`SQLITE_BUFFER\` (a \`.lbss\` symbol).

A \`QUAD(0)\` anchor in \`.data\` keeps the writable PHDR alive on small binaries that have no other \`.data\` symbols.

### 3. \`HEAP_SIZE\` 1.5 GiB → 12 GiB
Sized for the worst-case KvCache (max_pos=32768) plus forward scratch.

## Verification

Live on Proxmox VM 900 with 32 GB VM RAM and a freshly baked \`qwen.fbin --max-seq-len=4096\`:

\`\`\`
[INFERENCE] D.3.7: detected 36-layer model ... max_pos=4096
[INFERENCE] D.3.7: prefilling 63 tokens in 1 chunk(s) of up to 64 tokens each
[INFERENCE] D.3.7: prefill (63 tokens × 28 layers, 1 chunk(s)) took ~7543 ms
[INFERENCE] D.3.7: Draug response: \"Jeg er Draug, en AI-assistent i Folkering OS.
 Jeg hjelper deg med å løse problemer og gjøre ting mer effektive. Hva trenger du
 hjelp til?<|im_end|>\"
\`\`\`

KvCache (1.125 GiB at max_pos=4096) allocated cleanly, prefill completes, decode runs to natural EOS, production sampler produces fluent in-character Norwegian.

## Test plan

- [x] All 9 userspace binaries link with 3 PHDRs (R / R+X / R+W) — verified via ELF inspection
- [x] Synapse boots without #PF on its 4.2 MB \`.lbss\` SQLITE_BUFFER
- [x] Inference task allocates 12 GiB heap and runs end-to-end at max_pos=4096
- [ ] Phase 2: re-deploy with \`qwen.fbin --max-seq-len=32768\` (model bake in progress) and validate >4000-token contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)